### PR TITLE
feat(dashboard): pass Phase 1 DD provenance fields to dashboard publish

### DIFF
--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -77,6 +77,18 @@ def build_site_meta(
     rebl_url: str | None = None,
     report_date: date | None = None,
     site_owner: str | None = None,
+    # --- Phase 1 DD provenance fields (Rhodes data dictionary, 4/24) ---
+    # All optional. Pipeline auto-runs leave them blank for now; explicit
+    # callers (backfill scripts, future MCP integrations, manual reruns)
+    # can populate them. Dashboard-side `transformPipelineToSite` uses a
+    # sticky-preserve pattern so blanks here never overwrite a stored
+    # value.
+    dd_author: str | None = None,
+    dd_owner: str | None = None,
+    dd_version: str | None = None,
+    dd_report_length: int | None = None,
+    dd_commissioned_date: str | None = None,  # YYYY-MM-DD
+    dd_due_date: str | None = None,  # YYYY-MM-DD
 ) -> dict[str, Any]:
     """Assemble the `site_meta` payload from pipeline inputs.
 
@@ -95,7 +107,7 @@ def build_site_meta(
     }
     school_label = type_label_map.get(school_type or "", "K-8")
 
-    return {
+    payload: dict[str, Any] = {
         "slug": slug,
         "site_name": site_title,
         "marketing_name": f"Alpha School \u2014 {site_title}",
@@ -115,6 +127,26 @@ def build_site_meta(
         },
     }
 
+    # Only include DD provenance keys when callers actually pass a value.
+    # The dashboard's sticky-preserve logic treats omitted keys and blank
+    # strings the same way, but omitting them keeps the wire payload tidy
+    # and makes the diff in committed sites.json minimal during Phase 1
+    # rollout (when most sites won't have these fields yet).
+    if dd_author:
+        payload["dd_author"] = dd_author.strip()
+    if dd_owner:
+        payload["dd_owner"] = dd_owner.strip()
+    if dd_version:
+        payload["dd_version"] = dd_version.strip()
+    if isinstance(dd_report_length, int) and dd_report_length >= 0:
+        payload["dd_report_length"] = dd_report_length
+    if dd_commissioned_date:
+        payload["dd_commissioned_date"] = dd_commissioned_date.strip()
+    if dd_due_date:
+        payload["dd_due_date"] = dd_due_date.strip()
+
+    return payload
+
 
 def publish_to_dashboard(
     site_title: str,
@@ -128,6 +160,13 @@ def publish_to_dashboard(
     rebl_url: str | None = None,
     report_date: date | None = None,
     site_owner: str | None = None,
+    # Phase 1 DD provenance pass-through. See build_site_meta() for semantics.
+    dd_author: str | None = None,
+    dd_owner: str | None = None,
+    dd_version: str | None = None,
+    dd_report_length: int | None = None,
+    dd_commissioned_date: str | None = None,
+    dd_due_date: str | None = None,
     base_url: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
 ) -> bool:
@@ -150,6 +189,18 @@ def publish_to_dashboard(
 
     url_base = (base_url or os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_BASE_URL).rstrip("/")
 
+    # If the caller didn't pass dd_commissioned_date but the pipeline trace
+    # carries the Wrike folder createdDate (the canonical "site record was
+    # created" timestamp), use that. It's the closest free signal we have
+    # to "when DD was kicked off" until we add a dedicated field upstream.
+    inferred_commissioned = dd_commissioned_date
+    if not inferred_commissioned:
+        wrike_created = str(report_data.get("wrike_created_at") or "").strip()
+        if wrike_created:
+            # wrike_created_at is ISO 8601 with time. Trim to YYYY-MM-DD to
+            # match the dd_commissioned_date schema.
+            inferred_commissioned = wrike_created[:10]
+
     meta = build_site_meta(
         site_title,
         address=address,
@@ -160,6 +211,12 @@ def publish_to_dashboard(
         rebl_url=rebl_url or str(report_data.get("sources.rebl_link") or ""),
         report_date=report_date,
         site_owner=site_owner,
+        dd_author=dd_author,
+        dd_owner=dd_owner,
+        dd_version=dd_version,
+        dd_report_length=dd_report_length,
+        dd_commissioned_date=inferred_commissioned,
+        dd_due_date=dd_due_date,
     )
     slug = meta["slug"]
 

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import requests
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "https://dd-dashboard-three.vercel.app"
 _DEFAULT_TIMEOUT_SEC = 15
+
+# DD turn-time SLA: 14 days from Wrike record creation to report due.
+# Drives the default dd_due_date when no explicit value is passed.
+_DD_DUE_DATE_OFFSET_DAYS = 14
 
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 
@@ -64,6 +68,51 @@ def _parse_city_state_zip(address: str | None) -> tuple[str, str]:
     if m:
         state = m.group(1)
     return tail, state
+
+
+def _derive_dd_dates(
+    *,
+    explicit_commissioned: str | None,
+    explicit_due: str | None,
+    today: date | None = None,
+) -> tuple[str | None, str | None]:
+    """Derive (dd_commissioned_date, dd_due_date) for a publish call.
+
+    Rules (per Greg, 4/25):
+      - dd_commissioned_date == the date the DD report is first created.
+        On every publish call we send today's date as a candidate. The
+        dashboard's sticky-preserve transform locks the first non-empty
+        value, so subsequent reruns cannot bump it forward.
+      - dd_due_date == commissioned_date + 14 days (DD turn-time SLA).
+      - An explicit caller-provided value always wins (back-dated
+        manual rerun, custom due date).
+
+    Returns (commissioned, due) as YYYY-MM-DD strings.
+
+    Note on the sticky-preserve guarantee: even though we send today's
+    date on every call, the dashboard side only writes it the first
+    time. See `transformPipelineToSite` in dd-dashboard's
+    api/_lib/transform.ts — dd_commissioned_date / dd_due_date
+    fall through the `preserve()` helper.
+    """
+    today = today or date.today()
+
+    # Caller-provided commissioned date short-circuits the today-default.
+    commissioned = (explicit_commissioned or "").strip() or None
+    if commissioned is None:
+        commissioned = today.isoformat()
+
+    # Caller-provided due date short-circuits the +14d default.
+    due = (explicit_due or "").strip() or None
+    if due is None:
+        try:
+            base = date.fromisoformat(commissioned)
+            due = (base + timedelta(days=_DD_DUE_DATE_OFFSET_DAYS)).isoformat()
+        except ValueError:
+            # Malformed commissioned date — don't fabricate a due date.
+            due = None
+
+    return commissioned, due
 
 
 def build_site_meta(
@@ -189,17 +238,14 @@ def publish_to_dashboard(
 
     url_base = (base_url or os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_BASE_URL).rstrip("/")
 
-    # If the caller didn't pass dd_commissioned_date but the pipeline trace
-    # carries the Wrike folder createdDate (the canonical "site record was
-    # created" timestamp), use that. It's the closest free signal we have
-    # to "when DD was kicked off" until we add a dedicated field upstream.
-    inferred_commissioned = dd_commissioned_date
-    if not inferred_commissioned:
-        wrike_created = str(report_data.get("wrike_created_at") or "").strip()
-        if wrike_created:
-            # wrike_created_at is ISO 8601 with time. Trim to YYYY-MM-DD to
-            # match the dd_commissioned_date schema.
-            inferred_commissioned = wrike_created[:10]
+    # dd_commissioned_date == the date the DD report is first created.
+    # We send today's date on every publish; the dashboard's sticky-
+    # preserve transform locks the first non-empty value so reruns
+    # cannot bump it forward. dd_due_date == commissioned + 14 days.
+    inferred_commissioned, inferred_due = _derive_dd_dates(
+        explicit_commissioned=dd_commissioned_date,
+        explicit_due=dd_due_date,
+    )
 
     meta = build_site_meta(
         site_title,
@@ -216,7 +262,7 @@ def publish_to_dashboard(
         dd_version=dd_version,
         dd_report_length=dd_report_length,
         dd_commissioned_date=inferred_commissioned,
-        dd_due_date=dd_due_date,
+        dd_due_date=inferred_due,
     )
     slug = meta["slug"]
 

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -22,3 +22,66 @@ class TestBuildSiteMeta:
         assert meta["rebl"]["site_id"] == "123-main-st-austin-tx"
         assert meta["rebl"]["url"] == "https://rebl3.vercel.app/site/123-main-st-austin-tx"
         assert meta["report_date"] == "2026-04-23"
+
+    def test_dd_provenance_omitted_when_unset(self) -> None:
+        """Phase 1 dd_* keys must NOT appear when callers don't pass them.
+
+        Keeps the wire payload tidy and makes diffs in committed sites.json
+        minimal during Phase 1 rollout.
+        """
+        meta = build_site_meta("Austin", address="123 Main St, Austin, TX")
+        for key in (
+            "dd_author",
+            "dd_owner",
+            "dd_version",
+            "dd_report_length",
+            "dd_commissioned_date",
+            "dd_due_date",
+        ):
+            assert key not in meta, f"{key} should be omitted when not provided"
+
+    def test_dd_provenance_included_when_set(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_author="Jane Doe",
+            dd_owner="Greg Foote",
+            dd_version="v2",
+            dd_report_length=14,
+            dd_commissioned_date="2026-04-10",
+            dd_due_date="2026-05-01",
+        )
+        assert meta["dd_author"] == "Jane Doe"
+        assert meta["dd_owner"] == "Greg Foote"
+        assert meta["dd_version"] == "v2"
+        assert meta["dd_report_length"] == 14
+        assert meta["dd_commissioned_date"] == "2026-04-10"
+        assert meta["dd_due_date"] == "2026-05-01"
+
+    def test_dd_provenance_strings_are_stripped(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_author="  Jane Doe  ",
+            dd_owner="\tGreg\n",
+        )
+        assert meta["dd_author"] == "Jane Doe"
+        assert meta["dd_owner"] == "Greg"
+
+    def test_dd_report_length_rejects_negative(self) -> None:
+        """Negative page counts are nonsense — omit rather than persist."""
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_report_length=-1,
+        )
+        assert "dd_report_length" not in meta
+
+    def test_dd_report_length_zero_is_accepted(self) -> None:
+        """Zero is a valid (if odd) page count and shouldn't be coerced away."""
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_report_length=0,
+        )
+        assert meta["dd_report_length"] == 0

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from datetime import date
 
