### PR TITLE
Add canonical REBL site identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ OPS_SKILLS_REPO_PATH=
 
 # Shovels.ai permit history API
 SHOVELS_API_KEY=your_shovels_api_key_here
+REBL_BASE_URL=https://rebl3.vercel.app
 
 # Notifications
 DD_REPORT_EMAIL_RECIPIENTS=

--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -105,6 +105,10 @@ class Settings(BaseSettings):
         "https://api.shovels.ai/v2",
         description="Base URL for the Shovels.ai API",
     )
+    rebl_base_url: str = Field(
+        "https://rebl3.vercel.app",
+        description="Base URL for resolving canonical REBL site IDs from addresses.",
+    )
 
     # LLM model IDs
     openai_filename_model: str = Field(

--- a/src/due_diligence_reporter/dashboard_aggregate.py
+++ b/src/due_diligence_reporter/dashboard_aggregate.py
@@ -49,7 +49,7 @@ class CandidatePayload:
     payload: dict[str, Any]     # parsed JSON body
 
     def record_slug(self) -> str:
-        """Slug as stored inside the payload itself — the canonical key.
+        """Slug as stored inside the payload itself — the dashboard merge key.
 
         Falls back to the filename-derived slug if the payload is
         missing a slug field for any reason.

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from typing import Any
 
 import requests
@@ -73,6 +73,8 @@ def build_site_meta(
     school_type: str | None = None,
     drive_folder_url: str | None = None,
     dd_report_url: str | None = None,
+    rebl_site_id: str | None = None,
+    rebl_url: str | None = None,
     report_date: date | None = None,
 ) -> dict[str, Any]:
     """Assemble the `site_meta` payload from pipeline inputs.
@@ -102,9 +104,13 @@ def build_site_meta(
         "school_type": school_label,
         "prepared_by": "DD Pipeline (auto)",
         "report_date": rd,
-        "published_at": datetime.now(timezone.utc).isoformat(),
+        "published_at": datetime.now(UTC).isoformat(),
         "drive_folder_url": drive_folder_url or "",
         "dd_report_url": dd_report_url or "",
+        "rebl": {
+            "site_id": rebl_site_id or "",
+            "url": rebl_url or "",
+        },
     }
 
 
@@ -116,6 +122,8 @@ def publish_to_dashboard(
     school_type: str | None = None,
     drive_folder_url: str | None = None,
     dd_report_url: str | None = None,
+    rebl_site_id: str | None = None,
+    rebl_url: str | None = None,
     report_date: date | None = None,
     base_url: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
@@ -145,6 +153,8 @@ def publish_to_dashboard(
         school_type=school_type,
         drive_folder_url=drive_folder_url,
         dd_report_url=dd_report_url,
+        rebl_site_id=rebl_site_id or str(report_data.get("meta.rebl_site_id") or ""),
+        rebl_url=rebl_url or str(report_data.get("sources.rebl_link") or ""),
         report_date=report_date,
     )
     slug = meta["slug"]

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -42,6 +42,7 @@ _HEADER_ROWS: list[tuple[str, str]] = [
     ("School Type", "meta.school_type"),
     ("Report Date", "meta.report_date"),
     ("Prepared By", "meta.prepared_by"),
+    ("REBL Site ID", "meta.rebl_site_id"),
     ("Drive Folder", "meta.drive_folder_url"),
 ]
 
@@ -72,6 +73,7 @@ _SOURCE_DOC_ROWS: list[tuple[str, str]] = [
     ("Site Investigation Report (SIR)", "sources.sir_link"),
     ("Building Inspection", "sources.inspection_link"),
     ("Block Plan", "sources.block_plan_link"),
+    ("REBL Site", "sources.rebl_link"),
     ("E-Occupancy Assessment", "sources.e_occupancy_link"),
     ("School Approval Assessment", "sources.school_approval_link"),
     ("Opening Plan", "sources.opening_plan_link"),
@@ -115,11 +117,16 @@ _LINK_GAP_LABELS: dict[str, str] = {
     "sources.sir_link": "[Not found - SIR]",
     "sources.inspection_link": "[Not found - Building Inspection]",
     "sources.block_plan_link": "[Not found - Block Plan]",
+    "sources.rebl_link": "[Not found - REBL Site]",
     "sources.e_occupancy_link": "[Not found - E-Occupancy Assessment]",
     "sources.school_approval_link": "[Not found - School Approval Assessment]",
     "sources.opening_plan_link": "[Not found - Opening Plan]",
     "sources.trace_link": "",
     "meta.drive_folder_url": "",
+}
+
+_HEADER_GAP_LABELS: dict[str, str] = {
+    "meta.rebl_site_id": "[Not found - REBL site not resolved]",
 }
 
 # ---------------------------------------------------------------------------
@@ -717,7 +724,7 @@ def build_dd_report_doc(
                     hyperlink_trace["applied"] += 1
                     hyperlink_trace["found_tokens"].append(token)
         else:
-            value = _resolve_value(replacements, token)
+            value = _resolve_value(replacements, token, _HEADER_GAP_LABELS.get(token, ""))
             if value:
                 phase2_requests.append({
                     "insertText": {

--- a/src/due_diligence_reporter/rebl.py
+++ b/src/due_diligence_reporter/rebl.py
@@ -1,0 +1,118 @@
+"""Helpers for resolving canonical REBL site identity from an address."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import requests
+
+DEFAULT_REBL_BASE_URL = "https://rebl3.vercel.app"
+DEFAULT_REBL_TIMEOUT_SEC = 15.0
+
+
+@dataclass(frozen=True)
+class ReblResolution:
+    """Canonical REBL identity lookup result for one address."""
+
+    address_submitted: str = ""
+    resolution_status: str = "not_requested"
+    site_id: str = ""
+    url: str = ""
+    matched_by: str = ""
+    scored: bool | None = None
+    overall: float | None = None
+    classification: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    address_normalized: str | None = None
+    error: str = ""
+
+    @classmethod
+    def missing_address(cls) -> ReblResolution:
+        return cls(resolution_status="missing_address", error="No address available for REBL resolve.")
+
+    @classmethod
+    def error_result(cls, address: str, error: str) -> ReblResolution:
+        return cls(
+            address_submitted=address,
+            resolution_status="error",
+            error=error.strip(),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_resolution_item(address: str, item: Any) -> ReblResolution:
+    if not isinstance(item, dict):
+        return ReblResolution.error_result(address, "Resolver returned a non-object item.")
+
+    site_id = str(item.get("site_id") or "").strip()
+    url = str(item.get("url") or "").strip()
+    status = "resolved" if site_id else "not_found"
+    return ReblResolution(
+        address_submitted=address,
+        resolution_status=status,
+        site_id=site_id,
+        url=url,
+        matched_by=str(item.get("matched_by") or "").strip(),
+        scored=item.get("scored"),
+        overall=item.get("overall"),
+        classification=item.get("classification"),
+        lat=item.get("lat"),
+        lng=item.get("lng"),
+        address_normalized=item.get("address_normalized"),
+    )
+
+
+def resolve_addresses(
+    addresses: list[str],
+    *,
+    base_url: str = DEFAULT_REBL_BASE_URL,
+    timeout: float = DEFAULT_REBL_TIMEOUT_SEC,
+    session: Any = requests,
+) -> list[ReblResolution]:
+    """Resolve a batch of site addresses to canonical REBL site IDs."""
+    payload = [{"address": address.strip()} for address in addresses if address.strip()]
+    if not payload:
+        return []
+
+    response = session.post(
+        f"{base_url.rstrip('/')}/api/resolve",
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=timeout,
+    )
+    if not response.ok:
+        raise RuntimeError(f"REBL resolve {response.status_code}: {response.text[:200]}")
+
+    body = response.json()
+    if not isinstance(body, list):
+        raise RuntimeError("REBL resolve returned a non-list response.")
+    if len(body) != len(payload):
+        raise RuntimeError(
+            f"REBL resolve returned {len(body)} results for {len(payload)} addresses.",
+        )
+
+    submitted = [item["address"] for item in payload]
+    return [_parse_resolution_item(address, item) for address, item in zip(submitted, body, strict=True)]
+
+
+def resolve_address(
+    address: str,
+    *,
+    base_url: str = DEFAULT_REBL_BASE_URL,
+    timeout: float = DEFAULT_REBL_TIMEOUT_SEC,
+    session: Any = requests,
+) -> ReblResolution:
+    """Resolve one site address to a canonical REBL site ID."""
+    cleaned = address.strip()
+    if not cleaned:
+        return ReblResolution.missing_address()
+    return resolve_addresses(
+        [cleaned],
+        base_url=base_url,
+        timeout=timeout,
+        session=session,
+    )[0]

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -546,8 +546,11 @@ def run_dd_report_agent(
                     # Stash the final, fully-merged report_data for the
                     # dashboard publisher.
                     rd = tool_input.get("report_data")
+                    normalized = result.get("normalized_report_data")
                     if isinstance(rd, dict):
                         trace.final_report_data = dict(rd)
+                    if isinstance(normalized, dict):
+                        trace.final_report_data.update(normalized)
             elif isinstance(result, dict):
                 report_fields = result.get("report_data_fields")
                 if isinstance(report_fields, dict):
@@ -1136,7 +1139,7 @@ def process_site_pipeline(
 def _publish_to_dashboard_best_effort(
     *,
     site_title: str,
-    trace: "ReportTrace | None",
+    trace: ReportTrace | None,
     drive_folder_url: str,
     dd_report_url: str,
     site_address: str | None,

--- a/src/due_diligence_reporter/report_schema.py
+++ b/src/due_diligence_reporter/report_schema.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import date, datetime
-from typing import Any, Callable
+from typing import Any
 
 from .utils import flatten_report_data_for_replacement
 
@@ -86,6 +87,7 @@ def _build_template_tokens() -> list[str]:
         "meta.marketing_name",
         "meta.report_date",
         "meta.prepared_by",
+        "meta.rebl_site_id",
         "meta.drive_folder_url",
         "exec.c_answer",
         "exec.c_edreg",
@@ -111,6 +113,7 @@ def _build_template_tokens() -> list[str]:
         "sources.sir_link",
         "sources.inspection_link",
         "sources.block_plan_link",
+        "sources.rebl_link",
         "sources.e_occupancy_link",
         "sources.school_approval_link",
         "sources.opening_plan_link",
@@ -130,6 +133,7 @@ TOKEN_SOURCES: dict[str, str] = {
     "meta.marketing_name": "Wrike",
     "meta.report_date": "System",
     "meta.prepared_by": "System",
+    "meta.rebl_site_id": "REBL",
     "exec.c_answer": "Agent",
     "exec.c_zoning": "SIR",
     "exec.c_occupancy": "E-Occupancy",
@@ -140,6 +144,7 @@ TOKEN_SOURCES: dict[str, str] = {
     "exec.alpha_fit": "Agent",
     "exec.acquisition_conditions": "Agent",
     "exec.tradeoffs_and_deficiencies": "Agent",
+    "sources.rebl_link": "REBL",
     "sources.opening_plan_link": "Agent",
 }
 
@@ -159,6 +164,7 @@ LINK_TOKENS: frozenset[str] = frozenset({
     "sources.sir_link",
     "sources.inspection_link",
     "sources.block_plan_link",
+    "sources.rebl_link",
     "sources.e_occupancy_link",
     "sources.school_approval_link",
     "sources.opening_plan_link",
@@ -171,6 +177,7 @@ LINK_DISPLAY_LABELS: dict[str, str] = {
     "sources.sir_link": "View SIR",
     "sources.inspection_link": "View Inspection",
     "sources.block_plan_link": "View Block Plan",
+    "sources.rebl_link": "View REBL Site",
     "sources.e_occupancy_link": "View E-Occupancy",
     "sources.school_approval_link": "View School Approval",
     "sources.opening_plan_link": "View Opening Plan",
@@ -190,6 +197,8 @@ AGENT_KEY_ALIASES: dict[str, str] = {
     "site.marketing_name": "meta.marketing_name",
     "site.prepared_by": "meta.prepared_by",
     "site.p1_assignee_name": "meta.prepared_by",
+    "rebl.site_id": "meta.rebl_site_id",
+    "rebl.url": "sources.rebl_link",
     "p1_assignee_name": "meta.prepared_by",
     "exec_summary.acquisition_conditions": "exec.acquisition_conditions",
     "exec_summary.direct_viable_buildout": "exec.direct_viable_buildout",
@@ -200,6 +209,7 @@ AGENT_KEY_ALIASES: dict[str, str] = {
     "appendix.inspection_link": "sources.inspection_link",
     "appendix.building_inspection_link": "sources.inspection_link",
     "appendix.block_plan_link": "sources.block_plan_link",
+    "appendix.rebl_link": "sources.rebl_link",
     "appendix.floorplan_viability_link": "sources.block_plan_link",
     "appendix.isp_link": "sources.block_plan_link",
 }

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -31,6 +31,7 @@ from .config import get_settings
 from .dashboard_publish import publish_site_record
 from .google_client import GoogleClient
 from .google_doc_builder import SOURCE_QUALITY_NOTES_KEY, build_dd_report_doc
+from .rebl import ReblResolution, resolve_address
 from .report_schema import (
     ALLOWED_CAN_WE_ANSWERS,
     LINK_DISPLAY_LABELS,
@@ -93,6 +94,7 @@ DOC_MIME = "application/msword"
 MIN_SITE_MATCH_SCORE = 20
 
 _READ_CONTEXT_BY_FILE_ID: dict[str, dict[str, str]] = {}
+_REBL_RESOLUTION_CACHE: dict[str, ReblResolution] = {}
 
 CAN_WE_SECTION_DELIMITER = "Education Regulatory Approval:"
 V3_CAN_WE_HEADING = "Can this school be open in time for the current school year (8/12 or 9/8)?"
@@ -524,7 +526,6 @@ def _school_approval_exec_status(state_upper: str, approval_type: str) -> str:
 def _school_approval_alpha_reference(state_upper: str) -> tuple[str, bool, bool]:
     """Return the Alpha state-history note plus worked/operating flags."""
     worked_note = _ALPHA_WORKED_STATE_REFERENCES.get(state_upper)
-    has_worked = worked_note is not None
     is_operating = state_upper in _ALPHA_OPERATING_STATES
 
     if is_operating and worked_note:
@@ -2814,10 +2815,10 @@ def _normalize_report_replacements(
     site_name: str,
     report_date: str,
     drive_folder_url: str,
-) -> tuple[dict[str, str], list[str], list[str], dict[str, str]]:
+) -> tuple[dict[str, str], list[str], list[str], dict[str, str], ReblResolution]:
     """Normalize report data and fill permissive V3 gap labels."""
     flat_report_data = flatten_report_data_for_replacement(report_data)
-    report_data = _inject_wrike_report_defaults(report_data, site_name)
+    report_data, rebl_resolution = _inject_wrike_report_defaults(report_data, site_name)
     replacements, unmatched, unfilled, token_sources = normalize_report_data(
         report_data,
         site_name=site_name,
@@ -2839,13 +2840,75 @@ def _normalize_report_replacements(
     ).strip()
     if source_quality_notes:
         replacements[SOURCE_QUALITY_NOTES_KEY] = source_quality_notes
-    return replacements, unmatched, unfilled, token_sources
+    return replacements, unmatched, unfilled, token_sources, rebl_resolution
+
+
+def _ensure_report_section(
+    report_data: dict[str, Any],
+    section: str,
+) -> dict[str, Any]:
+    block = report_data.get(section)
+    if not isinstance(block, dict):
+        block = {}
+        report_data[section] = block
+    return block
+
+
+def _resolve_rebl_identity(address: str) -> ReblResolution:
+    cleaned = address.strip()
+    if not cleaned:
+        return ReblResolution.missing_address()
+
+    cached = _REBL_RESOLUTION_CACHE.get(cleaned)
+    if cached is not None:
+        return cached
+
+    settings = get_settings()
+    try:
+        resolved = resolve_address(cleaned, base_url=settings.rebl_base_url)
+    except Exception as e:
+        resolved = ReblResolution.error_result(cleaned, str(e))
+        logger.warning("REBL resolve failed for '%s': %s", cleaned, e)
+
+    _REBL_RESOLUTION_CACHE[cleaned] = resolved
+    return resolved
+
+
+def _apply_rebl_defaults(
+    report_data: dict[str, Any],
+    rebl_resolution: ReblResolution,
+) -> None:
+    if not rebl_resolution.site_id and not rebl_resolution.url:
+        return
+
+    meta = _ensure_report_section(report_data, "meta")
+    sources = _ensure_report_section(report_data, "sources")
+    if rebl_resolution.site_id:
+        meta["rebl_site_id"] = rebl_resolution.site_id
+    if rebl_resolution.url:
+        sources["rebl_link"] = rebl_resolution.url
+
+
+def _apply_wrike_prepared_by_defaults(
+    report_data: dict[str, Any],
+    summary: dict[str, Any],
+) -> None:
+    p1_name = summary.get("p1_assignee_name")
+    p1_email = summary.get("p1_assignee_email")
+
+    if isinstance(p1_name, str) and p1_name.strip():
+        report_data["p1_assignee_name"] = p1_name.strip()
+        site_block = _ensure_report_section(report_data, "site")
+        site_block["p1_assignee_name"] = p1_name.strip()
+
+    if isinstance(p1_email, str) and p1_email.strip():
+        report_data["p1_assignee_email"] = p1_email.strip()
 
 
 def _inject_wrike_report_defaults(
     report_data: dict[str, Any],
     site_name: str,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], ReblResolution]:
     """Inject authoritative Wrike defaults that should not depend on agent output."""
     enriched: dict[str, Any] = json.loads(json.dumps(report_data))
     try:
@@ -2856,26 +2919,13 @@ def _inject_wrike_report_defaults(
 
     if not record:
         enriched["p1_assignee_name"] = MISSING_P1_ASSIGNEE_LABEL
-        return enriched
+        return enriched, ReblResolution.error_result("", "Wrike site record not found.")
 
     summary = build_site_summary(record)
-    p1_name = summary.get("p1_assignee_name")
-    p1_email = summary.get("p1_assignee_email")
-
-    if isinstance(p1_name, str) and p1_name.strip():
-        enriched["p1_assignee_name"] = p1_name.strip()
-        site_block = enriched.get("site")
-        if not isinstance(site_block, dict):
-            site_block = {}
-            enriched["site"] = site_block
-        site_block["p1_assignee_name"] = p1_name.strip()
-    # When Wrike P1 is absent, leave p1_assignee_name unset so _resolve_prepared_by
-    # falls through to agent-provided meta.prepared_by (e.g. from LocationOS getSite)
-
-    if isinstance(p1_email, str) and p1_email.strip():
-        enriched["p1_assignee_email"] = p1_email.strip()
-
-    return enriched
+    _apply_wrike_prepared_by_defaults(enriched, summary)
+    rebl_resolution = _resolve_rebl_identity(str(summary.get("address") or ""))
+    _apply_rebl_defaults(enriched, rebl_resolution)
+    return enriched, rebl_resolution
 
 
 def _find_existing_report_doc(
@@ -3034,6 +3084,7 @@ def _build_report_trace_data(
     unmatched: list[str],
     hyperlink_trace: dict[str, Any],
     token_evidence: dict[str, str] | None,
+    rebl_resolution: ReblResolution,
 ) -> dict[str, Any]:
     """Build the report trace payload persisted beside the DD report."""
     evidence = token_evidence or {}
@@ -3062,6 +3113,7 @@ def _build_report_trace_data(
         "unmatched_keys": unmatched,
         "unfilled_tokens": unfilled,
         "hyperlinks": hyperlink_trace,
+        "rebl": rebl_resolution.to_dict(),
         **({"supplemental_evidence": supplemental_evidence} if supplemental_evidence else {}),
     }
 
@@ -3263,7 +3315,7 @@ async def create_dd_report(
                 raise RuntimeError("Invalid document ID returned from create operation")
 
             logger.info("Created blank document: %s (id=%s)", doc_name, doc_id)
-            replacements, unmatched, unfilled, _token_sources = _normalize_report_replacements(
+            replacements, unmatched, unfilled, _token_sources, rebl_resolution = _normalize_report_replacements(
                 report_data=report_data,
                 site_name=site_name.strip(),
                 report_date=today_str,
@@ -3314,6 +3366,7 @@ async def create_dd_report(
                 unmatched=unmatched,
                 hyperlink_trace=hyperlink_trace,
                 token_evidence=token_evidence,
+                rebl_resolution=rebl_resolution,
             )
             try:
                 _upload_report_trace(
@@ -3342,6 +3395,7 @@ async def create_dd_report(
                     report_date=today_str,
                     drive_folder_url=drive_folder_url,
                     dd_report_url=doc_url or "",
+                    rebl_resolution=rebl_resolution,
                 )
                 dashboard_payload = publish_site_record(
                     gc=gc,
@@ -3366,6 +3420,7 @@ async def create_dd_report(
                 "unmatched_agent_keys": len(unmatched),
                 "unfilled_template_tokens": len(unfilled),
                 "hyperlinks_applied": hyperlink_trace["applied"],
+                "normalized_report_data": replacements,
                 "message": f"DD report created: {doc_url}",
             }
             if dashboard_payload is not None:

--- a/src/due_diligence_reporter/site_record.py
+++ b/src/due_diligence_reporter/site_record.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from .rebl import ReblResolution
 from .report_schema import COST_TOKEN_BASES, SCENARIOS
 
 CLASSIFICATIONS = ("yes", "yes_if", "no", "review")
@@ -153,6 +154,7 @@ class SourceLinks:
     sir: str = ""
     inspection: str = ""
     block_plan: str = ""
+    rebl: str = ""
     e_occupancy: str = ""
     school_approval: str = ""
     opening_plan: str = ""
@@ -182,6 +184,7 @@ class SiteRecord:
     direct_viable_buildout: str = ""
     alpha_fit: str = ""
     classification: ClassificationRecord = field(default_factory=ClassificationRecord)
+    rebl: ReblResolution = field(default_factory=ReblResolution)
     scenarios: dict[str, ScenarioRecord] = field(default_factory=dict)
     sources: SourceLinks = field(default_factory=SourceLinks)
     acquisition_conditions: str = ""
@@ -198,6 +201,7 @@ class SiteRecord:
         dd_report_url: str,
         slug_suffix: str | None = None,
         classification_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+        rebl_resolution: ReblResolution | None = None,
     ) -> SiteRecord:
         """Build a SiteRecord from normalized DD replacements."""
 
@@ -233,12 +237,18 @@ class SiteRecord:
             sir=g("sources.sir_link"),
             inspection=g("sources.inspection_link"),
             block_plan=g("sources.block_plan_link"),
+            rebl=g("sources.rebl_link"),
             e_occupancy=g("sources.e_occupancy_link"),
             school_approval=g("sources.school_approval_link"),
             opening_plan=g("sources.opening_plan_link"),
             trace=g("sources.trace_link"),
             drive_folder=drive_folder_url.strip(),
             dd_report=dd_report_url.strip(),
+        )
+        fallback_rebl = ReblResolution(
+            resolution_status="resolved" if g("meta.rebl_site_id") or g("sources.rebl_link") else "not_requested",
+            site_id=g("meta.rebl_site_id"),
+            url=g("sources.rebl_link"),
         )
 
         return cls(
@@ -259,6 +269,7 @@ class SiteRecord:
             direct_viable_buildout=g("exec.direct_viable_buildout"),
             alpha_fit=g("exec.alpha_fit"),
             classification=classification,
+            rebl=rebl_resolution or fallback_rebl,
             scenarios=scenarios,
             sources=sources,
             acquisition_conditions=acquisition_conditions,

--- a/tests/test_dashboard_publish.py
+++ b/tests/test_dashboard_publish.py
@@ -20,10 +20,12 @@ def record() -> SiteRecord:
         {
             "meta.site_name": "Palm Beach Gardens",
             "meta.city_state_zip": "Palm Beach Gardens, FL 33410",
+            "meta.rebl_site_id": "palm-beach-gardens-fl",
             "exec.c_answer": "Yes",
             "exec.fastest_open_capacity": "180",
             "sources.sir_link": "https://drive.google.com/sir",
             "sources.block_plan_link": "https://drive.google.com/block-plan",
+            "sources.rebl_link": "https://rebl3.vercel.app/site/palm-beach-gardens-fl",
         },
         site_name="Palm Beach Gardens",
         report_date="04/22/26",
@@ -60,6 +62,7 @@ class TestPublishSiteRecord:
 
         payload = json.loads(call.kwargs["file_bytes"].decode("utf-8"))
         assert payload["slug"] == "palm-beach-gardens"
+        assert payload["rebl"]["site_id"] == "palm-beach-gardens-fl"
         assert payload["classification"]["label"] == "yes"
         assert payload["sources"]["sir"] == "https://drive.google.com/sir"
         assert payload["sources"]["block_plan"] == "https://drive.google.com/block-plan"

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import date
+
+from due_diligence_reporter.dashboard_publisher import build_site_meta
+
+
+class TestBuildSiteMeta:
+    def test_includes_rebl_block(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX 78701",
+            school_type="micro",
+            drive_folder_url="https://drive.google.com/drive/folders/abc",
+            dd_report_url="https://docs.google.com/document/d/xyz",
+            rebl_site_id="123-main-st-austin-tx",
+            rebl_url="https://rebl3.vercel.app/site/123-main-st-austin-tx",
+            report_date=date(2026, 4, 23),
+        )
+
+        assert meta["slug"] == "austin"
+        assert meta["rebl"]["site_id"] == "123-main-st-austin-tx"
+        assert meta["rebl"]["url"] == "https://rebl3.vercel.app/site/123-main-st-austin-tx"
+        assert meta["report_date"] == "2026-04-23"

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -454,7 +454,7 @@ class TestReportNormalizationDefaults:
             "p1_assignee_email": "jane@example.com",
         }
 
-        replacements, _, _, _ = _normalize_report_replacements(
+        replacements, _, _, _, _ = _normalize_report_replacements(
             report_data={"meta": {"prepared_by": "DD Report Agent"}},
             site_name="Alpha Atlanta 345",
             report_date="04/02/2026",
@@ -475,7 +475,7 @@ class TestReportNormalizationDefaults:
         mock_find_site_record.return_value = {"id": "wrike-1"}
         mock_build_site_summary.return_value = {}
 
-        replacements, _, _, _ = _normalize_report_replacements(
+        replacements, _, _, _, _ = _normalize_report_replacements(
             report_data={
                 "exec": {
                     "c_answer": "Conditional",
@@ -505,12 +505,43 @@ class TestReportNormalizationDefaults:
 
         mock_find_site_record.return_value = None
 
-        enriched = _inject_wrike_report_defaults(
+        enriched, rebl_resolution = _inject_wrike_report_defaults(
             {"meta": {"prepared_by": "DD Report Agent"}},
             "Alpha Atlanta 345",
         )
 
         assert enriched["p1_assignee_name"] == MISSING_P1_ASSIGNEE_LABEL
+        assert rebl_resolution.resolution_status == "error"
+
+    @patch("due_diligence_reporter.server.resolve_address")
+    @patch("due_diligence_reporter.server.build_site_summary")
+    @patch("due_diligence_reporter.server.find_site_record")
+    def test_inject_wrike_defaults_adds_rebl_fields(
+        self,
+        mock_find_site_record: MagicMock,
+        mock_build_site_summary: MagicMock,
+        mock_resolve_address: MagicMock,
+    ) -> None:
+        from due_diligence_reporter.rebl import ReblResolution
+        from due_diligence_reporter.server import _inject_wrike_report_defaults
+
+        mock_find_site_record.return_value = {"id": "wrike-1"}
+        mock_build_site_summary.return_value = {
+            "address": "123 Main St, Austin, TX 78701",
+            "p1_assignee_name": "Jane Owner",
+        }
+        mock_resolve_address.return_value = ReblResolution(
+            address_submitted="123 Main St, Austin, TX 78701",
+            resolution_status="resolved",
+            site_id="123-main-st-austin-tx",
+            url="https://rebl3.vercel.app/site/123-main-st-austin-tx",
+        )
+
+        enriched, rebl_resolution = _inject_wrike_report_defaults({}, "Alpha Austin")
+
+        assert enriched["meta"]["rebl_site_id"] == "123-main-st-austin-tx"
+        assert enriched["sources"]["rebl_link"] == "https://rebl3.vercel.app/site/123-main-st-austin-tx"
+        assert rebl_resolution.site_id == "123-main-st-austin-tx"
 
     @patch("due_diligence_reporter.server.requests.get")
     def test_optional_params_passed_correctly(self, mock_get: MagicMock) -> None:

--- a/tests/test_google_doc_builder.py
+++ b/tests/test_google_doc_builder.py
@@ -327,7 +327,7 @@ class TestTokenCoverage:
         # meta tokens
         v3_tokens.update([
             "meta.site_name", "meta.marketing_name", "meta.city_state_zip",
-            "meta.school_type", "meta.report_date", "meta.prepared_by",
+            "meta.school_type", "meta.report_date", "meta.prepared_by", "meta.rebl_site_id",
             "meta.drive_folder_url",
         ])
 
@@ -360,14 +360,14 @@ class TestTokenCoverage:
         # sources
         v3_tokens.update([
             "sources.sir_link", "sources.inspection_link",
-            "sources.block_plan_link",
+            "sources.block_plan_link", "sources.rebl_link",
             "sources.e_occupancy_link", "sources.school_approval_link",
             "sources.opening_plan_link",
             "sources.trace_link",
         ])
 
-        # 7 meta + 8 exec summary/direct + 6 scenario summary + 24 cost + 2 narrative + 7 sources = 54
-        assert len(v3_tokens) == 54, f"Expected 54 V3 tokens, got {len(v3_tokens)}"
+        # 8 meta + 8 exec summary/direct + 6 scenario summary + 24 cost + 2 narrative + 8 sources = 56
+        assert len(v3_tokens) == 56, f"Expected 56 V3 tokens, got {len(v3_tokens)}"
 
         # All V3 tokens should be covered by the builder
         missing = v3_tokens - self._BUILDER_TOKENS
@@ -443,6 +443,7 @@ class TestBuildDdReportDoc:
             "meta.school_type": "micro",
             "meta.report_date": "04/14/2026",
             "meta.prepared_by": "Jane Smith",
+            "meta.rebl_site_id": "alpha-boca-raton-2200",
             "meta.drive_folder_url": "https://drive.google.com/drive/folders/abc123",
             "exec.c_answer": "Yes",
             "exec.c_edreg": "FL: Registration required. Timeline: 30 days.",
@@ -463,6 +464,7 @@ class TestBuildDdReportDoc:
             "sources.sir_link": "https://drive.google.com/file/d/sir123",
             "sources.inspection_link": "https://drive.google.com/file/d/insp123",
             "sources.block_plan_link": "https://drive.google.com/file/d/block123",
+            "sources.rebl_link": "https://rebl3.vercel.app/site/alpha-boca-raton-2200",
             "sources.e_occupancy_link": "https://drive.google.com/file/d/eocc123",
             "sources.school_approval_link": "https://drive.google.com/file/d/sa123",
             "sources.opening_plan_link": "https://drive.google.com/file/d/op123",

--- a/tests/test_rebl.py
+++ b/tests/test_rebl.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from due_diligence_reporter.rebl import ReblResolution, resolve_address, resolve_addresses
+from due_diligence_reporter.server import _build_report_trace_data
+
+
+class _FakeResponse:
+    def __init__(self, *, ok: bool, status_code: int, body, text: str = "") -> None:
+        self.ok = ok
+        self.status_code = status_code
+        self._body = body
+        self.text = text
+
+    def json(self):
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+
+    def post(self, url: str, *, json, headers, timeout: float):
+        self.calls.append({
+            "url": url,
+            "json": json,
+            "headers": headers,
+            "timeout": timeout,
+        })
+        return self.response
+
+
+class TestResolveAddresses:
+    def test_batches_addresses_and_preserves_order(self) -> None:
+        session = _FakeSession(_FakeResponse(
+            ok=True,
+            status_code=200,
+            body=[
+                {"site_id": "first-site", "url": "https://rebl3.vercel.app/site/first-site", "matched_by": "slug"},
+                {"site_id": "", "url": "", "matched_by": "none"},
+            ],
+        ))
+
+        result = resolve_addresses(
+            ["123 Main St, Austin, TX", "500 Elm St, Dallas, TX"],
+            session=session,
+        )
+
+        assert [item.site_id for item in result] == ["first-site", ""]
+        assert result[0].resolution_status == "resolved"
+        assert result[1].resolution_status == "not_found"
+        assert session.calls[0]["json"] == [
+            {"address": "123 Main St, Austin, TX"},
+            {"address": "500 Elm St, Dallas, TX"},
+        ]
+
+    def test_empty_address_short_circuits(self) -> None:
+        result = resolve_address("")
+        assert result == ReblResolution.missing_address()
+
+    def test_http_error_raises(self) -> None:
+        session = _FakeSession(_FakeResponse(
+            ok=False,
+            status_code=503,
+            body={"error": "down"},
+            text="service unavailable",
+        ))
+
+        with pytest.raises(RuntimeError, match="REBL resolve 503"):
+            resolve_addresses(["123 Main St, Austin, TX"], session=session)
+
+
+class TestReportTraceRebl:
+    def test_build_report_trace_includes_rebl_block(self) -> None:
+        rebl = ReblResolution(
+            address_submitted="123 Main St, Austin, TX",
+            resolution_status="resolved",
+            site_id="123-main-st-austin-tx",
+            url="https://rebl3.vercel.app/site/123-main-st-austin-tx",
+            matched_by="slug",
+            scored=True,
+        )
+
+        trace = _build_report_trace_data(
+            site_name="Austin",
+            report_date="04/23/2026",
+            doc_id="doc123",
+            doc_url="https://docs.google.com/document/d/doc123",
+            replacements={"meta.site_name": "Austin"},
+            unfilled=["meta.rebl_site_id"],
+            unmatched=[],
+            hyperlink_trace={"applied": 0},
+            token_evidence=None,
+            rebl_resolution=rebl,
+        )
+
+        assert trace["rebl"]["site_id"] == "123-main-st-austin-tx"
+        assert trace["rebl"]["url"] == "https://rebl3.vercel.app/site/123-main-st-austin-tx"
+        assert trace["rebl"]["resolution_status"] == "resolved"

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -44,7 +44,7 @@ def test_no_alias_is_also_a_template_token() -> None:
 
 
 def test_token_count_v3() -> None:
-    assert len(TEMPLATE_TOKENS) == 54, f"Expected 54 tokens, got {len(TEMPLATE_TOKENS)}"
+    assert len(TEMPLATE_TOKENS) == 56, f"Expected 56 tokens, got {len(TEMPLATE_TOKENS)}"
     assert all("delta_" not in t for t in TEMPLATE_TOKENS)
 
 
@@ -75,6 +75,10 @@ class TestNormalization:
                 "e_occupancy_link": "https://example.com/eocc",
             },
             "meta": {"site_name": "Alpha Test"},
+            "rebl": {
+                "site_id": "alpha-test-site",
+                "url": "https://rebl3.vercel.app/site/alpha-test-site",
+            },
         }
         replacements, unmatched, _unfilled, sources = normalize_report_data(
             report_data,
@@ -89,12 +93,15 @@ class TestNormalization:
         assert replacements["exec.tradeoffs_and_deficiencies"] == "No nearby park access [1]"
         assert replacements["sources.sir_link"] == "https://example.com/sir"
         assert replacements["sources.block_plan_link"] == "https://example.com/block-plan"
+        assert replacements["meta.rebl_site_id"] == "alpha-test-site"
+        assert replacements["sources.rebl_link"] == "https://rebl3.vercel.app/site/alpha-test-site"
         assert replacements["meta.site_name"] == "Alpha Test"
-        assert unmatched == []
+        assert unmatched == ["rebl.site_id", "rebl.url"]
         assert sources["exec.fastest_open_capacity"] == "Capacity Brainlift"
         assert sources["exec.max_capacity_capacity"] == "Capacity Brainlift"
         assert sources["exec.fastest_open_capex"] == "RayCon"
         assert sources["exec.fastest_open_open_date"] == "RayCon"
+        assert sources["meta.rebl_site_id"] == "alias:rebl.site_id"
 
     def test_legacy_v2_aliases_map_to_v3(self) -> None:
         report_data = {
@@ -141,6 +148,7 @@ class TestNormalization:
         assert "meta.report_date" not in unfilled
         assert "exec.direct_viable_buildout" in unfilled
         assert "exec.alpha_fit" in unfilled
+        assert "meta.rebl_site_id" in unfilled
         assert "exec.fastest_open_capacity" in unfilled
         assert "exec.max_capacity_capacity" in unfilled
         assert "exec.tradeoffs_and_deficiencies" in unfilled
@@ -260,6 +268,11 @@ class TestLinkTokenSets:
     def test_block_plan_link_present_in_v3_schema(self) -> None:
         assert "sources.block_plan_link" in TEMPLATE_TOKEN_SET
         assert "sources.block_plan_link" in LINK_TOKENS
+
+    def test_rebl_tokens_present_in_v3_schema(self) -> None:
+        assert "meta.rebl_site_id" in TEMPLATE_TOKEN_SET
+        assert "sources.rebl_link" in TEMPLATE_TOKEN_SET
+        assert "sources.rebl_link" in LINK_TOKENS
 
     def test_isp_link_removed_from_v3_schema(self) -> None:
         assert "sources.isp_link" not in TEMPLATE_TOKEN_SET

--- a/tests/test_site_record.py
+++ b/tests/test_site_record.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import pytest
 
+from due_diligence_reporter.rebl import ReblResolution
 from due_diligence_reporter.site_record import (
     CLASSIFICATIONS,
     SiteRecord,
@@ -105,6 +106,7 @@ def _full_replacements() -> dict[str, str]:
         "meta.school_type": "K-8",
         "meta.report_date": "04/22/26",
         "meta.prepared_by": "Greg Foote",
+        "meta.rebl_site_id": "palm-beach-gardens-fl",
         "meta.drive_folder_url": "https://drive.google.com/drive/folders/ABC",
         "exec.c_answer": "Yes see notes",
         "exec.c_edreg": "Approved - FL nonpublic registration",
@@ -125,6 +127,7 @@ def _full_replacements() -> dict[str, str]:
         "sources.sir_link": "https://drive.google.com/sir",
         "sources.inspection_link": "https://drive.google.com/inspection",
         "sources.block_plan_link": "https://drive.google.com/block-plan",
+        "sources.rebl_link": "https://rebl3.vercel.app/site/palm-beach-gardens-fl",
         "sources.e_occupancy_link": "https://drive.google.com/eo",
         "sources.school_approval_link": "https://drive.google.com/sa",
         "sources.opening_plan_link": "https://drive.google.com/op",
@@ -189,8 +192,30 @@ class TestFromReplacements:
         )
         assert record.sources.sir == "https://drive.google.com/sir"
         assert record.sources.block_plan == "https://drive.google.com/block-plan"
+        assert record.sources.rebl == "https://rebl3.vercel.app/site/palm-beach-gardens-fl"
         assert record.sources.dd_report == "https://docs.google.com/document/d/XYZ"
         assert record.sources.drive_folder == "https://drive.google.com/drive/folders/ABC"
+
+    def test_rebl_resolution_is_preserved(self) -> None:
+        resolution = ReblResolution(
+            address_submitted="4520 PGA Blvd, Palm Beach Gardens, FL 33418",
+            resolution_status="resolved",
+            site_id="palm-beach-gardens-fl",
+            url="https://rebl3.vercel.app/site/palm-beach-gardens-fl",
+            matched_by="slug",
+            scored=True,
+        )
+        record = SiteRecord.from_replacements(
+            _full_replacements(),
+            site_name="Palm Beach Gardens",
+            report_date="04/22/26",
+            drive_folder_url="https://drive.google.com/drive/folders/ABC",
+            dd_report_url="https://docs.google.com/document/d/XYZ",
+            rebl_resolution=resolution,
+        )
+        assert record.rebl.site_id == "palm-beach-gardens-fl"
+        assert record.rebl.url == "https://rebl3.vercel.app/site/palm-beach-gardens-fl"
+        assert record.rebl.matched_by == "slug"
 
     def test_to_dict_is_json_serializable(self) -> None:
         record = SiteRecord.from_replacements(
@@ -203,6 +228,7 @@ class TestFromReplacements:
         reloaded = json.loads(json.dumps(record.to_dict()))
         assert reloaded["slug"] == "palm-beach-gardens"
         assert reloaded["classification"]["label"] == "yes_if"
+        assert reloaded["rebl"]["site_id"] == "palm-beach-gardens-fl"
         assert reloaded["scenarios"]["fastest_open"]["capacity"] == "180"
         assert reloaded["sources"]["block_plan"] == "https://drive.google.com/block-plan"
 


### PR DESCRIPTION
Resolve REBL site IDs from Wrike addresses so the DD report, trace, and dashboard outputs share the same canonical identifier instead of deriving local slugs per surface.