### PR TITLE
Replace template-copy-and-replace with programmatic Google Doc builder

### DIFF
--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -37,14 +37,15 @@ class Settings(BaseSettings):
         description="OAuth scopes for Drive, Docs, and Gmail operations",
     )
 
-    # DD Report Templates
+    # DD Report Templates (deprecated — reports are now built programmatically)
     dd_template_v3_google_doc_id: str = Field(
         "",
-        description="Google Doc ID of the V3 DD report template",
+        description="Deprecated: Google Doc ID of the V3 DD report template. "
+        "Reports are now built programmatically via google_doc_builder.",
     )
     dd_template_v2_google_doc_id: str = Field(
         "",
-        description="Legacy fallback Google Doc ID for DD report template",
+        description="Deprecated: Legacy fallback Google Doc ID for DD report template.",
     )
 
     # Google Drive root folder containing all site folders

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -1,0 +1,1052 @@
+"""Programmatic Google Doc builder for the DD report.
+
+Constructs the entire DD report document structure from scratch using
+Google Docs API batchUpdate requests, replacing the old template-copy-
+and-replace flow.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .report_schema import LINK_DISPLAY_LABELS, LINK_TOKENS
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Style constants — reproduce the V3 template visual appearance
+# ---------------------------------------------------------------------------
+
+_DARK_BLUE: dict[str, float] = {"red": 0.102, "green": 0.235, "blue": 0.369}  # #1A3C5E
+_WHITE: dict[str, float] = {"red": 1.0, "green": 1.0, "blue": 1.0}
+_LIGHT_BLUE_BG: dict[str, float] = {"red": 0.937, "green": 0.961, "blue": 0.984}  # #EFF5FB
+_LIGHT_BLUE_BORDER: dict[str, float] = {"red": 0.722, "green": 0.796, "blue": 0.878}  # #B8CBE0
+_LIGHT_GRAY: dict[str, float] = {"red": 0.973, "green": 0.976, "blue": 0.980}  # #F8F9FA
+_LINK_BLUE: dict[str, float] = {"red": 0.067, "green": 0.333, "blue": 0.800}  # #1155CC
+
+# Google Docs API point units (1pt = 1 magnitude with UNIT=PT)
+_PT = "PT"
+
+# ---------------------------------------------------------------------------
+# Header table rows: (label, token_key)
+# ---------------------------------------------------------------------------
+
+_HEADER_ROWS: list[tuple[str, str]] = [
+    ("Site Name / Address", "meta.site_name"),
+    ("Current Marketing Name", "meta.marketing_name"),
+    ("City, State, Zip", "meta.city_state_zip"),
+    ("School Type", "meta.school_type"),
+    ("Report Date", "meta.report_date"),
+    ("Prepared By", "meta.prepared_by"),
+    ("Drive Folder", "meta.drive_folder_url"),
+]
+
+# ---------------------------------------------------------------------------
+# Cost breakdown rows: (row_key, display_label)
+# ---------------------------------------------------------------------------
+
+_COST_BREAKDOWN_ROWS: list[tuple[str, str]] = [
+    ("demolition", "Demolition"),
+    ("framing_doors", "Framing / Doors"),
+    ("mep_fire_life_safety", "MEP / Fire / Life Safety"),
+    ("plumbing_bathrooms", "Plumbing / Bathrooms"),
+    ("finish_work", "Finish Work"),
+    ("furniture", "Furniture"),
+    ("tech_security_signage", "Tech / Security / Signage"),
+    ("other_hard_costs", "Other Hard Costs"),
+    ("soft_costs", "Soft Costs"),
+    ("gc_fee", "GC Fee"),
+    ("contingency", "Contingency"),
+    ("grand_total", "Grand Total"),
+]
+
+# ---------------------------------------------------------------------------
+# Source document rows: (label, token_key)
+# ---------------------------------------------------------------------------
+
+_SOURCE_DOC_ROWS: list[tuple[str, str]] = [
+    ("Site Investigation Report (SIR)", "sources.sir_link"),
+    ("Building Inspection", "sources.inspection_link"),
+    ("Program Fit Analysis (ISP)", "sources.isp_link"),
+    ("E-Occupancy Assessment", "sources.e_occupancy_link"),
+    ("School Approval Assessment", "sources.school_approval_link"),
+    ("Report Trace", "sources.trace_link"),
+]
+
+# ---------------------------------------------------------------------------
+# Gap labels for missing token values
+# ---------------------------------------------------------------------------
+
+_LINK_GAP_LABELS: dict[str, str] = {
+    "sources.sir_link": "[Not found - SIR]",
+    "sources.inspection_link": "[Not found - Building Inspection]",
+    "sources.isp_link": "[Not found - ISP]",
+    "sources.e_occupancy_link": "[Not found - E-Occupancy Assessment]",
+    "sources.school_approval_link": "[Not found - School Approval Assessment]",
+    "sources.trace_link": "",
+    "meta.drive_folder_url": "",
+}
+
+# ---------------------------------------------------------------------------
+# Internal request builder helpers
+# ---------------------------------------------------------------------------
+
+
+class _DocBuilder:
+    """Accumulates Google Docs API batchUpdate requests in document order.
+
+    Tracks the current insertion index so callers insert content
+    sequentially from top to bottom.  All text insertions shift the
+    index forward automatically.
+    """
+
+    def __init__(self, start_index: int = 1) -> None:
+        self._idx = start_index
+        self.requests: list[dict[str, Any]] = []
+
+    @property
+    def index(self) -> int:
+        return self._idx
+
+    # -- primitives ----------------------------------------------------------
+
+    def insert_text(self, text: str) -> tuple[int, int]:
+        """Insert *text* at the current index.  Returns (start, end)."""
+        start = self._idx
+        self.requests.append({
+            "insertText": {
+                "location": {"index": start},
+                "text": text,
+            }
+        })
+        self._idx += len(text)
+        return start, self._idx
+
+    def style_text(
+        self,
+        start: int,
+        end: int,
+        *,
+        bold: bool | None = None,
+        font_size: float | None = None,
+        font_family: str | None = None,
+        foreground_color: dict[str, float] | None = None,
+        link_url: str | None = None,
+    ) -> None:
+        """Apply text styling to the range [start, end)."""
+        style: dict[str, Any] = {}
+        fields: list[str] = []
+
+        if bold is not None:
+            style["bold"] = bold
+            fields.append("bold")
+        if font_size is not None:
+            style["fontSize"] = {"magnitude": font_size, "unit": _PT}
+            fields.append("fontSize")
+        if font_family is not None:
+            style["weightedFontFamily"] = {"fontFamily": font_family}
+            fields.append("weightedFontFamily")
+        if foreground_color is not None:
+            style["foregroundColor"] = {"color": {"rgbColor": foreground_color}}
+            fields.append("foregroundColor")
+        if link_url is not None:
+            style["link"] = {"url": link_url}
+            fields.append("link")
+
+        if not fields:
+            return
+
+        self.requests.append({
+            "updateTextStyle": {
+                "range": {"startIndex": start, "endIndex": end},
+                "textStyle": style,
+                "fields": ",".join(fields),
+            }
+        })
+
+    def style_paragraph(
+        self,
+        start: int,
+        end: int,
+        *,
+        named_style: str | None = None,
+        alignment: str | None = None,
+        space_above: float | None = None,
+        space_below: float | None = None,
+        border_bottom: dict[str, Any] | None = None,
+    ) -> None:
+        """Apply paragraph styling to the range [start, end)."""
+        style: dict[str, Any] = {}
+        fields: list[str] = []
+
+        if named_style is not None:
+            style["namedStyleType"] = named_style
+            fields.append("namedStyleType")
+        if alignment is not None:
+            style["alignment"] = alignment
+            fields.append("alignment")
+        if space_above is not None:
+            style["spaceAbove"] = {"magnitude": space_above, "unit": _PT}
+            fields.append("spaceAbove")
+        if space_below is not None:
+            style["spaceBelow"] = {"magnitude": space_below, "unit": _PT}
+            fields.append("spaceBelow")
+        if border_bottom is not None:
+            style["borderBottom"] = border_bottom
+            fields.append("borderBottom")
+
+        if not fields:
+            return
+
+        self.requests.append({
+            "updateParagraphStyle": {
+                "range": {"startIndex": start, "endIndex": end},
+                "paragraphStyle": style,
+                "fields": ",".join(fields),
+            }
+        })
+
+    # -- table helpers -------------------------------------------------------
+
+    def insert_table(self, rows: int, columns: int) -> int:
+        """Insert a table at the current index.  Returns the index *before*
+        the table so callers can locate its cells in the live document.
+
+        IMPORTANT: after inserting a table the exact index offsets for
+        cell contents are not known until the document is read back from
+        the API.  Use ``insert_table`` as a "phase boundary": build all
+        pre-table content first, flush requests, then read the document
+        back and populate cells in a second pass.
+        """
+        table_start = self._idx
+        self.requests.append({
+            "insertTable": {
+                "rows": rows,
+                "columns": columns,
+                "location": {"index": table_start},
+            }
+        })
+        # We cannot know the exact character-length of the table skeleton
+        # the API will insert, so we set _idx to a sentinel that forces
+        # callers to re-read the document before inserting more text.
+        self._idx = -1
+        return table_start
+
+    def insert_page_break(self) -> None:
+        """Insert a page break at the current index."""
+        # A page break is effectively \f — we insert a newline and
+        # style it later if needed.  For the DD report we use section
+        # headings rather than page breaks.
+        pass
+
+    # -- composite helpers ---------------------------------------------------
+
+    def insert_heading(self, text: str, *, level: int = 1) -> tuple[int, int]:
+        """Insert a heading line and style it as HEADING_{level}."""
+        start, end = self.insert_text(text + "\n")
+        named = f"HEADING_{level}"
+        self.style_paragraph(start, end, named_style=named)
+        return start, end
+
+    def insert_paragraph(self, text: str) -> tuple[int, int]:
+        """Insert a normal paragraph with a trailing newline."""
+        return self.insert_text(text + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Table cell population helpers
+# ---------------------------------------------------------------------------
+
+
+def _cell_index(table_element: dict[str, Any], row: int, col: int) -> int:
+    """Return the content start index for cell (row, col) in a table element."""
+    rows = table_element["table"]["tableRows"]
+    cell = rows[row]["tableCells"][col]
+    # Each cell has a content array; the first paragraph's first element
+    # gives us the insertion point.
+    content = cell["content"]
+    if content:
+        first_para = content[0]
+        if "paragraph" in first_para:
+            elements = first_para["paragraph"].get("elements", [])
+            if elements:
+                return elements[0].get("startIndex", 0)
+            return first_para.get("startIndex", 0)
+        return first_para.get("startIndex", 0)
+    return 0
+
+
+def _table_cell_range(table_element: dict[str, Any], row: int, col: int) -> tuple[int, int]:
+    """Return (start, end) indices covering the full content of a cell."""
+    rows = table_element["table"]["tableRows"]
+    cell = rows[row]["tableCells"][col]
+    content = cell["content"]
+    if not content:
+        return (0, 0)
+    first = content[0]
+    last = content[-1]
+    start = first.get("startIndex", 0)
+    end = last.get("endIndex", start + 1)
+    return start, end
+
+
+def _build_cell_style_requests(
+    table_element: dict[str, Any],
+    row: int,
+    col: int,
+    *,
+    bg_color: dict[str, float] | None = None,
+) -> list[dict[str, Any]]:
+    """Build requests to style a table cell background."""
+    rows = table_element["table"]["tableRows"]
+    cell = rows[row]["tableCells"][col]
+    cell_start, cell_end = _table_cell_range(table_element, row, col)
+    requests: list[dict[str, Any]] = []
+
+    if bg_color is not None:
+        # tableCellStyle update — operates on cell location range
+        requests.append({
+            "updateTableCellStyle": {
+                "tableRange": {
+                    "tableCellLocation": {
+                        "tableStartLocation": {"index": table_element.get("startIndex", 1)},
+                        "rowIndex": row,
+                        "columnIndex": col,
+                    },
+                    "rowSpan": 1,
+                    "columnSpan": 1,
+                },
+                "tableCellStyle": {
+                    "backgroundColor": {"color": {"rgbColor": bg_color}},
+                },
+                "fields": "backgroundColor",
+            }
+        })
+
+    return requests
+
+
+def _resolve_value(
+    replacements: dict[str, str],
+    token: str,
+    gap_label: str = "",
+) -> str:
+    """Resolve a token value from replacements, returning gap_label if missing."""
+    value = replacements.get(token, "")
+    if value and value.strip():
+        return value
+    return gap_label
+
+
+def _is_link_token(token: str) -> bool:
+    """Return True if this token is a hyperlink token."""
+    return token in LINK_TOKENS
+
+
+def _resolve_link_value(
+    replacements: dict[str, str],
+    token: str,
+) -> tuple[str, str | None]:
+    """Return (display_text, url_or_none) for a link token.
+
+    If the token value is a URL, returns the display label and URL.
+    If empty/missing, returns a gap label and None.
+    """
+    value = replacements.get(token, "")
+    if value.startswith("http"):
+        display = LINK_DISPLAY_LABELS.get(token, value)
+        return display, value
+    if value and value.strip():
+        return value, None
+    gap = _LINK_GAP_LABELS.get(token, "")
+    return gap, None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_dd_report_doc(
+    docs_service: Any,
+    drive_service: Any,
+    doc_id: str,
+    replacements: dict[str, str],
+    site_title: str,
+) -> dict[str, Any]:
+    """Construct the full DD report document structure in a blank Google Doc.
+
+    This function populates the document using multiple batchUpdate
+    passes.  The Google Docs API requires that table cell indices be read
+    back from the live document after a table is inserted — we cannot
+    predict the exact character offsets.  Therefore we use a multi-pass
+    approach:
+
+    1. Insert all text/heading content and tables (structure only).
+    2. Read back the document to get actual element indices.
+    3. Populate table cells and apply styling in subsequent passes.
+
+    Args:
+        docs_service: An authenticated ``docs`` API service object.
+        drive_service: An authenticated ``drive`` API service object.
+        doc_id: The ID of the blank document to populate.
+        replacements: Normalized token→value mapping.
+        site_title: The site name for the report title.
+
+    Returns:
+        A dict summarizing the build: hyperlinks_applied, etc.
+    """
+    hyperlink_trace: dict[str, Any] = {
+        "applied": 0,
+        "found_tokens": [],
+        "not_found_tokens": [],
+    }
+
+    # ── Phase 1: Insert top-level structure ──────────────────────────────
+    b = _DocBuilder()
+
+    # Title
+    title_start, title_end = b.insert_text("Site Due Diligence Report\n")
+    b.style_text(
+        title_start, title_end - 1,
+        bold=True, font_size=24, font_family="Arial",
+        foreground_color=_DARK_BLUE,
+    )
+    b.style_paragraph(title_start, title_end, alignment="CENTER")
+
+    # Empty line before header table
+    b.insert_text("\n")
+
+    # Header table placeholder
+    header_table_idx = b.insert_table(len(_HEADER_ROWS), 2)
+
+    # Flush phase 1
+    _batch_update(docs_service, doc_id, b.requests)
+
+    # ── Phase 2: Populate header table ───────────────────────────────────
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+
+    header_table_el = _find_table(body_content, 0)
+    if header_table_el is None:
+        logger.error("Could not find header table in document")
+        return hyperlink_trace
+
+    phase2_requests: list[dict[str, Any]] = []
+
+    # Populate header cells — work in reverse row order so index offsets
+    # for earlier rows remain valid.
+    for row_idx in range(len(_HEADER_ROWS) - 1, -1, -1):
+        label, token = _HEADER_ROWS[row_idx]
+
+        # Value column (col 1)
+        val_idx = _cell_index(header_table_el, row_idx, 1)
+        if _is_link_token(token):
+            display, url = _resolve_link_value(replacements, token)
+            if display:
+                phase2_requests.append({
+                    "insertText": {
+                        "location": {"index": val_idx},
+                        "text": display,
+                    }
+                })
+                if url:
+                    phase2_requests.append({
+                        "updateTextStyle": {
+                            "range": {"startIndex": val_idx, "endIndex": val_idx + len(display)},
+                            "textStyle": {
+                                "link": {"url": url},
+                                "foregroundColor": {"color": {"rgbColor": _LINK_BLUE}},
+                            },
+                            "fields": "link,foregroundColor",
+                        }
+                    })
+                    hyperlink_trace["applied"] += 1
+                    hyperlink_trace["found_tokens"].append(token)
+        else:
+            value = _resolve_value(replacements, token)
+            if value:
+                phase2_requests.append({
+                    "insertText": {
+                        "location": {"index": val_idx},
+                        "text": value,
+                    }
+                })
+
+        # Label column (col 0)
+        label_idx = _cell_index(header_table_el, row_idx, 0)
+        phase2_requests.append({
+            "insertText": {
+                "location": {"index": label_idx},
+                "text": label,
+            }
+        })
+
+    # Style header table cells
+    for row_idx in range(len(_HEADER_ROWS)):
+        label, token = _HEADER_ROWS[row_idx]
+        # Label cell: bold, 10pt, light blue bg
+        label_start, label_end = _table_cell_range(header_table_el, row_idx, 0)
+        # We'll apply text styling after insertion — use the label_idx we know
+        phase2_requests.extend(
+            _build_cell_style_requests(header_table_el, row_idx, 0, bg_color=_LIGHT_BLUE_BG)
+        )
+        # Value cell: white bg
+        phase2_requests.extend(
+            _build_cell_style_requests(header_table_el, row_idx, 1, bg_color=_WHITE)
+        )
+
+    if phase2_requests:
+        _batch_update(docs_service, doc_id, phase2_requests)
+
+    # Style header table text (read doc again after insertions)
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    header_table_el = _find_table(body_content, 0)
+
+    if header_table_el:
+        text_style_requests: list[dict[str, Any]] = []
+        for row_idx in range(len(_HEADER_ROWS)):
+            # Label column — bold
+            cs, ce = _table_cell_range(header_table_el, row_idx, 0)
+            text_style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily",
+                }
+            })
+            # Value column — normal
+            vs, ve = _table_cell_range(header_table_el, row_idx, 1)
+            text_style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": vs, "endIndex": ve},
+                    "textStyle": {
+                        "bold": False,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily",
+                }
+            })
+
+        # Apply column widths via updateTableColumnProperties
+        table_start = header_table_el.get("startIndex", 1)
+        text_style_requests.append({
+            "updateTableColumnProperties": {
+                "tableStartLocation": {"index": table_start},
+                "columnIndices": [0],
+                "tableColumnProperties": {
+                    "widthType": "FIXED_WIDTH",
+                    "width": {"magnitude": 140, "unit": _PT},
+                },
+                "fields": "widthType,width",
+            }
+        })
+        text_style_requests.append({
+            "updateTableColumnProperties": {
+                "tableStartLocation": {"index": table_start},
+                "columnIndices": [1],
+                "tableColumnProperties": {
+                    "widthType": "FIXED_WIDTH",
+                    "width": {"magnitude": 328, "unit": _PT},
+                },
+                "fields": "widthType,width",
+            }
+        })
+
+        if text_style_requests:
+            _batch_update(docs_service, doc_id, text_style_requests)
+
+    # ── Phase 3: Executive Summary section ───────────────────────────────
+    # Read document to find end index for appending after header table
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    end_idx = _doc_end_index(body_content)
+
+    b3 = _DocBuilder(start_index=end_idx)
+
+    # Horizontal divider
+    div_start, div_end = b3.insert_text("\n")
+    b3.style_paragraph(
+        div_start, div_end,
+        border_bottom={
+            "color": {"color": {"rgbColor": _LIGHT_BLUE_BORDER}},
+            "width": {"magnitude": 1, "unit": _PT},
+            "padding": {"magnitude": 6, "unit": _PT},
+            "dashStyle": "SOLID",
+        },
+    )
+
+    # Executive Summary heading
+    b3.insert_heading("Executive Summary", level=1)
+
+    # "Can We Open?" card
+    c_answer = _resolve_value(replacements, "exec.c_answer", "[Pending]")
+    c_zoning = _resolve_value(replacements, "exec.c_zoning", "[Pending]")
+    c_edreg = _resolve_value(replacements, "exec.c_edreg", "[Pending]")
+    c_occupancy = _resolve_value(replacements, "exec.c_occupancy", "[Pending]")
+
+    can_we_q = "Can this school be open in time for the current school year?\n"
+    q_start, q_end = b3.insert_text(can_we_q)
+    b3.style_text(q_start, q_end - 1, bold=True, font_size=11, font_family="Arial")
+
+    answer_text = f"{c_answer}\n"
+    a_start, a_end = b3.insert_text(answer_text)
+    b3.style_text(a_start, a_end - 1, bold=True, font_size=12, font_family="Arial")
+
+    checklist_text = (
+        f"Zoning: {c_zoning}\n"
+        f"Education Regulatory Approval: {c_edreg}\n"
+        f"Occupancy path: {c_occupancy}\n"
+    )
+    cl_start, cl_end = b3.insert_text(checklist_text)
+    b3.style_text(cl_start, cl_end - 1, font_size=10, font_family="Arial")
+
+    # Buildout Analysis heading
+    b3.insert_text("\n")
+    b3.insert_heading("Buildout Analysis", level=2)
+
+    # Build Scenarios summary table
+    b3.insert_table(4, 3)
+
+    _batch_update(docs_service, doc_id, b3.requests)
+
+    # ── Phase 4: Populate Build Scenarios table ──────────────────────────
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+
+    # Find the scenarios table (second table in the document)
+    scenarios_table = _find_table(body_content, 1)
+    if scenarios_table is None:
+        logger.error("Could not find build scenarios table")
+        return hyperlink_trace
+
+    scenario_data = [
+        ("", "Fastest Open", "Max Capacity"),
+        ("Student Capacity",
+         _resolve_value(replacements, "exec.fastest_open_capacity", "[Not found]"),
+         _resolve_value(replacements, "exec.max_capacity_capacity", "[Not found]")),
+        ("Target Open Date",
+         _resolve_value(replacements, "exec.fastest_open_open_date", "[Not found]"),
+         _resolve_value(replacements, "exec.max_capacity_open_date", "[Not found]")),
+        ("Estimated CAPEX",
+         _resolve_value(replacements, "exec.fastest_open_capex", "[Not found]"),
+         _resolve_value(replacements, "exec.max_capacity_capex", "[Not found]")),
+    ]
+
+    phase4_requests: list[dict[str, Any]] = []
+    # Populate in reverse order
+    for row_idx in range(3, -1, -1):
+        for col_idx in range(2, -1, -1):
+            text = scenario_data[row_idx][col_idx]
+            if text:
+                cell_idx = _cell_index(scenarios_table, row_idx, col_idx)
+                phase4_requests.append({
+                    "insertText": {
+                        "location": {"index": cell_idx},
+                        "text": text,
+                    }
+                })
+
+    if phase4_requests:
+        _batch_update(docs_service, doc_id, phase4_requests)
+
+    # Style the scenarios table
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    scenarios_table = _find_table(body_content, 1)
+
+    if scenarios_table:
+        style_requests: list[dict[str, Any]] = []
+        # Header row: dark blue bg, white bold text
+        for col_idx in range(3):
+            style_requests.extend(
+                _build_cell_style_requests(scenarios_table, 0, col_idx, bg_color=_DARK_BLUE)
+            )
+            cs, ce = _table_cell_range(scenarios_table, 0, col_idx)
+            style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                        "foregroundColor": {"color": {"rgbColor": _WHITE}},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily,foregroundColor",
+                }
+            })
+        # Data rows: bold labels in col 0
+        for row_idx in range(1, 4):
+            cs, ce = _table_cell_range(scenarios_table, row_idx, 0)
+            style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily",
+                }
+            })
+            for col_idx in range(1, 3):
+                vs, ve = _table_cell_range(scenarios_table, row_idx, col_idx)
+                style_requests.append({
+                    "updateTextStyle": {
+                        "range": {"startIndex": vs, "endIndex": ve},
+                        "textStyle": {
+                            "fontSize": {"magnitude": 10, "unit": _PT},
+                            "weightedFontFamily": {"fontFamily": "Arial"},
+                        },
+                        "fields": "fontSize,weightedFontFamily",
+                    }
+                })
+        if style_requests:
+            _batch_update(docs_service, doc_id, style_requests)
+
+    # ── Phase 5: Cost Breakdown section ──────────────────────────────────
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    end_idx = _doc_end_index(body_content)
+
+    b5 = _DocBuilder(start_index=end_idx)
+    b5.insert_text("\n")
+    b5.insert_heading("Detailed Cost Breakdown", level=2)
+
+    num_cost_rows = len(_COST_BREAKDOWN_ROWS) + 1  # +1 for header
+    b5.insert_table(num_cost_rows, 3)
+
+    _batch_update(docs_service, doc_id, b5.requests)
+
+    # Populate cost table
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    cost_table = _find_table(body_content, 2)
+
+    if cost_table is None:
+        logger.error("Could not find cost breakdown table")
+        return hyperlink_trace
+
+    cost_header = ("Line Item", "Fastest Open", "Max Capacity")
+    cost_rows_data: list[tuple[str, str, str]] = []
+    for row_key, display_label in _COST_BREAKDOWN_ROWS:
+        fo_val = _resolve_value(
+            replacements,
+            f"exec.cost_{row_key}_fastest_open",
+            "[Not found]",
+        )
+        mc_val = _resolve_value(
+            replacements,
+            f"exec.cost_{row_key}_max_capacity",
+            "[Not found]",
+        )
+        cost_rows_data.append((display_label, fo_val, mc_val))
+
+    phase5_requests: list[dict[str, Any]] = []
+    # Populate in reverse order
+    all_cost_data = [cost_header] + cost_rows_data
+    for row_idx in range(len(all_cost_data) - 1, -1, -1):
+        for col_idx in range(2, -1, -1):
+            text = all_cost_data[row_idx][col_idx]
+            if text:
+                cell_idx = _cell_index(cost_table, row_idx, col_idx)
+                phase5_requests.append({
+                    "insertText": {
+                        "location": {"index": cell_idx},
+                        "text": text,
+                    }
+                })
+
+    if phase5_requests:
+        _batch_update(docs_service, doc_id, phase5_requests)
+
+    # Style cost table
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    cost_table = _find_table(body_content, 2)
+
+    if cost_table:
+        style_requests = []
+        # Header row
+        for col_idx in range(3):
+            style_requests.extend(
+                _build_cell_style_requests(cost_table, 0, col_idx, bg_color=_DARK_BLUE)
+            )
+            cs, ce = _table_cell_range(cost_table, 0, col_idx)
+            style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                        "foregroundColor": {"color": {"rgbColor": _WHITE}},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily,foregroundColor",
+                }
+            })
+
+        # Data rows — alternating shading, bold labels, bold Grand Total
+        for data_row_idx in range(len(_COST_BREAKDOWN_ROWS)):
+            table_row_idx = data_row_idx + 1
+            row_key, display_label = _COST_BREAKDOWN_ROWS[data_row_idx]
+            is_grand_total = row_key == "grand_total"
+
+            # Alternating row shading (even data rows = odd table rows)
+            if data_row_idx % 2 == 1:
+                for col_idx in range(3):
+                    style_requests.extend(
+                        _build_cell_style_requests(
+                            cost_table, table_row_idx, col_idx, bg_color=_LIGHT_GRAY,
+                        )
+                    )
+
+            # Label column — always bold
+            cs, ce = _table_cell_range(cost_table, table_row_idx, 0)
+            style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily",
+                }
+            })
+
+            # Value columns
+            for col_idx in range(1, 3):
+                vs, ve = _table_cell_range(cost_table, table_row_idx, col_idx)
+                style_requests.append({
+                    "updateTextStyle": {
+                        "range": {"startIndex": vs, "endIndex": ve},
+                        "textStyle": {
+                            "bold": is_grand_total,
+                            "fontSize": {"magnitude": 10, "unit": _PT},
+                            "weightedFontFamily": {"fontFamily": "Arial"},
+                        },
+                        "fields": "bold,fontSize,weightedFontFamily",
+                    }
+                })
+
+        if style_requests:
+            _batch_update(docs_service, doc_id, style_requests)
+
+    # ── Phase 6: Notes and Source Documents ───────────────────────────────
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    end_idx = _doc_end_index(body_content)
+
+    b6 = _DocBuilder(start_index=end_idx)
+
+    b6.insert_text("\n")
+    b6.insert_heading("Notes and Source Documents", level=1)
+
+    # Acquisition Conditions
+    acq_label_start, acq_label_end = b6.insert_text("Acquisition Conditions\n")
+    b6.style_text(acq_label_start, acq_label_end - 1, bold=True, font_size=11, font_family="Arial")
+
+    acq_val = _resolve_value(replacements, "exec.acquisition_conditions", "[No acquisition conditions provided]")
+    b6.insert_paragraph(acq_val)
+
+    b6.insert_text("\n")
+
+    # Risks to Note
+    risk_label_start, risk_label_end = b6.insert_text("Risks to Note\n")
+    b6.style_text(risk_label_start, risk_label_end - 1, bold=True, font_size=11, font_family="Arial")
+
+    risk_val = _resolve_value(replacements, "exec.risk_notes", "[No risks noted]")
+    b6.insert_paragraph(risk_val)
+
+    b6.insert_text("\n")
+
+    # Source Documents heading
+    b6.insert_heading("Source Documents", level=2)
+
+    # Source documents table
+    b6.insert_table(len(_SOURCE_DOC_ROWS) + 1, 2)  # +1 for header
+
+    _batch_update(docs_service, doc_id, b6.requests)
+
+    # ── Phase 7: Populate source documents table ─────────────────────────
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+
+    source_table = _find_table(body_content, 3)
+    if source_table is None:
+        logger.error("Could not find source documents table")
+        return hyperlink_trace
+
+    source_table_data: list[tuple[str, str, str | None]] = [
+        ("Document", "Link", None),  # header
+    ]
+    for label, token in _SOURCE_DOC_ROWS:
+        display, url = _resolve_link_value(replacements, token)
+        source_table_data.append((label, display, url))
+
+    phase7_requests: list[dict[str, Any]] = []
+    # Populate in reverse
+    for row_idx in range(len(source_table_data) - 1, -1, -1):
+        row = source_table_data[row_idx]
+        label_text = row[0]
+        value_text = row[1]
+
+        # Value column
+        if value_text:
+            val_idx = _cell_index(source_table, row_idx, 1)
+            phase7_requests.append({
+                "insertText": {
+                    "location": {"index": val_idx},
+                    "text": value_text,
+                }
+            })
+            # Apply hyperlink if URL is present
+            if len(row) > 2 and row[2] is not None:
+                url = row[2]
+                phase7_requests.append({
+                    "updateTextStyle": {
+                        "range": {"startIndex": val_idx, "endIndex": val_idx + len(value_text)},
+                        "textStyle": {
+                            "link": {"url": url},
+                            "foregroundColor": {"color": {"rgbColor": _LINK_BLUE}},
+                        },
+                        "fields": "link,foregroundColor",
+                    }
+                })
+                hyperlink_trace["applied"] += 1
+                # Find original token for tracing
+                if row_idx > 0:
+                    token_key = _SOURCE_DOC_ROWS[row_idx - 1][1]
+                    hyperlink_trace["found_tokens"].append(token_key)
+
+        # Label column
+        if label_text:
+            label_idx = _cell_index(source_table, row_idx, 0)
+            phase7_requests.append({
+                "insertText": {
+                    "location": {"index": label_idx},
+                    "text": label_text,
+                }
+            })
+
+    if phase7_requests:
+        _batch_update(docs_service, doc_id, phase7_requests)
+
+    # Style source documents table
+    doc = docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    source_table = _find_table(body_content, 3)
+
+    if source_table:
+        style_requests = []
+        # Header row
+        for col_idx in range(2):
+            style_requests.extend(
+                _build_cell_style_requests(source_table, 0, col_idx, bg_color=_DARK_BLUE)
+            )
+            cs, ce = _table_cell_range(source_table, 0, col_idx)
+            style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                        "foregroundColor": {"color": {"rgbColor": _WHITE}},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily,foregroundColor",
+                }
+            })
+        # Data rows — bold label column
+        for row_idx in range(1, len(_SOURCE_DOC_ROWS) + 1):
+            cs, ce = _table_cell_range(source_table, row_idx, 0)
+            style_requests.append({
+                "updateTextStyle": {
+                    "range": {"startIndex": cs, "endIndex": ce},
+                    "textStyle": {
+                        "bold": True,
+                        "fontSize": {"magnitude": 10, "unit": _PT},
+                        "weightedFontFamily": {"fontFamily": "Arial"},
+                    },
+                    "fields": "bold,fontSize,weightedFontFamily",
+                }
+            })
+
+        if style_requests:
+            _batch_update(docs_service, doc_id, style_requests)
+
+    # Track link tokens that were NOT found
+    all_link_tokens_in_sources = {token for _, token in _SOURCE_DOC_ROWS}
+    all_link_tokens_in_sources.add("meta.drive_folder_url")
+    for token in all_link_tokens_in_sources:
+        if token not in hyperlink_trace["found_tokens"]:
+            value = replacements.get(token, "")
+            if value.startswith("http"):
+                # URL was provided but not hyperlinked — shouldn't happen in builder
+                pass
+            elif token != "sources.trace_link":
+                # Token was missing or non-URL
+                hyperlink_trace["not_found_tokens"].append(token)
+
+    logger.info(
+        "Document builder complete: %d hyperlinks applied, %d link tokens not found",
+        hyperlink_trace["applied"],
+        len(hyperlink_trace["not_found_tokens"]),
+    )
+
+    return hyperlink_trace
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _batch_update(
+    docs_service: Any,
+    doc_id: str,
+    requests: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Execute a batchUpdate, returning the response."""
+    if not requests:
+        return None
+    return (
+        docs_service.documents()
+        .batchUpdate(documentId=doc_id, body={"requests": requests})
+        .execute()
+    )
+
+
+def _find_table(
+    body_content: list[dict[str, Any]],
+    table_index: int,
+) -> dict[str, Any] | None:
+    """Find the Nth table element (0-indexed) in the document body content."""
+    count = 0
+    for element in body_content:
+        if "table" in element:
+            if count == table_index:
+                return element
+            count += 1
+    return None
+
+
+def _doc_end_index(body_content: list[dict[str, Any]]) -> int:
+    """Return the end index of the last element in the document body.
+
+    Subtracts 1 because the document always has a trailing newline that
+    we need to insert *before*.
+    """
+    if not body_content:
+        return 1
+    last = body_content[-1]
+    end = last.get("endIndex", 1)
+    return max(end - 1, 1)

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -17,6 +17,7 @@ from mcp.server import FastMCP
 from .classifier import classify_by_keywords, classify_document, match_file_to_site_llm
 from .config import get_settings
 from .google_client import GoogleClient