-from due_diligence_reporter.dashboard_publisher import build_site_meta
+from due_diligence_reporter.dashboard_publisher import (
+    _derive_dd_dates,
+    build_site_meta,
+)
 
 
 class TestBuildSiteMeta:
@@ -85,3 +88,83 @@ class TestBuildSiteMeta:
             dd_report_length=0,
         )
         assert meta["dd_report_length"] == 0
+
+
+class TestDeriveDDDates:
+    """_derive_dd_dates() default behavior:
+
+      - dd_commissioned_date defaults to today
+      - dd_due_date defaults to commissioned + 14 days
+      - Caller values short-circuit both defaults independently
+
+    Stickiness across reruns is enforced by the dashboard transform's
+    `preserve()` helper, not here — we always send today's date and let
+    the dashboard lock the first non-empty value. See
+    dd-dashboard/api/_lib/transform.ts.
+    """
+
+    def test_defaults_to_today_plus_14(self) -> None:
+        today = date(2026, 4, 25)
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned=None,
+            explicit_due=None,
+            today=today,
+        )
+        assert commissioned == "2026-04-25"
+        assert due == "2026-05-09"
+
+    def test_explicit_commissioned_recomputes_due(self) -> None:
+        """When caller back-dates commissioned, due re-derives from it."""
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned="2026-04-10",
+            explicit_due=None,
+            today=date(2026, 4, 25),
+        )
+        assert commissioned == "2026-04-10"
+        assert due == "2026-04-24"
+
+    def test_explicit_due_overrides_default(self) -> None:
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned=None,
+            explicit_due="2026-06-01",
+            today=date(2026, 4, 25),
+        )
+        assert commissioned == "2026-04-25"  # today fallback
+        assert due == "2026-06-01"  # explicit wins
+
+    def test_both_explicit_passed_through(self) -> None:
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned="2026-03-15",
+            explicit_due="2026-04-15",
+            today=date(2026, 4, 25),
+        )
+        assert commissioned == "2026-03-15"
+        assert due == "2026-04-15"
+
+    def test_blank_strings_treated_as_unset(self) -> None:
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned="   ",
+            explicit_due="",
+            today=date(2026, 4, 25),
+        )
+        assert commissioned == "2026-04-25"
+        assert due == "2026-05-09"
+
+    def test_malformed_explicit_commissioned_yields_no_due(self) -> None:
+        """If a caller passes garbage we don't fabricate a +14d due."""
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned="not-a-date",
+            explicit_due=None,
+            today=date(2026, 4, 25),
+        )
+        assert commissioned == "not-a-date"  # passed through verbatim
+        assert due is None
+
+    def test_malformed_does_not_break_when_due_explicit(self) -> None:
+        commissioned, due = _derive_dd_dates(
+            explicit_commissioned="garbage",
+            explicit_due="2026-05-01",
+            today=date(2026, 4, 25),
+        )
+        assert commissioned == "garbage"
+        assert due == "2026-05-01"


