### PR TITLE
[codex] Add DD process flow diagram

### DIFF
--- a/docs/process/dd-end-to-end-flow.mmd
+++ b/docs/process/dd-end-to-end-flow.mmd
@@ -1,0 +1,120 @@
+---
+title: Due Diligence Reporter End-to-End Flow
+---
+flowchart TD
+    A1["1. Inbox scan trigger<br/>scripts/scan_inbox.py<br/>Every 15 minutes"]
+    A2["2. Daily sweep trigger<br/>scripts/daily_dd_check.py"]
+    A3["3. Manual trigger<br/>MCP usage or scripts/generate_v2_report.py"]
+
+    subgraph Intake["A. Inbox intake and document filing"]
+        I1["Search Gmail for unprocessed DD emails"]
+        I2{"Internal sender?"}
+        I3["Mark email processed and skip"]
+        I4{"PDF attachments found?"}
+        I5["Label email for manual review"]
+        I6["For each attachment:<br/>classify document type and confidence"]
+        I7["Match attachment to Wrike site<br/>deterministic scoring -> LLM fallback"]
+        I8{"Supported doc type?"}
+        I9["Skip attachment"]
+        I10{"Confidence >= 0.70?"}
+        I11["Queue manual review"]
+        I12{"Block Plan?"}
+        I13["Upload SIR / ISP / Building Inspection<br/>to shared Drive folder"]
+        I14["Resolve site M1 folder"]
+        I15["Upload Block Plan to M1"]
+        I16["Run Block Plan downstream:<br/>read shared SIR + Inspection<br/>apply Capacity Brainlift<br/>run RayCon cost estimate<br/>save derived reports to M1"]
+        I17["Finalize inbox run:<br/>apply processed/manual-review labels"]
+        I18["For each SIR upload:<br/>send SIR arrival email<br/>generate CDS verification overlay<br/>upload overlay and email CDS recipients"]
+        I19{"Any upload has site identity<br/>and run is not dry-run/scan-only?"}
+        I20["For each matched site:<br/>refresh shared folder cache<br/>build match terms"]
+        I21["Stop here and wait for<br/>daily sweep or manual trigger"]
+    end
+
+    subgraph Pipeline["B. Shared DD report pipeline"]
+        P0["Call process_site_pipeline()"]
+        P1["Readiness check:<br/>match shared-folder source docs by site terms<br/>scan site folder recursively for AI-generated artifacts only"]
+        P2{"Required docs present?<br/>Current gate = SIR + Building Inspection"}
+        P3["Status: waiting_on_docs<br/>post Google Chat result"]
+        P4{"DD report already exists?"}
+        P5["Status: report_exists<br/>post Google Chat result"]
+        P6["Run Anthropic DD agent<br/>up to 40 tool-calling iterations"]
+        P7["Typical tool sequence:<br/>get_site_record<br/>list_drive_documents<br/>get_site_comments<br/>read_drive_document"]
+        P8{"Block Plan or derived planning docs available?"}
+        P9["Optional planning branch:<br/>use Block Plan / Capacity / RayCon context"]
+        P10["Analysis tools:<br/>apply_e_occupancy_skill<br/>apply_school_approval_skill<br/>get_cost_estimate"]
+        P11["create_dd_report:<br/>inject Wrike defaults<br/>resolve REBL identity<br/>normalize report data<br/>create or reuse DD Google Doc<br/>build document structure programmatically<br/>create trace report"]
+        P12{"Agent run succeeded?"}
+        P13["Save JSON run trace for failed run"]
+        P14{"Unreadable SIR / Inspection<br/>seen in failed trace?"}
+        P15["Post source-review alert to Google Chat"]
+        P16["Status: generation_failed<br/>post Google Chat result"]
+        P17["Save JSON run trace beside report"]
+        P18{"Unreadable SIR / Inspection<br/>seen in successful trace?"}
+        P19["Post source-review alert to Google Chat"]
+        P20["check_report_completeness:<br/>block on {{tokens}}, raw token leaks,<br/>or invalid can-we-answer value"]
+        P21{"Ready to send?"}
+        P22["Status: report_incomplete<br/>post Google Chat result"]
+        P23["Email report link to configured recipients + P1"]
+        P24["Best-effort dashboard publish"]
+        P25["Status: report_created<br/>post Google Chat result"]
+    end
+
+    A1 --> I1
+    I1 --> I2
+    I2 -- Yes --> I3
+    I2 -- No --> I4
+    I4 -- No --> I5
+    I4 -- Yes --> I6
+    I6 --> I7
+    I7 --> I8
+    I8 -- No --> I9
+    I8 -- Yes --> I10
+    I10 -- No --> I11
+    I10 -- Yes --> I12
+    I12 -- No --> I13
+    I12 -- Yes --> I14
+    I14 --> I15 --> I16
+    I9 --> I17
+    I11 --> I17
+    I13 --> I17
+    I16 --> I17
+    I17 --> I18 --> I19
+    I19 -- Yes --> I20 --> P0
+    I19 -- No --> I21
+
+    A2 --> D1["Fetch active Wrike DD sites with Drive folders<br/>prefetch shared folder cache once"]
+    D1 --> P0
+
+    A3 --> D2["Select one site<br/>load prompt and build match terms"]
+    D2 --> P0
+
+    P0 --> P1 --> P2
+    P2 -- No --> P3
+    P2 -- Yes --> P4
+    P4 -- Yes --> P5
+    P4 -- No --> P6
+    P6 --> P7 --> P8
+    P8 -- Yes --> P9 --> P10
+    P8 -- No --> P10
+    P10 --> P11 --> P12
+    P12 -- No --> P13 --> P14
+    P14 -- Yes --> P15 --> P16
+    P14 -- No --> P16
+    P12 -- Yes --> P17 --> P18
+    P18 -- Yes --> P19 --> P20
+    P18 -- No --> P20
+    P20 --> P21
+    P21 -- No --> P22
+    P21 -- Yes --> P23 --> P24 --> P25
+
+    classDef trigger fill:#f7ead9,stroke:#8a5a00,color:#3b2600;
+    classDef process fill:#e8f1fb,stroke:#1d5fa7,color:#0a2946;
+    classDef decision fill:#f3f0e8,stroke:#6b655d,color:#2d2a26;
+    classDef output fill:#e8f4e0,stroke:#467a1f,color:#173408;
+    classDef alert fill:#fbe8e8,stroke:#a02d2d,color:#531616;
+
+    class A1,A2,A3 trigger;
+    class I1,I6,I7,I13,I14,I15,I16,I17,I18,I20,D1,D2,P0,P1,P6,P7,P9,P10,P11,P13,P15,P17,P19,P20,P23,P24 process;
+    class I2,I4,I8,I10,I12,I19,P2,P4,P8,P12,P14,P18,P21 decision;
+    class I3,I9,I21,P5,P25 output;
+    class I5,I11,P3,P16,P22 alert;


### PR DESCRIPTION
## Summary
- add a Mermaid `.mmd` diagram for the due diligence reporter end-to-end workflow
- capture the current implemented flow across inbox intake, block plan downstream work, readiness checks, report generation, delivery, and dashboard publish
- reflect current code behavior, including the present readiness gate on SIR plus Building Inspection

## Test Plan
- not run (docs-only change)