+from .google_doc_builder import build_dd_report_doc
 from .report_schema import (
     ALLOWED_CAN_WE_ANSWERS,
     LINK_DISPLAY_LABELS,
@@ -28,8 +29,6 @@ from .report_schema import (
     normalize_report_data,
 )
 from .utils import (
-    build_hyperlink_requests,
-    build_replace_all_text_requests,
     escape_html_text,
     extract_folder_id_from_url,
     extract_text_from_pdf_bytes,
@@ -2264,7 +2263,11 @@ def _upload_report_trace(
     doc_id: str,
     trace_data: dict[str, Any],
 ) -> None:
-    """Upload the report trace JSON and link it from the generated report."""
+    """Upload the report trace JSON and link it from the generated report.
+
+    Finds the "Report Trace" row in the source documents table and
+    inserts the trace label as a hyperlink in the link cell.
+    """
     trace_name = f"{site_name} Report Trace - {report_date.replace('/', '-')}.json"
     trace_json = json.dumps(trace_data, indent=2)
     trace_file = gc.upload_file_to_folder(
@@ -2279,23 +2282,100 @@ def _upload_report_trace(
         return
 
     trace_label = LINK_DISPLAY_LABELS.get("sources.trace_link", trace_url)
-    gc.batch_update_document(
-        doc_id,
-        build_replace_all_text_requests({"sources.trace_link": trace_label}),
-    )
-    doc_body = gc.get_document(doc_id).get("body", {})
-    start_idx = find_text_index_in_doc(doc_body, trace_label)
-    if start_idx is None:
-        return
 
-    gc.batch_update_document(doc_id, [{
-        "updateTextStyle": {
-            "range": {"startIndex": start_idx, "endIndex": start_idx + len(trace_label)},
-            "textStyle": {"link": {"url": trace_url}},
-            "fields": "link",
-        }
-    }])
-    logger.info("Linked trace report in doc: %s", trace_label)
+    # Find the Report Trace row in the source documents table.
+    # The builder inserts the trace link cell as empty; we look for
+    # the "Report Trace" label in column 0 and insert into column 1.
+    doc = gc.get_document(doc_id)
+    doc_body = doc.get("body", {})
+    body_content = doc_body.get("content", [])
+
+    trace_cell_idx = _find_trace_link_cell(body_content)
+    if trace_cell_idx is not None:
+        # Insert trace label text and apply hyperlink styling
+        gc.batch_update_document(doc_id, [
+            {
+                "insertText": {
+                    "location": {"index": trace_cell_idx},
+                    "text": trace_label,
+                }
+            },
+            {
+                "updateTextStyle": {
+                    "range": {
+                        "startIndex": trace_cell_idx,
+                        "endIndex": trace_cell_idx + len(trace_label),
+                    },
+                    "textStyle": {
+                        "link": {"url": trace_url},
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {"red": 0.067, "green": 0.333, "blue": 0.800},
+                            },
+                        },
+                    },
+                    "fields": "link,foregroundColor",
+                }
+            },
+        ])
+        logger.info("Linked trace report in doc: %s", trace_label)
+    else:
+        # Fallback: search for any existing trace label text
+        start_idx = find_text_index_in_doc(doc_body, trace_label)
+        if start_idx is not None:
+            gc.batch_update_document(doc_id, [{
+                "updateTextStyle": {
+                    "range": {
+                        "startIndex": start_idx,
+                        "endIndex": start_idx + len(trace_label),
+                    },
+                    "textStyle": {"link": {"url": trace_url}},
+                    "fields": "link",
+                }
+            }])
+            logger.info("Linked trace report in doc (fallback): %s", trace_label)
+        else:
+            logger.warning("Could not find trace link cell in document")
+
+
+def _find_trace_link_cell(body_content: list[dict[str, Any]]) -> int | None:
+    """Find the insertion index for the trace link cell in the source docs table.
+
+    Scans tables for a row whose first cell contains "Report Trace" and
+    returns the start index of the second cell's first paragraph.
+    """
+    for element in body_content:
+        if "table" not in element:
+            continue
+        for row in element["table"].get("tableRows", []):
+            cells = row.get("tableCells", [])
+            if len(cells) < 2:
+                continue
+            # Check if first cell contains "Report Trace"
+            cell0_text = _extract_cell_text(cells[0])
+            if "Report Trace" in cell0_text:
+                # Return the start index of the second cell's content
+                cell1_content = cells[1].get("content", [])
+                if cell1_content:
+                    first_para = cell1_content[0]
+                    if "paragraph" in first_para:
+                        elements = first_para["paragraph"].get("elements", [])
+                        if elements:
+                            return elements[0].get("startIndex", 0)
+                        return first_para.get("startIndex", 0)
+    return None
+
+
+def _extract_cell_text(cell: dict[str, Any]) -> str:
+    """Extract all text from a table cell."""
+    texts: list[str] = []
+    for content_el in cell.get("content", []):
+        if "paragraph" in content_el:
+            for pe in content_el["paragraph"].get("elements", []):
+                text_run = pe.get("textRun")
+                if text_run:
+                    texts.append(text_run.get("content", ""))
+    return "".join(texts)
 
 
 @mcp.tool()
@@ -2334,24 +2414,6 @@ async def create_dd_report(
             "message": f"Could not extract a Google Drive folder ID from: {drive_folder_url}",
         }
 
-    settings = get_settings()
-    template_id = settings.dd_template_v3_google_doc_id
-    if not template_id and settings.dd_template_v2_google_doc_id:
-        template_id = settings.dd_template_v2_google_doc_id
-        logger.warning(
-            "Using legacy DD_TEMPLATE_V2_GOOGLE_DOC_ID fallback. "
-            "Set DD_TEMPLATE_V3_GOOGLE_DOC_ID for V3 template runs.",
-        )
-    if not template_id:
-        return {
-            "status": "error",
-            "error": "Missing configuration",
-            "message": (
-                "DD_TEMPLATE_V3_GOOGLE_DOC_ID is not configured. "
-                "Set this environment variable to the Google Doc template ID."
-            ),
-        }
-
     today_str = datetime.now().strftime("%m/%d/%Y")
     doc_name = f"{site_name.strip()} DD Report - {today_str}"
     logger.info("Creating DD report: %s", doc_name)
@@ -2378,18 +2440,18 @@ async def create_dd_report(
                     "message": f"DD report already exists: {existing_doc_url}",
                 }
 
-            logger.info("Copying template %s to folder %s as '%s'", template_id, folder_id, doc_name)
-            copied_doc = gc.copy_document(
-                template_id=template_id,
+            logger.info("Creating blank document in folder %s as '%s'", folder_id, doc_name)
+            new_doc = gc.create_document(
                 name=doc_name,
-                parent_folder_id=folder_id,
+                folder_id=folder_id,
+                text_content="",
             )
-            doc_id = copied_doc.get("id")
-            doc_url = copied_doc.get("webViewLink")
+            doc_id = new_doc.get("id")
+            doc_url = new_doc.get("webViewLink")
             if not doc_id or not isinstance(doc_id, str):
-                raise RuntimeError("Invalid document ID returned from copy operation")
+                raise RuntimeError("Invalid document ID returned from create operation")
 
-            logger.info("Copied template to new document: %s (id=%s)", doc_name, doc_id)
+            logger.info("Created blank document: %s (id=%s)", doc_name, doc_id)
             replacements, unmatched, unfilled, _token_sources = _normalize_report_replacements(
                 report_data=report_data,
                 site_name=site_name.strip(),
@@ -2403,20 +2465,32 @@ async def create_dd_report(
             if unmatched:
                 logger.warning("Unmatched agent keys (no template token): %s", unmatched)
 
-            text_replacements, link_urls = _prepare_report_text_replacements(replacements)
-            replace_requests = build_replace_all_text_requests(text_replacements)
-            if replace_requests:
-                gc.batch_update_document(doc_id, replace_requests)
-                logger.info("Applied %d text replacements to document %s", len(replace_requests), doc_id)
-            else:
-                logger.warning("No placeholder replacements to apply - report_data may be empty")
-
-            hyperlink_trace = _apply_report_hyperlinks(
-                gc=gc,
+            # Build the document structure programmatically
+            builder_result = build_dd_report_doc(
+                docs_service=gc.docs_service,
+                drive_service=gc.drive_service,
                 doc_id=doc_id,
                 replacements=replacements,
-                link_urls=link_urls,
+                site_title=site_name.strip(),
             )
+
+            hyperlink_trace = {
+                "candidates": {},
+                "found_in_doc": builder_result.get("found_tokens", []),
+                "not_found_in_doc": builder_result.get("not_found_tokens", []),
+                "missing_from_agent": [t for t in LINK_TOKENS if t not in replacements],
+                "non_url_values": {
+                    key: replacements[key][:120]
+                    for key in LINK_TOKENS
+                    if key in replacements and not replacements[key].startswith("http")
+                },
+                "unmapped_agent_urls": [
+                    key for key, value in replacements.items()
+                    if key not in LINK_TOKENS and value.startswith("http")
+                ],
+                "applied": builder_result.get("applied", 0),
+                "error": None,
+            }
 
             logger.info("DD report created successfully: %s", doc_url)
             trace_data = _build_report_trace_data(
@@ -2445,7 +2519,7 @@ async def create_dd_report(
             return {
                 "status": "success",
                 "document": {"id": doc_id, "name": doc_name, "url": doc_url},
-                "replacements_applied": len(replace_requests),
+                "replacements_applied": len(replacements),
                 "unmatched_agent_keys": len(unmatched),
                 "unfilled_template_tokens": len(unfilled),
                 "hyperlinks_applied": hyperlink_trace["applied"],

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -675,7 +675,7 @@ class TestAsyncOffloading:
         from due_diligence_reporter.server import create_dd_report
 
         gc = MagicMock()
-        gc.copy_document.return_value = {
+        gc.create_document.return_value = {
             "id": "doc123",
             "webViewLink": "https://docs.google.com/document/d/doc123",
         }
@@ -689,17 +689,14 @@ class TestAsyncOffloading:
             "due_diligence_reporter.server.asyncio.to_thread",
             new=AsyncMock(side_effect=run_inline),
         ) as mock_to_thread, patch(
-            "due_diligence_reporter.server.get_settings",
-            return_value=MagicMock(dd_template_v3_google_doc_id="template123"),
-        ), patch(
             "due_diligence_reporter.server._make_google_client",
             return_value=gc,
         ), patch(
             "due_diligence_reporter.server.normalize_report_data",
             return_value=({}, [], [], {}),
         ), patch(
-            "due_diligence_reporter.server.build_replace_all_text_requests",
-            return_value=[],
+            "due_diligence_reporter.server.build_dd_report_doc",
+            return_value={"applied": 0, "found_tokens": [], "not_found_tokens": []},
         ):
             result = asyncio.run(create_dd_report(
                 site_name="Alpha",
@@ -708,7 +705,7 @@ class TestAsyncOffloading:
             ))
 
         assert result["status"] == "success"
-        gc.copy_document.assert_called_once()
+        gc.create_document.assert_called_once()
         mock_to_thread.assert_awaited_once()
 
     def test_create_dd_report_reuses_existing_same_day_doc(self) -> None:
@@ -728,9 +725,6 @@ class TestAsyncOffloading:
             "due_diligence_reporter.server.asyncio.to_thread",
             new=AsyncMock(side_effect=run_inline),
         ), patch(
-            "due_diligence_reporter.server.get_settings",
-            return_value=MagicMock(dd_template_v3_google_doc_id="template123"),
-        ), patch(
             "due_diligence_reporter.server._make_google_client",
             return_value=gc,
         ), patch(
@@ -745,6 +739,6 @@ class TestAsyncOffloading:
 
         assert result["status"] == "success"
         assert result["document"]["id"] == "doc-existing"
-        gc.copy_document.assert_not_called()
+        gc.create_document.assert_not_called()
 
 

--- a/tests/test_google_doc_builder.py
+++ b/tests/test_google_doc_builder.py
@@ -1,0 +1,588 @@
+"""Tests for the programmatic Google Doc builder."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from due_diligence_reporter.google_doc_builder import (
+    _COST_BREAKDOWN_ROWS,
+    _DocBuilder,
+    _HEADER_ROWS,
+    _LINK_GAP_LABELS,
+    _SOURCE_DOC_ROWS,
+    _cell_index,
+    _doc_end_index,
+    _find_table,
+    _resolve_link_value,
+    _resolve_value,
+    build_dd_report_doc,
+)
+from due_diligence_reporter.report_schema import (
+    LINK_DISPLAY_LABELS,
+    LINK_TOKENS,
+    TEMPLATE_TOKENS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fake doc body for API read-back
+# ---------------------------------------------------------------------------
+
+
+def _make_table_element(
+    start_index: int,
+    rows: int,
+    cols: int,
+    *,
+    cell_texts: dict[tuple[int, int], str] | None = None,
+) -> dict[str, Any]:
+    """Create a minimal table element for tests.
+
+    Each cell has a single paragraph with one textRun.
+    Cell indices are assigned sequentially starting from start_index + 1.
+    """
+    idx = start_index + 1
+    table_rows = []
+    for r in range(rows):
+        cells = []
+        for c in range(cols):
+            text = ""
+            if cell_texts and (r, c) in cell_texts:
+                text = cell_texts[(r, c)]
+            cell_content = {
+                "paragraph": {
+                    "elements": [
+                        {
+                            "startIndex": idx,
+                            "endIndex": idx + max(len(text), 1),
+                            "textRun": {"content": text or "\n"},
+                        }
+                    ]
+                },
+                "startIndex": idx,
+                "endIndex": idx + max(len(text), 1),
+            }
+            cells.append({
+                "content": [cell_content],
+                "startIndex": idx,
+                "endIndex": idx + max(len(text), 1),
+            })
+            idx += max(len(text), 1) + 2  # gap for structural chars
+        table_rows.append({"tableCells": cells})
+
+    return {
+        "startIndex": start_index,
+        "endIndex": idx,
+        "table": {
+            "rows": rows,
+            "columns": cols,
+            "tableRows": table_rows,
+        },
+    }
+
+
+def _make_paragraph_element(start_index: int, text: str) -> dict[str, Any]:
+    return {
+        "startIndex": start_index,
+        "endIndex": start_index + len(text),
+        "paragraph": {
+            "elements": [
+                {
+                    "startIndex": start_index,
+                    "endIndex": start_index + len(text),
+                    "textRun": {"content": text},
+                }
+            ]
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# _DocBuilder unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocBuilder:
+    def test_insert_text_advances_index(self) -> None:
+        b = _DocBuilder(start_index=1)
+        start, end = b.insert_text("hello")
+        assert start == 1
+        assert end == 6
+        assert b.index == 6
+
+    def test_insert_text_creates_request(self) -> None:
+        b = _DocBuilder(start_index=1)
+        b.insert_text("hello")
+        assert len(b.requests) == 1
+        req = b.requests[0]
+        assert "insertText" in req
+        assert req["insertText"]["location"]["index"] == 1
+        assert req["insertText"]["text"] == "hello"
+
+    def test_style_text_creates_request(self) -> None:
+        b = _DocBuilder()
+        b.style_text(1, 6, bold=True, font_size=12, font_family="Arial")
+        assert len(b.requests) == 1
+        req = b.requests[0]["updateTextStyle"]
+        assert req["range"]["startIndex"] == 1
+        assert req["range"]["endIndex"] == 6
+        assert req["textStyle"]["bold"] is True
+        assert req["textStyle"]["fontSize"]["magnitude"] == 12
+        assert "bold" in req["fields"]
+        assert "fontSize" in req["fields"]
+
+    def test_style_text_with_link(self) -> None:
+        b = _DocBuilder()
+        b.style_text(1, 10, link_url="https://example.com")
+        assert len(b.requests) == 1
+        req = b.requests[0]["updateTextStyle"]
+        assert req["textStyle"]["link"]["url"] == "https://example.com"
+        assert "link" in req["fields"]
+
+    def test_style_text_noop_when_no_fields(self) -> None:
+        b = _DocBuilder()
+        b.style_text(1, 5)
+        assert len(b.requests) == 0
+
+    def test_style_paragraph(self) -> None:
+        b = _DocBuilder()
+        b.style_paragraph(1, 10, named_style="HEADING_1", alignment="CENTER")
+        assert len(b.requests) == 1
+        req = b.requests[0]["updateParagraphStyle"]
+        assert req["paragraphStyle"]["namedStyleType"] == "HEADING_1"
+        assert req["paragraphStyle"]["alignment"] == "CENTER"
+
+    def test_insert_heading(self) -> None:
+        b = _DocBuilder(start_index=1)
+        start, end = b.insert_heading("Test Heading", level=2)
+        assert start == 1
+        # "Test Heading\n" = 13 chars
+        assert end == 14
+        # Should have insertText + updateParagraphStyle
+        assert len(b.requests) == 2
+        assert "insertText" in b.requests[0]
+        assert "updateParagraphStyle" in b.requests[1]
+        assert b.requests[1]["updateParagraphStyle"]["paragraphStyle"]["namedStyleType"] == "HEADING_2"
+
+    def test_insert_table_sets_sentinel_index(self) -> None:
+        b = _DocBuilder(start_index=10)
+        table_start = b.insert_table(3, 2)
+        assert table_start == 10
+        assert b.index == -1  # sentinel — must re-read doc
+
+    def test_insert_paragraph(self) -> None:
+        b = _DocBuilder(start_index=1)
+        start, end = b.insert_paragraph("Some text")
+        assert start == 1
+        assert end == 11  # "Some text\n" = 10 chars
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveValue:
+    def test_returns_value_when_present(self) -> None:
+        assert _resolve_value({"key": "val"}, "key") == "val"
+
+    def test_returns_gap_when_missing(self) -> None:
+        assert _resolve_value({}, "key", "[gap]") == "[gap]"
+
+    def test_returns_gap_when_empty(self) -> None:
+        assert _resolve_value({"key": ""}, "key", "[gap]") == "[gap]"
+
+    def test_returns_gap_when_whitespace(self) -> None:
+        assert _resolve_value({"key": "  "}, "key", "[gap]") == "[gap]"
+
+    def test_returns_empty_string_default_gap(self) -> None:
+        assert _resolve_value({}, "key") == ""
+
+
+class TestResolveLinkValue:
+    def test_url_returns_display_and_url(self) -> None:
+        repl = {"sources.sir_link": "https://drive.google.com/file/abc"}
+        display, url = _resolve_link_value(repl, "sources.sir_link")
+        assert display == "View SIR"
+        assert url == "https://drive.google.com/file/abc"
+
+    def test_non_url_returns_value_and_none(self) -> None:
+        repl = {"sources.sir_link": "[Not found - SIR]"}
+        display, url = _resolve_link_value(repl, "sources.sir_link")
+        assert display == "[Not found - SIR]"
+        assert url is None
+
+    def test_missing_returns_gap_and_none(self) -> None:
+        display, url = _resolve_link_value({}, "sources.sir_link")
+        assert display == _LINK_GAP_LABELS["sources.sir_link"]
+        assert url is None
+
+    def test_empty_returns_gap_and_none(self) -> None:
+        display, url = _resolve_link_value({"sources.sir_link": ""}, "sources.sir_link")
+        assert display == _LINK_GAP_LABELS["sources.sir_link"]
+        assert url is None
+
+
+class TestFindTable:
+    def test_finds_first_table(self) -> None:
+        table = _make_table_element(10, 2, 2)
+        para = _make_paragraph_element(1, "text\n")
+        content = [para, table]
+        result = _find_table(content, 0)
+        assert result is not None
+        assert "table" in result
+
+    def test_finds_second_table(self) -> None:
+        t1 = _make_table_element(10, 2, 2)
+        t2 = _make_table_element(100, 3, 3)
+        content = [t1, t2]
+        result = _find_table(content, 1)
+        assert result is not None
+        assert result["startIndex"] == 100
+
+    def test_returns_none_when_no_tables(self) -> None:
+        para = _make_paragraph_element(1, "text\n")
+        assert _find_table([para], 0) is None
+
+    def test_returns_none_when_index_too_high(self) -> None:
+        table = _make_table_element(10, 2, 2)
+        assert _find_table([table], 1) is None
+
+
+class TestDocEndIndex:
+    def test_returns_last_end_minus_one(self) -> None:
+        content = [
+            {"endIndex": 10},
+            {"endIndex": 50},
+        ]
+        assert _doc_end_index(content) == 49
+
+    def test_empty_content_returns_1(self) -> None:
+        assert _doc_end_index([]) == 1
+
+    def test_never_below_1(self) -> None:
+        content = [{"endIndex": 1}]
+        assert _doc_end_index(content) == 1
+
+
+class TestCellIndex:
+    def test_returns_start_index_of_cell_content(self) -> None:
+        table = _make_table_element(10, 2, 2)
+        idx = _cell_index(table, 0, 0)
+        # First cell should start at start_index + 1 = 11
+        assert idx == 11
+
+
+# ---------------------------------------------------------------------------
+# Template token coverage
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCoverage:
+    """Verify the builder handles all 40 template tokens from the V3 spec."""
+
+    # Collect all tokens referenced by the builder module
+    _BUILDER_TOKENS: set[str] = set()
+
+    @classmethod
+    def setup_class(cls) -> None:
+        # Header tokens
+        for _, token in _HEADER_ROWS:
+            cls._BUILDER_TOKENS.add(token)
+
+        # Executive summary tokens
+        cls._BUILDER_TOKENS.update([
+            "exec.c_answer", "exec.c_zoning", "exec.c_edreg", "exec.c_occupancy",
+        ])
+
+        # Scenario summary tokens
+        for scenario in ("fastest_open", "max_capacity"):
+            for metric in ("capacity", "open_date", "capex"):
+                cls._BUILDER_TOKENS.add(f"exec.{scenario}_{metric}")
+
+        # Cost breakdown tokens
+        for row_key, _ in _COST_BREAKDOWN_ROWS:
+            for scenario in ("fastest_open", "max_capacity"):
+                cls._BUILDER_TOKENS.add(f"exec.cost_{row_key}_{scenario}")
+
+        # Narrative tokens
+        cls._BUILDER_TOKENS.update([
+            "exec.acquisition_conditions", "exec.risk_notes",
+        ])
+
+        # Source link tokens
+        for _, token in _SOURCE_DOC_ROWS:
+            cls._BUILDER_TOKENS.add(token)
+
+    def test_all_v3_template_tokens_covered(self) -> None:
+        """Every V3 token (40 tokens from the corrected template) is handled."""
+        # The V3 corrected template only has fastest_open and max_capacity
+        # scenarios — not recommended_path or max_value.
+        v3_tokens = set()
+
+        # meta tokens
+        v3_tokens.update([
+            "meta.site_name", "meta.marketing_name", "meta.city_state_zip",
+            "meta.school_type", "meta.report_date", "meta.prepared_by",
+            "meta.drive_folder_url",
+        ])
+
+        # exec can-we-open tokens
+        v3_tokens.update([
+            "exec.c_answer", "exec.c_edreg", "exec.c_occupancy", "exec.c_zoning",
+        ])
+
+        # exec scenario summary (2 scenarios × 3 metrics = 6)
+        for scenario in ("fastest_open", "max_capacity"):
+            for metric in ("capacity", "capex", "open_date"):
+                v3_tokens.add(f"exec.{scenario}_{metric}")
+
+        # exec cost breakdown (12 rows × 2 scenarios = 24)
+        cost_keys = [
+            "cost_demolition", "cost_framing_doors", "cost_mep_fire_life_safety",
+            "cost_plumbing_bathrooms", "cost_finish_work", "cost_furniture",
+            "cost_tech_security_signage", "cost_other_hard_costs", "cost_soft_costs",
+            "cost_gc_fee", "cost_contingency", "cost_grand_total",
+        ]
+        for key in cost_keys:
+            for scenario in ("fastest_open", "max_capacity"):
+                v3_tokens.add(f"exec.{key}_{scenario}")
+
+        # exec narrative
+        v3_tokens.update(["exec.acquisition_conditions", "exec.risk_notes"])
+
+        # sources
+        v3_tokens.update([
+            "sources.sir_link", "sources.inspection_link", "sources.isp_link",
+            "sources.e_occupancy_link", "sources.school_approval_link",
+            "sources.trace_link",
+        ])
+
+        # 7 meta + 4 can-we-open + 6 scenario summary + 24 cost + 2 narrative + 6 sources = 49
+        assert len(v3_tokens) == 49, f"Expected 49 V3 tokens, got {len(v3_tokens)}"
+
+        # All V3 tokens should be covered by the builder
+        missing = v3_tokens - self._BUILDER_TOKENS
+        assert not missing, f"Builder does not handle V3 tokens: {missing}"
+
+    def test_builder_tokens_are_subset_of_template_tokens(self) -> None:
+        """Every token the builder references exists in TEMPLATE_TOKENS."""
+        template_set = set(TEMPLATE_TOKENS)
+        unknown = self._BUILDER_TOKENS - template_set
+        assert not unknown, f"Builder references unknown tokens: {unknown}"
+
+
+# ---------------------------------------------------------------------------
+# build_dd_report_doc integration test (mocked API)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_docs_service(
+    *,
+    num_tables: int = 4,
+) -> MagicMock:
+    """Create a mock docs_service that returns plausible doc structures.
+
+    Each call to documents().get() returns a body with the expected
+    number of tables plus trailing paragraph.
+    """
+    service = MagicMock()
+
+    def _make_body() -> dict[str, Any]:
+        content: list[dict[str, Any]] = []
+        idx = 1
+
+        # Title paragraph
+        content.append(_make_paragraph_element(idx, "Site Due Diligence Report\n"))
+        idx += 30
+
+        # Tables
+        for t in range(num_tables):
+            if t == 0:
+                rows, cols = len(_HEADER_ROWS), 2
+            elif t == 1:
+                rows, cols = 4, 3
+            elif t == 2:
+                rows, cols = len(_COST_BREAKDOWN_ROWS) + 1, 3
+            else:
+                rows, cols = len(_SOURCE_DOC_ROWS) + 1, 2
+
+            table = _make_table_element(idx, rows, cols)
+            content.append(table)
+            idx = table["endIndex"] + 5
+
+        # Trailing paragraph
+        content.append(_make_paragraph_element(idx, "\n"))
+        idx += 1
+
+        return {"body": {"content": content}, "documentId": "doc123"}
+
+    service.documents.return_value.get.return_value.execute = _make_body
+    service.documents.return_value.batchUpdate.return_value.execute.return_value = {}
+
+    return service
+
+
+class TestBuildDdReportDoc:
+    """Integration-level tests for build_dd_report_doc with mocked API."""
+
+    def _full_replacements(self) -> dict[str, str]:
+        """Build a complete set of replacements for all 40 V3 tokens."""
+        repl: dict[str, str] = {
+            "meta.site_name": "Alpha Boca Raton 2200",
+            "meta.marketing_name": "Boca Academy",
+            "meta.city_state_zip": "Boca Raton, FL 33431",
+            "meta.school_type": "micro",
+            "meta.report_date": "04/14/2026",
+            "meta.prepared_by": "Jane Smith",
+            "meta.drive_folder_url": "https://drive.google.com/drive/folders/abc123",
+            "exec.c_answer": "Yes see notes",
+            "exec.c_edreg": "FL: Registration required. Timeline: 30 days.",
+            "exec.c_occupancy": "78/100 YELLOW - Office general, 6-9 months",
+            "exec.c_zoning": "Permitted by right",
+            "exec.fastest_open_capacity": "69 students",
+            "exec.fastest_open_capex": "$487,000",
+            "exec.fastest_open_open_date": "08/26",
+            "exec.max_capacity_capacity": "125 students",
+            "exec.max_capacity_capex": "$812,000",
+            "exec.max_capacity_open_date": "11/26",
+            "exec.acquisition_conditions": "- Landlord must provide 6-month TI window\n- ADA ramp required",
+            "exec.risk_notes": "- No sprinkler system\n- Fire alarm > 15 years old",
+            "sources.sir_link": "https://drive.google.com/file/d/sir123",
+            "sources.inspection_link": "https://drive.google.com/file/d/insp123",
+            "sources.isp_link": "https://drive.google.com/file/d/isp123",
+            "sources.e_occupancy_link": "https://drive.google.com/file/d/eocc123",
+            "sources.school_approval_link": "https://drive.google.com/file/d/sa123",
+            "sources.trace_link": "",  # Not yet uploaded at build time
+        }
+        # Cost breakdown tokens
+        cost_keys = [
+            "cost_demolition", "cost_framing_doors", "cost_mep_fire_life_safety",
+            "cost_plumbing_bathrooms", "cost_finish_work", "cost_furniture",
+            "cost_tech_security_signage", "cost_other_hard_costs", "cost_soft_costs",
+            "cost_gc_fee", "cost_contingency", "cost_grand_total",
+        ]
+        for key in cost_keys:
+            repl[f"exec.{key}_fastest_open"] = f"${hash(key) % 100},000"
+            repl[f"exec.{key}_max_capacity"] = f"${hash(key) % 200},000"
+        return repl
+
+    def test_returns_hyperlink_trace(self) -> None:
+        """build_dd_report_doc returns a dict with applied/found/not_found."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = self._full_replacements()
+
+        result = build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Alpha Boca")
+
+        assert "applied" in result
+        assert "found_tokens" in result
+        assert "not_found_tokens" in result
+        assert isinstance(result["applied"], int)
+        assert result["applied"] >= 0
+
+    def test_batch_update_called_multiple_times(self) -> None:
+        """The builder issues multiple batchUpdate calls for the multi-pass approach."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = self._full_replacements()
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Alpha Boca")
+
+        batch_calls = docs_svc.documents.return_value.batchUpdate.call_count
+        assert batch_calls >= 4, f"Expected at least 4 batchUpdate calls, got {batch_calls}"
+
+    def test_hyperlinks_applied_for_source_links(self) -> None:
+        """Source document URLs get hyperlink requests."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = self._full_replacements()
+
+        result = build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Alpha Boca")
+
+        # We have 5 source URLs + 1 drive folder URL = up to 6 hyperlinks
+        # (trace_link is empty, so not hyperlinked)
+        assert result["applied"] >= 5
+        assert "sources.sir_link" in result["found_tokens"]
+
+    def test_missing_values_get_gap_labels(self) -> None:
+        """When tokens are missing, the builder still generates requests."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        # Minimal replacements — most tokens missing
+        repl: dict[str, str] = {
+            "meta.site_name": "Test Site",
+            "meta.report_date": "04/14/2026",
+        }
+
+        result = build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test Site")
+
+        # Should still complete without error
+        assert "applied" in result
+        # No hyperlinks since no URLs provided
+        assert result["applied"] == 0
+
+    def test_trace_link_not_found_when_empty(self) -> None:
+        """sources.trace_link is not in not_found_tokens when empty (expected)."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = self._full_replacements()
+        repl["sources.trace_link"] = ""
+
+        result = build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Alpha Boca")
+
+        # trace_link should NOT be in not_found — it's expected to be empty
+        assert "sources.trace_link" not in result.get("not_found_tokens", [])
+
+
+class TestBuildDdReportDocRequestStructure:
+    """Verify the structure of batchUpdate requests."""
+
+    def test_first_batch_contains_insert_text_and_table(self) -> None:
+        """The first batchUpdate should contain the title text insertion and table."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {"meta.site_name": "Test", "meta.report_date": "04/14/2026"}
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        # Get the first batchUpdate call
+        first_call = docs_svc.documents.return_value.batchUpdate.call_args_list[0]
+        body = first_call[1]["body"] if "body" in first_call[1] else first_call.kwargs["body"]
+        requests = body["requests"]
+
+        # Should contain insertText for the title
+        insert_texts = [r for r in requests if "insertText" in r]
+        assert len(insert_texts) >= 1
+        title_req = insert_texts[0]
+        assert "Site Due Diligence Report" in title_req["insertText"]["text"]
+
+        # Should contain insertTable for header table
+        insert_tables = [r for r in requests if "insertTable" in r]
+        assert len(insert_tables) == 1
+        assert insert_tables[0]["insertTable"]["rows"] == len(_HEADER_ROWS)
+        assert insert_tables[0]["insertTable"]["columns"] == 2
+
+
+class TestGapLabelsForLinks:
+    """Test that link tokens with no value get appropriate gap labels."""
+
+    def test_all_link_tokens_have_gap_labels(self) -> None:
+        """Every link token in _LINK_GAP_LABELS maps to a source doc row or header."""
+        all_link_tokens_in_builder = {t for _, t in _SOURCE_DOC_ROWS}
+        all_link_tokens_in_builder.add("meta.drive_folder_url")
+        for token in all_link_tokens_in_builder:
+            assert token in _LINK_GAP_LABELS, f"No gap label for {token}"
+
+    def test_source_doc_rows_match_link_tokens(self) -> None:
+        """Every source doc row token is a known LINK_TOKEN."""
+        for _, token in _SOURCE_DOC_ROWS:
+            assert token in LINK_TOKENS, f"{token} not in LINK_TOKENS"
+
+    def test_display_labels_exist_for_all_source_tokens(self) -> None:
+        """Every source doc token has a display label in LINK_DISPLAY_LABELS."""
+        for _, token in _SOURCE_DOC_ROWS:
+            assert token in LINK_DISPLAY_LABELS, f"No display label for {token}"


### PR DESCRIPTION
The DD report is now constructed from scratch using Google Docs API batchUpdate requests instead of copying a template and doing text replacement. This eliminates the dependency on a pre-existing Google Doc template and makes the document structure version-controlled in code.

New google_doc_builder.py module with build_dd_report_doc() that constructs the full document in 7 phases: title, header table, executive summary, build scenarios, cost breakdown, notes, and source documents. Hyperlinks are applied inline during construction.