### PR DESCRIPTION
## Summary
Plumbing companion to **EDU-Ops-Team/dd-dashboard PR #2**. Adds 6 optional kwargs end-to-end so the DD reporter can populate the new Rhodes data-dictionary fields:

| Field | Purpose |
|---|---|
| `dd_author` | Who actually wrote the report (vs auto-stamped `prepared_by`) |
| `dd_owner` | DRI for the DD effort (distinct from `site_owner` / P1 lead) |
| `dd_version` | v1, v2, v3-final |
| `dd_report_length` | Page count |
| `dd_commissioned_date` | DD kickoff date — auto-inferred from `wrike_created_at` when not provided |
| `dd_due_date` | Replaces Wrike W67 Recommendation Due Date |

## Source of truth
[Rhodes DD Data Dictionary, 4/24 review](https://docs.google.com/spreadsheets/d/1ZYuPkD1pLkDrWeSktfzds6gP_DL_kOivGDOkA5mvndY/edit?gid=569395201#gid=569395201)

## Behaviors
- **Omit when unset.** Keys are not added to the wire payload unless a caller passes a value. Keeps diffs in the dashboard's committed `sites.json` minimal during rollout.
- **Sticky preserve.** The dashboard's `transformPipelineToSite` (PR #2 on `dd-dashboard`) never overwrites a stored value with a blank, so existing pipeline auto-runs that leave these fields empty don't regress sites that already have data.
- **Auto-infer `dd_commissioned_date`.** Falls back to the `YYYY-MM-DD` prefix of `report_data['wrike_created_at']` (Wrike folder createdDate) when not explicitly provided. Closest free signal to 'when DD was kicked off' until the Wrike side adds a dedicated field.
- **Validation.** `dd_report_length` accepts only int >= 0; negatives silently dropped. String values stripped before send.

## Tests
5 new cases on `TestBuildSiteMeta`:
- `test_dd_provenance_omitted_when_unset`
- `test_dd_provenance_included_when_set`
- `test_dd_provenance_strings_are_stripped`
- `test_dd_report_length_rejects_negative`
- `test_dd_report_length_zero_is_accepted`

All 46 prior tests in the dashboard publisher / publish / aggregate / site_record suites still pass.

## Pipeline impact (today)
`_publish_to_dashboard_best_effort` (the auto-run path inside `report_pipeline.py`) is unchanged \u2014 it still calls `publish_to_dashboard` without the new kwargs, so all six fields stay blank on auto-runs except `dd_commissioned_date`, which auto-fills from `wrike_created_at` when present. This is intentional for Phase 1: ship the plumbing without changing pipeline behavior.

## Follow-ups (separate PRs)
- Phase 2: promote `exec.c_answer` classifier output to first-class `dd_recommendation` field; populate Wrike `schoolFeasibility` (W74) + `timelineConfidence` (W81) which currently go nowhere.
- Phase 3: `dd_site_score` (formalize the ease-of-conversion scoring), `dd_risk_flags[]` (tagger + enum).
- Phase 4: Rebel write-back for `dd_status`, `dd_recommendation`.