### PR TITLE
Exclude Andrea from P1 assignment pool

### DIFF
--- a/src/due_diligence_reporter/assignment.py
+++ b/src/due_diligence_reporter/assignment.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any
 
@@ -36,6 +36,31 @@ GROWTH_FLAGSHIP_TYPES = {"250", "1000", "growth", "flagship"}
 EXCLUDED_TYPES = {"jc fisher", "jc_fisher"}
 
 AUTO_ASSIGN_EMAILS = ["thomas.barrow@trilogy.com", "israe.zizaoui@trilogy.com"]
+
+
+def _parse_disabled_values(raw: str) -> set[str]:
+    """Return lowercase CSV values with surrounding whitespace removed."""
+    return {
+        value.strip().lower()
+        for value in raw.split(",")
+        if value.strip()
+    }
+
+
+def _is_disabled_member(
+    entry: dict[str, Any],
+    disabled_names: set[str],
+    disabled_emails: set[str],
+) -> bool:
+    """Return True when a team-config entry is explicitly excluded."""
+    email = str(entry.get("email", "")).strip().lower()
+    if email and email in disabled_emails:
+        return True
+
+    name = " ".join(str(entry.get("name", "")).strip().lower().split())
+    if not name:
+        return False
+    return any(disabled_name in name for disabled_name in disabled_names)
 
 # ---------------------------------------------------------------------------
 # US state centroids (lat, lon) for Rule 3 Haversine
@@ -105,6 +130,8 @@ def load_team_members(settings: Settings) -> list[TeamMember]:
     raw = (settings.p1_team_config or "").strip()
     if not raw:
         return []
+    disabled_names = _parse_disabled_values(getattr(settings, "p1_disabled_names", "Andrea"))
+    disabled_emails = _parse_disabled_values(getattr(settings, "p1_disabled_emails", ""))
     try:
         entries = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -113,6 +140,13 @@ def load_team_members(settings: Settings) -> list[TeamMember]:
     members = []
     for entry in entries:
         try:
+            if _is_disabled_member(entry, disabled_names, disabled_emails):
+                logger.info(
+                    "Skipping disabled team member from assignment pool: %s <%s>",
+                    entry.get("name", ""),
+                    entry.get("email", ""),
+                )
+                continue
             members.append(
                 TeamMember(
                     name=entry["name"],

--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -134,6 +134,20 @@ class Settings(BaseSettings):
             "preferred_airline and strongly_preferred_airline are optional."
         ),
     )
+    p1_disabled_names: str = Field(
+        "Andrea",
+        description=(
+            "Comma-separated assignee names excluded from P1 assignment. "
+            "Used to block former team members even if they still appear in P1_TEAM_CONFIG."
+        ),
+    )
+    p1_disabled_emails: str = Field(
+        "",
+        description=(
+            "Comma-separated assignee email addresses excluded from P1 assignment. "
+            "Checked in addition to p1_disabled_names."
+        ),
+    )
 
     # Google Chat
     google_chat_webhook_url: str = Field(

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -7,18 +7,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from due_diligence_reporter.assignment import (
-    AssignmentResult,
     TeamMember,
     assign_p1,
+    build_site_counts,
     check_same_day_viable,
     haversine_km,
     load_team_members,
-    rule1_assign,
     rule2_assign,
     rule3_assign,
-    build_site_counts,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -47,6 +44,8 @@ def _settings(p1_team_config: str = "", serpapi_key: str = "") -> MagicMock:
     s = MagicMock()
     s.p1_team_config = p1_team_config
     s.serpapi_key = serpapi_key
+    s.p1_disabled_names = "Andrea"
+    s.p1_disabled_emails = ""
     return s
 
 
@@ -79,6 +78,27 @@ class TestLoadTeamMembers:
     def test_skips_entries_missing_required_fields(self):
         cfg = '[{"name":"Bad"}]'  # missing email, home_airport, home_state
         members = load_team_members(_settings(p1_team_config=cfg))
+        assert members == []
+
+    def test_skips_disabled_member_by_name(self):
+        cfg = (
+            '['
+            '{"name":"Andrea Smith","email":"andrea@x.com","home_airport":"DEN","home_state":"CO"},'
+            '{"name":"Bob","email":"bob@x.com","home_airport":"AUS","home_state":"TX"}'
+            ']'
+        )
+        members = load_team_members(_settings(p1_team_config=cfg))
+        assert len(members) == 1
+        assert members[0].name == "Bob"
+
+    def test_skips_disabled_member_by_email(self):
+        cfg = '[{"name":"Bob","email":"bob@x.com","home_airport":"DEN","home_state":"CO"}]'
+        settings = _settings(p1_team_config=cfg)
+        settings.p1_disabled_names = ""
+        settings.p1_disabled_emails = "bob@x.com"
+
+        members = load_team_members(settings)
+
         assert members == []
 
 
@@ -230,6 +250,15 @@ class TestAssignP1:
 
     def test_no_team_config_returns_error(self):
         result = assign_p1("micro", "Austin", "TX", _settings(), [], MagicMock())
+        assert result["status"] == "error"
+
+    def test_disabled_member_not_assignable(self):
+        settings = _settings(
+            p1_team_config='[{"name":"Andrea Smith","email":"andrea@t.com","home_airport":"AUS","home_state":"TX"}]',
+        )
+
+        result = assign_p1("micro", "", "TX", settings, [], MagicMock())
+
         assert result["status"] == "error"
 
     def test_rule2_used_when_no_city(self):


### PR DESCRIPTION
Filter disabled members out of the P1 assignment roster so stale live team config cannot continue routing sites to former employees.

Add config-backed disabled name/email lists and tests covering name and email exclusion paths.