### PR TITLE
feat(dd-phase2): vocab split — c_answer Yes/No + publisher dd_recommendation go/no_go

### DIFF
--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -36,7 +36,7 @@ Four dimensions, each a fixed pick-menu:
 
 | Dimension | Source | Options |
 |-----------|--------|---------|
-| `exec.c_answer` | Agent synthesis | Yes / Yes see notes / No |
+| `exec.c_answer` | Agent synthesis | Go / No Go (binary) |
 | `exec.c_zoning` | SIR | Permitted by right / Use Permit Required (Admin) / Use Permit Required (Public) / Prohibited |
 | `exec.c_occupancy` | E-Occupancy skill | Has E-Occupancy / Change of use required, meets E-Occupancy / Change of use required, needs work |
 | `exec.c_edreg` | School Approval skill | Not required / Required and have done / Required have not done |

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -36,7 +36,7 @@ Four dimensions, each a fixed pick-menu:
 
 | Dimension | Source | Options |
 |-----------|--------|---------|
-| `exec.c_answer` | Agent synthesis | Go / No Go (binary) |
+| `exec.c_answer` | Agent synthesis | Yes / No (binary) — the literal answer to "Can this be a school by [date]?". The publisher derives the dashboard's Go / No Go recommendation chip (`dd_recommendation`) from this automatically. |
 | `exec.c_zoning` | SIR | Permitted by right / Use Permit Required (Admin) / Use Permit Required (Public) / Prohibited |
 | `exec.c_occupancy` | E-Occupancy skill | Has E-Occupancy / Change of use required, meets E-Occupancy / Change of use required, needs work |
 | `exec.c_edreg` | School Approval skill | Not required / Required and have done / Required have not done |

--- a/docs/prompts/prompt_v2.md
+++ b/docs/prompts/prompt_v2.md
@@ -569,7 +569,7 @@ Each dimension uses a **fixed option menu**. Pick exactly one option per field b
 
 | Token | Source | Options (pick one) |
 |---|---|---|
-| `exec.c_answer` | Agent (synthesize from all sources) | `Yes` / `Yes see notes` / `No` — **no other values are valid**; do not use `Conditional` |
+| `exec.c_answer` | Agent (synthesize from all sources) | `Go` / `No Go` — **binary; no other values are valid**. Use `Go` when the school can open by the school-year deadline, `No Go` when it cannot. Do not use `Yes`, `No`, `Yes see notes`, or `Conditional` — the system will alias old values forward, but new reports must emit canonical Go / No Go. |
 | `exec.c_zoning` | SIR (zoning designation + permitted uses) | `Permitted by right` / `Use Permit Required (Admin approval)` / `Use Permit Required (Public approval)` / `Prohibited` |
 | `exec.c_occupancy` | E-Occupancy skill (uses Building Inspection data) | `Has E-Occupancy` / `Change of use required, meets E-Occupancy` / `Change of use required, needs work` |
 | `exec.c_edreg` | School Approval skill | `Not required` / `Required and have done` / `Required have not done` |

--- a/docs/prompts/prompt_v2.md
+++ b/docs/prompts/prompt_v2.md
@@ -569,7 +569,7 @@ Each dimension uses a **fixed option menu**. Pick exactly one option per field b
 
 | Token | Source | Options (pick one) |
 |---|---|---|
-| `exec.c_answer` | Agent (synthesize from all sources) | `Go` / `No Go` — **binary; no other values are valid**. Use `Go` when the school can open by the school-year deadline, `No Go` when it cannot. Do not use `Yes`, `No`, `Yes see notes`, or `Conditional` — the system will alias old values forward, but new reports must emit canonical Go / No Go. |
+| `exec.c_answer` | Agent (synthesize from all sources) | `Yes` / `No` — **binary; no other values are valid**. This is the literal answer to "Can this be a school by [date]?". Use `Yes` when the school can open by the school-year deadline, `No` when it cannot. Do not use `Go`, `No Go`, `Yes see notes`, or `Conditional` — the system will alias old values forward, but new reports must emit canonical Yes / No. The publisher derives the dashboard's Go / No Go recommendation chip (`dd_recommendation`) from this value automatically (Yes → `go`, No → `no_go`). |
 | `exec.c_zoning` | SIR (zoning designation + permitted uses) | `Permitted by right` / `Use Permit Required (Admin approval)` / `Use Permit Required (Public approval)` / `Prohibited` |
 | `exec.c_occupancy` | E-Occupancy skill (uses Building Inspection data) | `Has E-Occupancy` / `Change of use required, meets E-Occupancy` / `Change of use required, needs work` |
 | `exec.c_edreg` | School Approval skill | `Not required` / `Required and have done` / `Required have not done` |

--- a/scripts/daily_dd_check.py
+++ b/scripts/daily_dd_check.py
@@ -49,6 +49,8 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     extract_google_folder_from_record,
     extract_p1_email_from_record,
     extract_p1_from_record,
+    extract_school_feasibility_from_record,
+    extract_timeline_confidence_from_record,
     filter_active_site_records,
     load_wrike_config,
 )
@@ -121,6 +123,10 @@ def main(site_filter: str | None = None) -> None:
         p1_email = extract_p1_email_from_record(record)
         p1_profile = extract_p1_from_record(record) or {}
         p1_name = p1_profile.get("name")
+        # Phase 2: Wrike W74 / W81 ratings (high/medium/low/unknown).
+        # None when the field isn't populated on the Wrike record.
+        school_feasibility = extract_school_feasibility_from_record(record)
+        timeline_confidence = extract_timeline_confidence_from_record(record)
         logger.info("Checking site: %s (match terms: %s, p1: %s)", site_title, match_terms, p1_email)
 
         try:
@@ -128,6 +134,8 @@ def main(site_filter: str | None = None) -> None:
                 gc, site_title, drive_folder_url, match_terms,
                 shared_cache, system_prompt, settings,
                 p1_email=p1_email, site_address=address, p1_name=p1_name,
+                school_feasibility=school_feasibility,
+                timeline_confidence=timeline_confidence,
             )
         except Exception as e:
             logger.exception("Unexpected pipeline failure for '%s'", site_title)

--- a/scripts/generate_v2_report.py
+++ b/scripts/generate_v2_report.py
@@ -41,6 +41,8 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
     extract_address_from_record,
+    extract_school_feasibility_from_record,
+    extract_timeline_confidence_from_record,
     extract_google_folder_from_record,
     extract_p1_email_from_record,
     extract_p1_from_record,
@@ -127,6 +129,9 @@ def main(site_filter: str, *, no_email: bool = False, skip_readiness: bool = Fal
     p1_email = extract_p1_email_from_record(record)
     p1_profile = extract_p1_from_record(record) or {}
     p1_name = p1_profile.get("name")
+    # Phase 2: Wrike W74 / W81 ratings (high/medium/low/unknown).
+    school_feasibility = extract_school_feasibility_from_record(record)
+    timeline_confidence = extract_timeline_confidence_from_record(record)
 
     logger.info("Generating V3 report for: %s", site_title)
 
@@ -154,6 +159,8 @@ def main(site_filter: str, *, no_email: bool = False, skip_readiness: bool = Fal
         gc, site_title, drive_folder_url, match_terms,
         shared_cache, system_prompt, settings,
         p1_email=p1_email, site_address=address, p1_name=p1_name,
+        school_feasibility=school_feasibility,
+        timeline_confidence=timeline_confidence,
     )
 
     # Post to Google Chat if configured

--- a/scripts/scan_inbox.py
+++ b/scripts/scan_inbox.py
@@ -65,6 +65,8 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
     extract_address_from_record,
+    extract_school_feasibility_from_record,
+    extract_timeline_confidence_from_record,
     extract_google_folder_from_record,
     extract_p1_email_from_record,
     extract_p1_from_record,
@@ -343,12 +345,17 @@ for you to fill in: CDS Verified Finding, CDS Source, and CDS Confidence.</p>
         p1_email = extract_p1_email_from_record(record)
         p1_profile = extract_p1_from_record(record) or {}
         p1_name = p1_profile.get("name")
+        # Phase 2: Wrike W74 / W81 ratings (high/medium/low/unknown).
+        school_feasibility = extract_school_feasibility_from_record(record)
+        timeline_confidence = extract_timeline_confidence_from_record(record)
 
         logger.info("Running pipeline for '%s' (match terms: %s, p1: %s)", site_title, match_terms, p1_email)
         result = process_site_pipeline(
             gc, site_title, drive_folder_url, match_terms,
             shared_cache, system_prompt, settings,
             p1_email=p1_email, site_address=address, p1_name=p1_name,
+            school_feasibility=school_feasibility,
+            timeline_confidence=timeline_confidence,
         )
 
         # Post each result to Google Chat

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -29,6 +29,11 @@ from typing import Any
 
 import requests
 
+from .report_schema import (
+    DD_RECOMMENDATION_FROM_C_ANSWER,
+    LEGACY_CAN_WE_ANSWER_ALIASES,
+)
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "https://dd-dashboard-three.vercel.app"
@@ -142,12 +147,15 @@ def build_site_meta(
     # All optional. Free-form strings on the wire so we can ship without
     # locking enum values; the data dictionary expects high/medium/low/
     # unknown for the two ratings and "in_progress"/"complete" for status.
-    # Note: dd_recommendation (go/no_go/follow_up) is intentionally NOT a
-    # field here. It's derived in the dashboard UI from the latest decision-
-    # button click in reviews.json (approve→go, reject→no_go, info_req→follow_up).
+    # Note: dd_recommendation here carries Go / No Go vocabulary derived from
+    # the report's exec.c_answer (Yes → "go", No → "no_go"). It represents
+    # "what the DD report concluded" and is distinct from the dashboard-side
+    # decision override (approve/reject/info_req via the decision button),
+    # which is layered on top in the UI by `effectiveDdStatusForSite`.
     school_feasibility: str | None = None,  # Wrike W74 (high/medium/low/unknown)
     timeline_confidence: str | None = None,  # Wrike W81 (high/medium/low/unknown)
-    dd_status: str | None = None,  # in_progress | complete
+    dd_status: str | None = None,  # in_progress | complete | follow_up
+    dd_recommendation: str | None = None,  # "go" | "no_go" (derived from c_answer)
 ) -> dict[str, Any]:
     """Assemble the `site_meta` payload from pipeline inputs.
 
@@ -213,6 +221,8 @@ def build_site_meta(
         payload["timeline_confidence"] = timeline_confidence.strip()
     if dd_status and dd_status.strip():
         payload["dd_status"] = dd_status.strip()
+    if dd_recommendation and dd_recommendation.strip():
+        payload["dd_recommendation"] = dd_recommendation.strip().lower()
 
     return payload
 
@@ -240,6 +250,7 @@ def publish_to_dashboard(
     school_feasibility: str | None = None,
     timeline_confidence: str | None = None,
     dd_status: str | None = None,
+    dd_recommendation: str | None = None,
     base_url: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
 ) -> bool:
@@ -279,6 +290,26 @@ def publish_to_dashboard(
     # "in_progress" or another label explicitly to override.
     effective_dd_status = (dd_status or "").strip() or "complete"
 
+    # Derive dd_recommendation (Go / No Go) from the report's c_answer
+    # (Yes / No) when the caller did not supply an explicit value. The
+    # report card stays plain-English; the dashboard chip uses the
+    # Go/No Go vocabulary. We normalize via the legacy alias map so that
+    # historical payloads (Go, Yes see notes, Conditional, etc.) still
+    # derive correctly. If the c_answer is missing or unrecognized,
+    # dd_recommendation is left unset and the dashboard falls back to
+    # its own logic.
+    effective_dd_recommendation = (dd_recommendation or "").strip().lower() or None
+    if not effective_dd_recommendation:
+        raw_c_answer = str(report_data.get("exec.c_answer") or "").strip()
+        if raw_c_answer:
+            canonical = LEGACY_CAN_WE_ANSWER_ALIASES.get(
+                raw_c_answer.rstrip(".,;:?!").lower()
+            )
+            if canonical is None and raw_c_answer in {"Yes", "No"}:
+                canonical = raw_c_answer
+            if canonical:
+                effective_dd_recommendation = DD_RECOMMENDATION_FROM_C_ANSWER.get(canonical)
+
     meta = build_site_meta(
         site_title,
         address=address,
@@ -298,6 +329,7 @@ def publish_to_dashboard(
         school_feasibility=school_feasibility,
         timeline_confidence=timeline_confidence,
         dd_status=effective_dd_status,
+        dd_recommendation=effective_dd_recommendation,
     )
     slug = meta["slug"]
 

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -138,6 +138,16 @@ def build_site_meta(
     dd_report_length: int | None = None,
     dd_commissioned_date: str | None = None,  # YYYY-MM-DD
     dd_due_date: str | None = None,  # YYYY-MM-DD
+    # --- Phase 2 DD provenance fields (Rhodes data dictionary, 4/24) ---
+    # All optional. Free-form strings on the wire so we can ship without
+    # locking enum values; the data dictionary expects high/medium/low/
+    # unknown for the two ratings and "in_progress"/"complete" for status.
+    # Note: dd_recommendation (go/no_go/follow_up) is intentionally NOT a
+    # field here. It's derived in the dashboard UI from the latest decision-
+    # button click in reviews.json (approve→go, reject→no_go, info_req→follow_up).
+    school_feasibility: str | None = None,  # Wrike W74 (high/medium/low/unknown)
+    timeline_confidence: str | None = None,  # Wrike W81 (high/medium/low/unknown)
+    dd_status: str | None = None,  # in_progress | complete
 ) -> dict[str, Any]:
     """Assemble the `site_meta` payload from pipeline inputs.
 
@@ -194,6 +204,16 @@ def build_site_meta(
     if dd_due_date:
         payload["dd_due_date"] = dd_due_date.strip()
 
+    # Phase 2: same omit-when-unset semantics as Phase 1. Strip first so
+    # whitespace-only inputs ("   ") are treated as unset and don't slip
+    # blank values onto the dashboard's stored record.
+    if school_feasibility and school_feasibility.strip():
+        payload["school_feasibility"] = school_feasibility.strip()
+    if timeline_confidence and timeline_confidence.strip():
+        payload["timeline_confidence"] = timeline_confidence.strip()
+    if dd_status and dd_status.strip():
+        payload["dd_status"] = dd_status.strip()
+
     return payload
 
 
@@ -216,6 +236,10 @@ def publish_to_dashboard(
     dd_report_length: int | None = None,
     dd_commissioned_date: str | None = None,
     dd_due_date: str | None = None,
+    # Phase 2 DD provenance pass-through. See build_site_meta() for semantics.
+    school_feasibility: str | None = None,
+    timeline_confidence: str | None = None,
+    dd_status: str | None = None,
     base_url: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
 ) -> bool:
@@ -247,6 +271,14 @@ def publish_to_dashboard(
         explicit_due=dd_due_date,
     )
 
+    # Auto-stamp dd_status="complete" when this publisher is reached without
+    # an explicit value. Rationale: publish_to_dashboard() is only called
+    # from `_publish_to_dashboard_best_effort` after a successful pipeline
+    # run, so by definition a successful POST means the report is complete.
+    # Callers (backfill scripts, partial republish flows) can still pass
+    # "in_progress" or another label explicitly to override.
+    effective_dd_status = (dd_status or "").strip() or "complete"
+
     meta = build_site_meta(
         site_title,
         address=address,
@@ -263,6 +295,9 @@ def publish_to_dashboard(
         dd_report_length=dd_report_length,
         dd_commissioned_date=inferred_commissioned,
         dd_due_date=inferred_due,
+        school_feasibility=school_feasibility,
+        timeline_confidence=timeline_confidence,
+        dd_status=effective_dd_status,
     )
     slug = meta["slug"]
 

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -865,12 +865,14 @@ def build_dd_report_doc(
     q_start, q_end = b3.insert_text(can_we_q)
     b3.style_text(q_start, q_end - 1, bold=True, font_size=11, font_family="Arial")
 
-    # Conjunction varies by answer polarity: "Go, if:" reads as forward-looking
-    # (here are the conditions that get us there); "No Go, because:" reads as
+    # Conjunction varies by answer polarity: "Yes, if:" reads as forward-looking
+    # (here are the conditions that get us there); "No, because:" reads as
     # backward-looking (here's what's blocking us). Match against canonical
-    # "Go" first, fall back to legacy "yes" for any not-yet-migrated reports.
+    # "Yes" first; legacy "go" / "yes see notes" / "conditional" also map
+    # to the affirmative branch for any not-yet-migrated reports.
     answer_lower = c_answer.strip().lower()
-    conjunction = "if" if answer_lower in {"go", "yes"} else "because"
+    affirmative = {"yes", "go", "yes see notes", "yes, see notes", "conditional"}
+    conjunction = "if" if answer_lower in affirmative else "because"
     answer_text = f"{c_answer}, {conjunction}:\n"
     a_start, a_end = b3.insert_text(answer_text)
     b3.style_text(a_start, a_end - 1, bold=True, font_size=12, font_family="Arial")

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -865,7 +865,12 @@ def build_dd_report_doc(
     q_start, q_end = b3.insert_text(can_we_q)
     b3.style_text(q_start, q_end - 1, bold=True, font_size=11, font_family="Arial")
 
-    conjunction = "if" if c_answer.strip().lower() == "yes" else "because"
+    # Conjunction varies by answer polarity: "Go, if:" reads as forward-looking
+    # (here are the conditions that get us there); "No Go, because:" reads as
+    # backward-looking (here's what's blocking us). Match against canonical
+    # "Go" first, fall back to legacy "yes" for any not-yet-migrated reports.
+    answer_lower = c_answer.strip().lower()
+    conjunction = "if" if answer_lower in {"go", "yes"} else "because"
     answer_text = f"{c_answer}, {conjunction}:\n"
     a_start, a_end = b3.insert_text(answer_text)
     b3.style_text(a_start, a_end - 1, bold=True, font_size=12, font_family="Arial")

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -1053,6 +1053,12 @@ def process_site_pipeline(
     p1_email: str | None = None,
     site_address: str | None = None,
     p1_name: str | None = None,
+    # --- Phase 2 DD provenance (Wrike W74 / W81) ---
+    # Optional. Callers (scripts/daily_dd_check.py et al.) read these from
+    # the Wrike record up front and forward them to the dashboard publish
+    # step. None means "don't override the dashboard's stored value".
+    school_feasibility: str | None = None,
+    timeline_confidence: str | None = None,
 ) -> PipelineResult:
     """Full single-site pipeline: readiness -> report generation -> completeness -> email.
 
@@ -1125,6 +1131,8 @@ def process_site_pipeline(
         dd_report_url=doc_url,
         site_address=site_address,
         p1_name=p1_name,
+        school_feasibility=school_feasibility,
+        timeline_confidence=timeline_confidence,
     )
 
     return PipelineResult(
@@ -1146,6 +1154,10 @@ def _publish_to_dashboard_best_effort(
     dd_report_url: str,
     site_address: str | None,
     p1_name: str | None = None,
+    # Phase 2 DD provenance pass-through. Publisher auto-stamps
+    # dd_status="complete" so it's not threaded through here.
+    school_feasibility: str | None = None,
+    timeline_confidence: str | None = None,
 ) -> None:
     """Fire-and-forget dashboard publish. Never raises."""
     if trace is None or not getattr(trace, "final_report_data", None):
@@ -1162,6 +1174,8 @@ def _publish_to_dashboard_best_effort(
             drive_folder_url=drive_folder_url,
             dd_report_url=dd_report_url,
             site_owner=p1_name,
+            school_feasibility=school_feasibility,
+            timeline_confidence=timeline_confidence,
         )
     except Exception as e:
         # publish_to_dashboard already swallows requests errors; this is a

--- a/src/due_diligence_reporter/report_schema.py
+++ b/src/due_diligence_reporter/report_schema.py
@@ -11,13 +11,20 @@ from .utils import flatten_report_data_for_replacement
 
 logger = logging.getLogger(__name__)
 
-# The Executive Summary "Can We Open?" card answer. Binary by design —
-# matches the dashboard recommendation chip (Go / No Go). Legacy reports
-# may still contain "Yes" / "No" / "Yes see notes" — see
-# LEGACY_CAN_WE_ANSWER_ALIASES below for backward-compat aliasing.
+# The Executive Summary "Can We Open?" card answer. Binary plain-English
+# Yes / No — the literal answer to "Can this be a school by [date]?".
+#
+# Note: this is a separate concern from the publisher field
+# `dd_recommendation`, which carries the Go / No Go vocabulary used by the
+# dashboard. The publisher derives `dd_recommendation` from this value
+# (Yes → "go", No → "no_go"); see DD_RECOMMENDATION_FROM_C_ANSWER below.
+#
+# Legacy reports may still contain "Go" / "No Go" / "Yes see notes" /
+# "Conditional" on this field — see LEGACY_CAN_WE_ANSWER_ALIASES for
+# backward-compat aliasing.
 ALLOWED_CAN_WE_ANSWERS: frozenset[str] = frozenset({
-    "Go",
-    "No Go",
+    "Yes",
+    "No",
 })
 
 ALLOWED_ZONING_STATUSES: frozenset[str] = frozenset({
@@ -39,7 +46,7 @@ ALLOWED_ALPHA_FIT_VALUES: frozenset[str] = frozenset({
 })
 
 # School-year start dates for deterministic c_answer computation.
-# fastest_open_open_date <= SCHOOL_YEAR_DEADLINE → "Go"; otherwise → "No Go".
+# fastest_open_open_date <= SCHOOL_YEAR_DEADLINE → "Yes"; otherwise → "No".
 SCHOOL_YEAR_START_DATES: tuple[date, ...] = (
     date(2026, 8, 12),  # 08/12/26
     date(2026, 9, 8),   # 09/08/26
@@ -47,22 +54,33 @@ SCHOOL_YEAR_START_DATES: tuple[date, ...] = (
 SCHOOL_YEAR_DEADLINE: date = max(SCHOOL_YEAR_START_DATES)  # 09/08/26
 
 # Legacy alias map for the Can-We-Open answer. Maps any historical or
-# case-variant value to the canonical "Go" / "No Go". Includes Yes/No
-# from the pre-rename era and "Yes see notes" / "conditional" which
-# both collapse into "Go" under the new binary system.
+# case-variant value to the canonical "Yes" / "No". Includes Go/No Go
+# from the brief Go/No-Go-on-c_answer experiment, and "Yes see notes" /
+# "Conditional" from the original three-state vocabulary which both
+# collapse into "Yes" under the binary system.
 LEGACY_CAN_WE_ANSWER_ALIASES: dict[str, str] = {
-    # New canonical values (case/whitespace tolerance)
-    "go": "Go",
-    "no go": "No Go",
-    "no-go": "No Go",
-    "nogo": "No Go",
-    # Pre-rename Yes/No vocabulary
-    "yes": "Go",
-    "no": "No Go",
-    # Pre-rename three-state vocabulary — collapse to Go (was a yes-with-caveats)
-    "yes see notes": "Go",
-    "yes, see notes": "Go",
-    "conditional": "Go",
+    # Canonical values (case/whitespace tolerance)
+    "yes": "Yes",
+    "no": "No",
+    # Go / No Go vocabulary used by the publisher and dashboard — collapse
+    # back to the report's Yes/No on this field.
+    "go": "Yes",
+    "no go": "No",
+    "no-go": "No",
+    "nogo": "No",
+    # Pre-rename three-state vocabulary — collapse to Yes (was a yes-with-caveats)
+    "yes see notes": "Yes",
+    "yes, see notes": "Yes",
+    "conditional": "Yes",
+}
+
+# Publisher-side derivation: the dashboard `dd_recommendation` field carries
+# Go / No Go vocabulary. Derive from the (already-normalized) c_answer.
+# Returns None when c_answer is missing or unrecognized — publisher then
+# omits dd_recommendation, and the dashboard falls back to its own logic.
+DD_RECOMMENDATION_FROM_C_ANSWER: dict[str, str] = {
+    "Yes": "go",
+    "No": "no_go",
 }
 
 MISSING_P1_ASSIGNEE_LABEL = "[Not found - P1 Assignee not set in Wrike]"
@@ -423,14 +441,14 @@ def normalize_report_data(
     _normalize_optional_field(flat, token_sources, "exec.alpha_fit", normalize_alpha_fit)
     _normalize_optional_field(flat, token_sources, "exec.c_answer", normalize_can_we_answer)
 
-    # Deterministic override: compute Go/No Go from fastest_open_open_date vs school year deadlines.
+    # Deterministic override: compute Yes/No from fastest_open_open_date vs school year deadlines.
     # If the date is parseable it always overrides the agent's answer.
     # If unparseable, the agent's normalized answer (or absence) stands.
     fastest_date_str = flat.get("exec.fastest_open_open_date")
     if isinstance(fastest_date_str, str):
         parsed_date = parse_open_date(fastest_date_str)
         if parsed_date is not None:
-            computed = "Go" if parsed_date <= SCHOOL_YEAR_DEADLINE else "No Go"
+            computed = "Yes" if parsed_date <= SCHOOL_YEAR_DEADLINE else "No"
             flat["exec.c_answer"] = computed
             token_sources["exec.c_answer"] = "computed:date_comparison"
         else:

--- a/src/due_diligence_reporter/report_schema.py
+++ b/src/due_diligence_reporter/report_schema.py
@@ -11,10 +11,13 @@ from .utils import flatten_report_data_for_replacement
 
 logger = logging.getLogger(__name__)
 
+# The Executive Summary "Can We Open?" card answer. Binary by design —
+# matches the dashboard recommendation chip (Go / No Go). Legacy reports
+# may still contain "Yes" / "No" / "Yes see notes" — see
+# LEGACY_CAN_WE_ANSWER_ALIASES below for backward-compat aliasing.
 ALLOWED_CAN_WE_ANSWERS: frozenset[str] = frozenset({
-    "Yes",
-    "Yes see notes",
-    "No",
+    "Go",
+    "No Go",
 })
 
 ALLOWED_ZONING_STATUSES: frozenset[str] = frozenset({
@@ -36,18 +39,30 @@ ALLOWED_ALPHA_FIT_VALUES: frozenset[str] = frozenset({
 })
 
 # School-year start dates for deterministic c_answer computation.
-# fastest_open_open_date <= SCHOOL_YEAR_DEADLINE → "Yes"; otherwise → "No".
+# fastest_open_open_date <= SCHOOL_YEAR_DEADLINE → "Go"; otherwise → "No Go".
 SCHOOL_YEAR_START_DATES: tuple[date, ...] = (
     date(2026, 8, 12),  # 08/12/26
     date(2026, 9, 8),   # 09/08/26
 )
 SCHOOL_YEAR_DEADLINE: date = max(SCHOOL_YEAR_START_DATES)  # 09/08/26
 
+# Legacy alias map for the Can-We-Open answer. Maps any historical or
+# case-variant value to the canonical "Go" / "No Go". Includes Yes/No
+# from the pre-rename era and "Yes see notes" / "conditional" which
+# both collapse into "Go" under the new binary system.
 LEGACY_CAN_WE_ANSWER_ALIASES: dict[str, str] = {
-    "yes": "Yes",
-    "yes see notes": "Yes see notes",
-    "no": "No",
-    "conditional": "Yes see notes",
+    # New canonical values (case/whitespace tolerance)
+    "go": "Go",
+    "no go": "No Go",
+    "no-go": "No Go",
+    "nogo": "No Go",
+    # Pre-rename Yes/No vocabulary
+    "yes": "Go",
+    "no": "No Go",
+    # Pre-rename three-state vocabulary — collapse to Go (was a yes-with-caveats)
+    "yes see notes": "Go",
+    "yes, see notes": "Go",
+    "conditional": "Go",
 }
 
 MISSING_P1_ASSIGNEE_LABEL = "[Not found - P1 Assignee not set in Wrike]"
@@ -408,14 +423,14 @@ def normalize_report_data(
     _normalize_optional_field(flat, token_sources, "exec.alpha_fit", normalize_alpha_fit)
     _normalize_optional_field(flat, token_sources, "exec.c_answer", normalize_can_we_answer)
 
-    # Deterministic override: compute Yes/No from fastest_open_open_date vs school year deadlines.
+    # Deterministic override: compute Go/No Go from fastest_open_open_date vs school year deadlines.
     # If the date is parseable it always overrides the agent's answer.
     # If unparseable, the agent's normalized answer (or absence) stands.
     fastest_date_str = flat.get("exec.fastest_open_open_date")
     if isinstance(fastest_date_str, str):
         parsed_date = parse_open_date(fastest_date_str)
         if parsed_date is not None:
-            computed = "Yes" if parsed_date <= SCHOOL_YEAR_DEADLINE else "No"
+            computed = "Go" if parsed_date <= SCHOOL_YEAR_DEADLINE else "No Go"
             flat["exec.c_answer"] = computed
             token_sources["exec.c_answer"] = "computed:date_comparison"
         else:

--- a/src/due_diligence_reporter/site_record.py
+++ b/src/due_diligence_reporter/site_record.py
@@ -71,13 +71,21 @@ def classify_site(
     yes_if_hits = [phrase for phrase in _YES_IF_PHRASES if phrase in exec_text]
     no_hits = [phrase for phrase in _NO_PHRASES if phrase in exec_text]
 
-    if c_answer == "no":
-        signals.append("c_answer=No")
+    # NOTE: c_answer canonical values are now "Go" / "No Go". Pre-rename
+    # values "yes" / "no" / "yes see notes" are accepted as legacy aliases
+    # so older normalized data continues to classify correctly. Internal
+    # classification keys (yes / yes_if / no / review) are unchanged —
+    # they're a separate concept that downstream routing depends on.
+    if c_answer in {"no go", "no-go", "nogo", "no"}:
+        signals.append(f"c_answer={c_answer}")
         if no_hits:
             signals.extend(f"no_phrase:{phrase}" for phrase in no_hits)
             return _finalize_classification("no", 0.95, signals, threshold)
         return _finalize_classification("no", 0.85, signals, threshold)
 
+    # Legacy three-state "Yes see notes" still produces a yes_if classification
+    # (the new binary system collapses these into Go on the user-facing side,
+    # but the routing-level signal is still meaningful for backfilled data).
     if c_answer in {"yes see notes", "yes, see notes"}:
         signals.append("c_answer=Yes see notes")
         if yes_if_hits:
@@ -85,8 +93,8 @@ def classify_site(
             return _finalize_classification("yes_if", 0.95, signals, threshold)
         return _finalize_classification("yes_if", 0.80, signals, threshold)
 
-    if c_answer == "yes":
-        signals.append("c_answer=Yes")
+    if c_answer in {"go", "yes"}:
+        signals.append(f"c_answer={c_answer}")
         if yes_if_hits:
             signals.extend(f"yes_if_phrase:{phrase}" for phrase in yes_if_hits)
             return _finalize_classification("yes_if", 0.75, signals, threshold)

--- a/src/due_diligence_reporter/site_record.py
+++ b/src/due_diligence_reporter/site_record.py
@@ -71,11 +71,13 @@ def classify_site(
     yes_if_hits = [phrase for phrase in _YES_IF_PHRASES if phrase in exec_text]
     no_hits = [phrase for phrase in _NO_PHRASES if phrase in exec_text]
 
-    # NOTE: c_answer canonical values are now "Go" / "No Go". Pre-rename
-    # values "yes" / "no" / "yes see notes" are accepted as legacy aliases
-    # so older normalized data continues to classify correctly. Internal
-    # classification keys (yes / yes_if / no / review) are unchanged —
-    # they're a separate concept that downstream routing depends on.
+    # NOTE: c_answer canonical values are "Yes" / "No" (the report's plain-
+    # English answer). The publisher derives Go / No Go separately into
+    # `dd_recommendation` for the dashboard. Legacy values "go" / "no go" /
+    # "yes see notes" / "conditional" are accepted here so older normalized
+    # data continues to classify correctly. Internal classification keys
+    # (yes / yes_if / no / review) are unchanged — they're a separate
+    # routing concept that downstream code depends on.
     if c_answer in {"no go", "no-go", "nogo", "no"}:
         signals.append(f"c_answer={c_answer}")
         if no_hits:
@@ -83,10 +85,11 @@ def classify_site(
             return _finalize_classification("no", 0.95, signals, threshold)
         return _finalize_classification("no", 0.85, signals, threshold)
 
-    # Legacy three-state "Yes see notes" still produces a yes_if classification
-    # (the new binary system collapses these into Go on the user-facing side,
-    # but the routing-level signal is still meaningful for backfilled data).
-    if c_answer in {"yes see notes", "yes, see notes"}:
+    # Legacy three-state "Yes see notes" / "Conditional" still produces a
+    # yes_if classification (the binary system collapses these into Yes on
+    # the user-facing side, but the routing-level signal is still meaningful
+    # for backfilled data).
+    if c_answer in {"yes see notes", "yes, see notes", "conditional"}:
         signals.append("c_answer=Yes see notes")
         if yes_if_hits:
             signals.extend(f"yes_if_phrase:{phrase}" for phrase in yes_if_hits)

--- a/src/due_diligence_reporter/wrike.py
+++ b/src/due_diligence_reporter/wrike.py
@@ -55,10 +55,29 @@ WRIKE_CUSTOM_FIELDS: dict[str, str] = {
     "loi_signed_date": "IEAGN6I6JUAIOUVH",
     "vendor_team": "IEAGN6I6JUAKDCYE",
     "google_folder": "IEAGN6I6JUAIKGJH",
+    # --- Phase 2 DD provenance fields (Rhodes data dictionary, 4/24) ---
+    # IDs left blank here intentionally — they are resolved by display name
+    # at runtime via _resolve_custom_field_id() below. Once we confirm the
+    # canonical IDs from Wrike, paste them here and the resolver will
+    # short-circuit to the cached value.
+    "school_feasibility": "",  # W74 "School Feasibility" (high/medium/low/unknown)
+    "timeline_confidence": "",  # W81 "Timeline Confidence" (high/medium/low/unknown)
 }
 
-# Reverse mapping: ID -> name
-WRIKE_CUSTOM_FIELD_NAMES: dict[str, str] = {v: k for k, v in WRIKE_CUSTOM_FIELDS.items()}
+# Display-name lookup used by _resolve_custom_field_id(). When a slot in
+# WRIKE_CUSTOM_FIELDS has a blank ID, the resolver hits Wrike's
+# /customfields endpoint, finds the field by display name, and caches the
+# result for the lifetime of the process.
+WRIKE_CUSTOM_FIELD_DISPLAY_NAMES: dict[str, str] = {
+    "school_feasibility": "School Feasibility",
+    "timeline_confidence": "Timeline Confidence",
+}
+
+# Reverse mapping: ID -> name. Skip entries with blank IDs (Phase 2 fields
+# that resolve at runtime) so they don't all collide on the empty key.
+WRIKE_CUSTOM_FIELD_NAMES: dict[str, str] = {
+    v: k for k, v in WRIKE_CUSTOM_FIELDS.items() if v
+}
 
 
 @dataclass(frozen=True)
@@ -217,6 +236,150 @@ def extract_google_folder_from_record(record: dict[str, Any]) -> str | None:
                 return value.strip()
 
     return None
+
+
+# --- Phase 2 DD provenance fields (W74 / W81) ---
+#
+# These two custom fields don't have their canonical IDs hardcoded in
+# WRIKE_CUSTOM_FIELDS yet. Instead, _resolve_custom_field_id() looks them
+# up by display name on first call and caches the result. Once we confirm
+# the IDs they can be pasted into WRIKE_CUSTOM_FIELDS and the resolver
+# will short-circuit.
+#
+# Process-wide cache. Keyed by slot name (e.g. "school_feasibility") and
+# stores the resolved Wrike custom field ID. None means "resolution
+# attempted and failed" — don't retry on every record.
+_CUSTOM_FIELD_ID_CACHE: dict[str, str | None] = {}
+
+
+def _resolve_custom_field_id(
+    slot: str,
+    *,
+    access_token: str | None = None,
+) -> str | None:
+    """Return the Wrike custom field ID for the given slot.
+
+    Lookup order:
+      1. Hardcoded ID in WRIKE_CUSTOM_FIELDS (if non-empty).
+      2. Process-wide cache (populated below on first miss).
+      3. Wrike GET /customfields, matched by display name from
+         WRIKE_CUSTOM_FIELD_DISPLAY_NAMES.
+
+    Returns None when the slot has no display-name mapping or the API
+    call fails. Network errors are swallowed — the caller treats a None
+    as "this field is unknown; skip the read".
+    """
+    hardcoded = WRIKE_CUSTOM_FIELDS.get(slot, "")
+    if hardcoded:
+        return hardcoded
+
+    if slot in _CUSTOM_FIELD_ID_CACHE:
+        return _CUSTOM_FIELD_ID_CACHE[slot]
+
+    display_name = WRIKE_CUSTOM_FIELD_DISPLAY_NAMES.get(slot)
+    if not display_name:
+        _CUSTOM_FIELD_ID_CACHE[slot] = None
+        return None
+
+    if access_token is None:
+        try:
+            access_token = load_wrike_config().access_token
+        except WrikeError:
+            _CUSTOM_FIELD_ID_CACHE[slot] = None
+            return None
+
+    try:
+        resp = _wrike_get(
+            f"{WRIKE_API_BASE_URL}/customfields",
+            headers=_wrike_headers(access_token),
+        )
+        data = resp.json().get("data", [])
+    except (WrikeError, requests.RequestException, ValueError) as exc:
+        logger.warning(
+            "Failed to resolve Wrike custom field id for %s: %s", slot, exc
+        )
+        _CUSTOM_FIELD_ID_CACHE[slot] = None
+        return None
+
+    target = display_name.casefold()
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        title = str(entry.get("title", "")).casefold()
+        if title == target:
+            field_id = str(entry.get("id", "")) or None
+            _CUSTOM_FIELD_ID_CACHE[slot] = field_id
+            return field_id
+
+    logger.info(
+        "Wrike custom field %r not found by display name %r", slot, display_name
+    )
+    _CUSTOM_FIELD_ID_CACHE[slot] = None
+    return None
+
+
+def _extract_string_custom_field(
+    record: dict[str, Any],
+    slot: str,
+    *,
+    access_token: str | None = None,
+) -> str | None:
+    """Generic string-valued custom-field reader keyed by slot name.
+
+    Used for Phase 2 fields where the IDs aren't hardcoded yet. Returns
+    a stripped string or None if the field is absent / blank / non-string.
+    """
+    field_id = _resolve_custom_field_id(slot, access_token=access_token)
+    if not field_id:
+        return None
+
+    custom_fields = record.get("customFields", [])
+    if not isinstance(custom_fields, list):
+        return None
+
+    for field in custom_fields:
+        if not isinstance(field, dict):
+            continue
+        if field.get("id") != field_id:
+            continue
+        value = field.get("value")
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def extract_school_feasibility_from_record(
+    record: dict[str, Any],
+    *,
+    access_token: str | None = None,
+) -> str | None:
+    """Read W74 "School Feasibility" from a Wrike Site Record.
+
+    Expected values: high / medium / low / unknown (data dictionary 4/24).
+    Returns the raw lowercased string, or None when absent.
+    """
+    raw = _extract_string_custom_field(
+        record, "school_feasibility", access_token=access_token
+    )
+    return raw.lower() if raw else None
+
+
+def extract_timeline_confidence_from_record(
+    record: dict[str, Any],
+    *,
+    access_token: str | None = None,
+) -> str | None:
+    """Read W81 "Timeline Confidence" from a Wrike Site Record.
+
+    Expected values: high / medium / low / unknown (data dictionary 4/24).
+    Returns the raw lowercased string, or None when absent.
+    """
+    raw = _extract_string_custom_field(
+        record, "timeline_confidence", access_token=access_token
+    )
+    return raw.lower() if raw else None
 
 
 def extract_total_building_sf_from_record(record: dict[str, Any]) -> int | None:

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -168,3 +168,68 @@ class TestDeriveDDDates:
         )
         assert commissioned == "garbage"
         assert due == "2026-05-01"
+
+
+class TestPhase2DDProvenance:
+    """Phase 2 DD provenance fields on build_site_meta:
+
+      - school_feasibility (Wrike W74) — free string
+      - timeline_confidence (Wrike W81) — free string
+      - dd_status — "in_progress" / "complete"
+
+    Note: dd_recommendation (go/no_go/follow_up) is intentionally NOT a
+    field here. It's derived in the dashboard UI from the latest decision
+    button click. See dd-dashboard client/src/lib/reviews.ts.
+    """
+
+    def test_phase2_omitted_when_unset(self) -> None:
+        meta = build_site_meta("Austin", address="123 Main St, Austin, TX")
+        for key in ("school_feasibility", "timeline_confidence", "dd_status"):
+            assert key not in meta, f"{key} should be omitted when not provided"
+
+    def test_phase2_included_when_set(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            school_feasibility="high",
+            timeline_confidence="medium",
+            dd_status="complete",
+        )
+        assert meta["school_feasibility"] == "high"
+        assert meta["timeline_confidence"] == "medium"
+        assert meta["dd_status"] == "complete"
+
+    def test_phase2_strings_are_stripped(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            school_feasibility="  high  ",
+            timeline_confidence="\tlow\n",
+            dd_status=" complete ",
+        )
+        assert meta["school_feasibility"] == "high"
+        assert meta["timeline_confidence"] == "low"
+        assert meta["dd_status"] == "complete"
+
+    def test_phase2_blank_strings_omitted(self) -> None:
+        """Blank/whitespace-only values should be treated as unset."""
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            school_feasibility="",
+            timeline_confidence="   ",
+            dd_status=None,
+        )
+        for key in ("school_feasibility", "timeline_confidence", "dd_status"):
+            assert key not in meta
+
+    def test_dd_recommendation_never_in_payload(self) -> None:
+        """Guardrail: dd_recommendation is derived UI-side, not stored."""
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            school_feasibility="high",
+            timeline_confidence="high",
+            dd_status="complete",
+        )
+        assert "dd_recommendation" not in meta

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from due_diligence_reporter.dashboard_publisher import (
     _derive_dd_dates,
     build_site_meta,
+    publish_to_dashboard,
 )
 
 
@@ -175,11 +179,12 @@ class TestPhase2DDProvenance:
 
       - school_feasibility (Wrike W74) — free string
       - timeline_confidence (Wrike W81) — free string
-      - dd_status — "in_progress" / "complete"
+      - dd_status — "in_progress" / "complete" / "follow_up"
+      - dd_recommendation — "go" / "no_go" (derived from c_answer)
 
-    Note: dd_recommendation (go/no_go/follow_up) is intentionally NOT a
-    field here. It's derived in the dashboard UI from the latest decision
-    button click. See dd-dashboard client/src/lib/reviews.ts.
+    The decision-driven override (approve / reject / info_req) is layered
+    on top of dd_recommendation in the dashboard UI by
+    `effectiveDdStatusForSite`.
     """
 
     def test_phase2_omitted_when_unset(self) -> None:
@@ -223,8 +228,7 @@ class TestPhase2DDProvenance:
         for key in ("school_feasibility", "timeline_confidence", "dd_status"):
             assert key not in meta
 
-    def test_dd_recommendation_never_in_payload(self) -> None:
-        """Guardrail: dd_recommendation is derived UI-side, not stored."""
+    def test_dd_recommendation_omitted_when_unset(self) -> None:
         meta = build_site_meta(
             "Austin",
             address="123 Main St, Austin, TX",
@@ -233,3 +237,98 @@ class TestPhase2DDProvenance:
             dd_status="complete",
         )
         assert "dd_recommendation" not in meta
+
+    def test_dd_recommendation_included_when_set(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_recommendation="go",
+        )
+        assert meta["dd_recommendation"] == "go"
+
+    def test_dd_recommendation_lowercased_and_stripped(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_recommendation="  No_Go  ",
+        )
+        assert meta["dd_recommendation"] == "no_go"
+
+    def test_dd_recommendation_blank_omitted(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            dd_recommendation="   ",
+        )
+        assert "dd_recommendation" not in meta
+
+
+class TestDdRecommendationDerivation:
+    """publish_to_dashboard derives dd_recommendation from report_data["exec.c_answer"].
+
+    The report card stays plain-English Yes / No; the dashboard chip reads
+    Go / No Go on the publisher field. The derivation maps Yes → "go",
+    No → "no_go". Legacy values ("Go", "No Go", "Yes see notes",
+    "Conditional") are aliased through LEGACY_CAN_WE_ANSWER_ALIASES so
+    pre-rename payloads still derive correctly.
+    """
+
+    def _capture_meta(self, report_data: dict, **publish_kwargs) -> dict:
+        """Run publish_to_dashboard with mocks; return the posted site_meta."""
+        captured: dict = {}
+
+        def fake_post(url, json, headers, timeout):
+            captured.update(json)
+            response = MagicMock()
+            response.status_code = 200
+            return response
+
+        env = {
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+            "DASHBOARD_PUBLISH_ENABLED": "1",
+        }
+        with patch.dict("os.environ", env, clear=False), \
+                patch("due_diligence_reporter.dashboard_publisher.requests.post", side_effect=fake_post):
+            publish_to_dashboard("Austin", report_data, **publish_kwargs)
+        return captured.get("site_meta", {})
+
+    @pytest.mark.parametrize(
+        ("c_answer", "expected"),
+        [
+            # Canonical Yes / No
+            ("Yes", "go"),
+            ("No", "no_go"),
+            ("yes", "go"),
+            ("NO", "no_go"),
+            # Legacy Go / No Go (from the brief publisher-vocab-on-c_answer
+            # experiment) — must derive correctly
+            ("Go", "go"),
+            ("No Go", "no_go"),
+            # Legacy three-state — collapses to go (was a yes-with-caveats)
+            ("Yes see notes", "go"),
+            ("Conditional", "go"),
+        ],
+    )
+    def test_derives_from_c_answer(self, c_answer: str, expected: str) -> None:
+        meta = self._capture_meta({"exec.c_answer": c_answer})
+        assert meta["dd_recommendation"] == expected
+
+    def test_missing_c_answer_omits_field(self) -> None:
+        meta = self._capture_meta({})
+        assert "dd_recommendation" not in meta
+
+    def test_blank_c_answer_omits_field(self) -> None:
+        meta = self._capture_meta({"exec.c_answer": "   "})
+        assert "dd_recommendation" not in meta
+
+    def test_unrecognized_c_answer_omits_field(self) -> None:
+        meta = self._capture_meta({"exec.c_answer": "Maybe"})
+        assert "dd_recommendation" not in meta
+
+    def test_explicit_kwarg_overrides_derivation(self) -> None:
+        # Caller passes Go but report says No — caller wins.
+        meta = self._capture_meta(
+            {"exec.c_answer": "No"},
+            dd_recommendation="go",
+        )
+        assert meta["dd_recommendation"] == "go"

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -355,9 +355,12 @@ class TestCheckReportCompleteness:
         from due_diligence_reporter.server import check_report_completeness
 
         gc = MagicMock()
+        # Canonical answer is now "Go" / "No Go" (binary). The legacy "Yes
+        # see notes" three-state value is no longer raw-canonical — agents
+        # should emit Go directly.
         gc.export_google_doc_as_text.return_value = (
             "Can this school be open in time for the current school year?\n"
-            "Yes see notes Education Regulatory Approval: Not required "
+            "Go Education Regulatory Approval: Not required "
             "Occupancy path: Has E-Occupancy Zoning: Permitted by right\n"
         )
 
@@ -377,7 +380,7 @@ class TestCheckReportCompleteness:
         gc = MagicMock()
         gc.export_google_doc_as_text.return_value = (
             "Can this school be open in time for the current school year?\n"
-            "Yes see notes Education Regulatory Approval: Required have not done "
+            "No Go Education Regulatory Approval: Required have not done "
             "Occupancy path: Change of use required, needs work Zoning: Use Permit Required (Public approval)\n"
             "Build Scenarios\n"
             "exec.cost_demolition_fastest_open exec.max_capacity_capex\n"
@@ -489,8 +492,8 @@ class TestReportNormalizationDefaults:
             drive_folder_url="https://drive.google.com/drive/folders/folder123",
         )
 
-        # Date 10/27 (Oct 2027) is past both school year deadlines — deterministic "No"
-        assert replacements["exec.c_answer"] == "No"
+        # Date 10/27 (Oct 2027) is past both school year deadlines — deterministic "No Go"
+        assert replacements["exec.c_answer"] == "No Go"
         assert replacements["exec.max_capacity_capacity"] == "[Not found - Max Capacity scenario not extracted]"
         assert replacements["exec.max_capacity_capex"] == "[Not found - Max Capacity scenario not extracted]"
         assert "exec.max_value_capacity" not in replacements

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -355,12 +355,12 @@ class TestCheckReportCompleteness:
         from due_diligence_reporter.server import check_report_completeness
 
         gc = MagicMock()
-        # Canonical answer is now "Go" / "No Go" (binary). The legacy "Yes
-        # see notes" three-state value is no longer raw-canonical — agents
-        # should emit Go directly.
+        # Canonical answer is the binary plain-English "Yes" / "No" — the
+        # literal answer to "Can this be a school by [date]?". The publisher
+        # derives Go / No Go separately into `dd_recommendation`.
         gc.export_google_doc_as_text.return_value = (
             "Can this school be open in time for the current school year?\n"
-            "Go Education Regulatory Approval: Not required "
+            "Yes Education Regulatory Approval: Not required "
             "Occupancy path: Has E-Occupancy Zoning: Permitted by right\n"
         )
 
@@ -380,7 +380,7 @@ class TestCheckReportCompleteness:
         gc = MagicMock()
         gc.export_google_doc_as_text.return_value = (
             "Can this school be open in time for the current school year?\n"
-            "No Go Education Regulatory Approval: Required have not done "
+            "No Education Regulatory Approval: Required have not done "
             "Occupancy path: Change of use required, needs work Zoning: Use Permit Required (Public approval)\n"
             "Build Scenarios\n"
             "exec.cost_demolition_fastest_open exec.max_capacity_capex\n"
@@ -492,8 +492,8 @@ class TestReportNormalizationDefaults:
             drive_folder_url="https://drive.google.com/drive/folders/folder123",
         )
 
-        # Date 10/27 (Oct 2027) is past both school year deadlines — deterministic "No Go"
-        assert replacements["exec.c_answer"] == "No Go"
+        # Date 10/27 (Oct 2027) is past both school year deadlines — deterministic "No"
+        assert replacements["exec.c_answer"] == "No"
         assert replacements["exec.max_capacity_capacity"] == "[Not found - Max Capacity scenario not extracted]"
         assert replacements["exec.max_capacity_capex"] == "[Not found - Max Capacity scenario not extracted]"
         assert "exec.max_value_capacity" not in replacements

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -167,11 +167,20 @@ class TestNormalization:
     @pytest.mark.parametrize(
         ("raw_value", "expected"),
         [
-            ("Yes", "Yes"),
-            ("YES", "Yes"),
-            ("No", "No"),
-            ("CONDITIONAL", "Yes see notes"),
-            ("Yes see notes", "Yes see notes"),
+            # Canonical Go / No Go (case/whitespace tolerant)
+            ("Go", "Go"),
+            ("GO", "Go"),
+            ("No Go", "No Go"),
+            ("NO GO", "No Go"),
+            ("no-go", "No Go"),
+            ("NoGo", "No Go"),
+            # Legacy Yes/No (pre-rename) — must still alias forward
+            ("Yes", "Go"),
+            ("YES", "Go"),
+            ("No", "No Go"),
+            # Legacy three-state "Yes see notes" / "Conditional" collapse to Go
+            ("CONDITIONAL", "Go"),
+            ("Yes see notes", "Go"),
         ],
     )
     def test_can_we_answer_normalizes_to_allowed_values(self, raw_value: str, expected: str) -> None:
@@ -297,7 +306,14 @@ class TestParseOpenDate:
 
 
 class TestDeterministicCAnswer:
-    def _run(self, fastest_open_date: str, agent_answer: str = "No") -> dict:
+    """Verify the date-comparison override emits canonical Go / No Go.
+
+    The deterministic computation in normalize_report_data compares
+    fastest_open_open_date against SCHOOL_YEAR_DEADLINE and overrides
+    the agent's answer with "Go" (date <= deadline) or "No Go" (after).
+    """
+
+    def _run(self, fastest_open_date: str, agent_answer: str = "No Go") -> dict:
         replacements, _, _, sources = normalize_report_data(
             {"exec": {"c_answer": agent_answer, "fastest_open_open_date": fastest_open_date}},
             site_name="Test",
@@ -305,38 +321,43 @@ class TestDeterministicCAnswer:
         )
         return {"replacements": replacements, "sources": sources}
 
-    def test_date_before_deadline_yields_yes(self) -> None:
+    def test_date_before_deadline_yields_go(self) -> None:
         result = self._run("07/15/26")
-        assert result["replacements"]["exec.c_answer"] == "Yes"
+        assert result["replacements"]["exec.c_answer"] == "Go"
         assert result["sources"]["exec.c_answer"] == "computed:date_comparison"
 
-    def test_date_on_deadline_yields_yes(self) -> None:
+    def test_date_on_deadline_yields_go(self) -> None:
         result = self._run("09/08/26")
-        assert result["replacements"]["exec.c_answer"] == "Yes"
+        assert result["replacements"]["exec.c_answer"] == "Go"
 
-    def test_date_after_deadline_yields_no(self) -> None:
+    def test_date_after_deadline_yields_no_go(self) -> None:
         result = self._run("09/09/26")
-        assert result["replacements"]["exec.c_answer"] == "No"
+        assert result["replacements"]["exec.c_answer"] == "No Go"
         assert result["sources"]["exec.c_answer"] == "computed:date_comparison"
 
-    def test_far_future_date_yields_no(self) -> None:
+    def test_far_future_date_yields_no_go(self) -> None:
         result = self._run("06/01/27")
-        assert result["replacements"]["exec.c_answer"] == "No"
+        assert result["replacements"]["exec.c_answer"] == "No Go"
 
-    def test_legacy_mm_yy_date_before_deadline_yields_yes(self) -> None:
+    def test_legacy_mm_yy_date_before_deadline_yields_go(self) -> None:
         # 08/26 parsed as 08/01/26, which is before 09/08/26
         result = self._run("08/26")
-        assert result["replacements"]["exec.c_answer"] == "Yes"
+        assert result["replacements"]["exec.c_answer"] == "Go"
 
     def test_overrides_agent_answer(self) -> None:
-        # Agent says "Yes" but date is after deadline
-        result = self._run("10/15/26", agent_answer="Yes")
-        assert result["replacements"]["exec.c_answer"] == "No"
+        # Agent says "Go" but date is after deadline — deterministic wins
+        result = self._run("10/15/26", agent_answer="Go")
+        assert result["replacements"]["exec.c_answer"] == "No Go"
 
     def test_unparseable_date_keeps_agent_answer(self) -> None:
-        result = self._run("Fall 2027", agent_answer="Yes")
-        assert result["replacements"]["exec.c_answer"] == "Yes"
+        result = self._run("Fall 2027", agent_answer="Go")
+        assert result["replacements"]["exec.c_answer"] == "Go"
         assert result["sources"]["exec.c_answer"] == "Agent"
+
+    def test_legacy_yes_agent_answer_aliased_when_date_unparseable(self) -> None:
+        # Old agent that still emits "Yes" — normalizer aliases to canonical Go
+        result = self._run("Fall 2027", agent_answer="Yes")
+        assert result["replacements"]["exec.c_answer"] == "Go"
 
     def test_school_year_deadline_constant(self) -> None:
         assert SCHOOL_YEAR_DEADLINE == date(2026, 9, 8)

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -167,20 +167,24 @@ class TestNormalization:
     @pytest.mark.parametrize(
         ("raw_value", "expected"),
         [
-            # Canonical Go / No Go (case/whitespace tolerant)
-            ("Go", "Go"),
-            ("GO", "Go"),
-            ("No Go", "No Go"),
-            ("NO GO", "No Go"),
-            ("no-go", "No Go"),
-            ("NoGo", "No Go"),
-            # Legacy Yes/No (pre-rename) — must still alias forward
-            ("Yes", "Go"),
-            ("YES", "Go"),
-            ("No", "No Go"),
-            # Legacy three-state "Yes see notes" / "Conditional" collapse to Go
-            ("CONDITIONAL", "Go"),
-            ("Yes see notes", "Go"),
+            # Canonical Yes / No (case/whitespace tolerant)
+            ("Yes", "Yes"),
+            ("YES", "Yes"),
+            ("yes", "Yes"),
+            ("No", "No"),
+            ("NO", "No"),
+            ("no", "No"),
+            # Legacy Go / No Go (from the brief publisher-vocab-on-c_answer
+            # experiment) — alias back to the report's Yes / No
+            ("Go", "Yes"),
+            ("GO", "Yes"),
+            ("No Go", "No"),
+            ("NO GO", "No"),
+            ("no-go", "No"),
+            ("NoGo", "No"),
+            # Legacy three-state "Yes see notes" / "Conditional" collapse to Yes
+            ("CONDITIONAL", "Yes"),
+            ("Yes see notes", "Yes"),
         ],
     )
     def test_can_we_answer_normalizes_to_allowed_values(self, raw_value: str, expected: str) -> None:
@@ -306,14 +310,14 @@ class TestParseOpenDate:
 
 
 class TestDeterministicCAnswer:
-    """Verify the date-comparison override emits canonical Go / No Go.
+    """Verify the date-comparison override emits canonical Yes / No.
 
     The deterministic computation in normalize_report_data compares
     fastest_open_open_date against SCHOOL_YEAR_DEADLINE and overrides
-    the agent's answer with "Go" (date <= deadline) or "No Go" (after).
+    the agent's answer with "Yes" (date <= deadline) or "No" (after).
     """
 
-    def _run(self, fastest_open_date: str, agent_answer: str = "No Go") -> dict:
+    def _run(self, fastest_open_date: str, agent_answer: str = "No") -> dict:
         replacements, _, _, sources = normalize_report_data(
             {"exec": {"c_answer": agent_answer, "fastest_open_open_date": fastest_open_date}},
             site_name="Test",
@@ -321,43 +325,48 @@ class TestDeterministicCAnswer:
         )
         return {"replacements": replacements, "sources": sources}
 
-    def test_date_before_deadline_yields_go(self) -> None:
+    def test_date_before_deadline_yields_yes(self) -> None:
         result = self._run("07/15/26")
-        assert result["replacements"]["exec.c_answer"] == "Go"
+        assert result["replacements"]["exec.c_answer"] == "Yes"
         assert result["sources"]["exec.c_answer"] == "computed:date_comparison"
 
-    def test_date_on_deadline_yields_go(self) -> None:
+    def test_date_on_deadline_yields_yes(self) -> None:
         result = self._run("09/08/26")
-        assert result["replacements"]["exec.c_answer"] == "Go"
+        assert result["replacements"]["exec.c_answer"] == "Yes"
 
-    def test_date_after_deadline_yields_no_go(self) -> None:
+    def test_date_after_deadline_yields_no(self) -> None:
         result = self._run("09/09/26")
-        assert result["replacements"]["exec.c_answer"] == "No Go"
+        assert result["replacements"]["exec.c_answer"] == "No"
         assert result["sources"]["exec.c_answer"] == "computed:date_comparison"
 
-    def test_far_future_date_yields_no_go(self) -> None:
+    def test_far_future_date_yields_no(self) -> None:
         result = self._run("06/01/27")
-        assert result["replacements"]["exec.c_answer"] == "No Go"
+        assert result["replacements"]["exec.c_answer"] == "No"
 
-    def test_legacy_mm_yy_date_before_deadline_yields_go(self) -> None:
+    def test_legacy_mm_yy_date_before_deadline_yields_yes(self) -> None:
         # 08/26 parsed as 08/01/26, which is before 09/08/26
         result = self._run("08/26")
-        assert result["replacements"]["exec.c_answer"] == "Go"
+        assert result["replacements"]["exec.c_answer"] == "Yes"
 
     def test_overrides_agent_answer(self) -> None:
-        # Agent says "Go" but date is after deadline — deterministic wins
-        result = self._run("10/15/26", agent_answer="Go")
-        assert result["replacements"]["exec.c_answer"] == "No Go"
+        # Agent says "Yes" but date is after deadline — deterministic wins
+        result = self._run("10/15/26", agent_answer="Yes")
+        assert result["replacements"]["exec.c_answer"] == "No"
 
     def test_unparseable_date_keeps_agent_answer(self) -> None:
-        result = self._run("Fall 2027", agent_answer="Go")
-        assert result["replacements"]["exec.c_answer"] == "Go"
+        result = self._run("Fall 2027", agent_answer="Yes")
+        assert result["replacements"]["exec.c_answer"] == "Yes"
         assert result["sources"]["exec.c_answer"] == "Agent"
 
-    def test_legacy_yes_agent_answer_aliased_when_date_unparseable(self) -> None:
-        # Old agent that still emits "Yes" — normalizer aliases to canonical Go
-        result = self._run("Fall 2027", agent_answer="Yes")
-        assert result["replacements"]["exec.c_answer"] == "Go"
+    def test_legacy_go_agent_answer_aliased_when_date_unparseable(self) -> None:
+        # Old agent that still emits "Go" (from the brief publisher-vocab
+        # experiment) — normalizer aliases back to canonical Yes
+        result = self._run("Fall 2027", agent_answer="Go")
+        assert result["replacements"]["exec.c_answer"] == "Yes"
+
+    def test_legacy_no_go_agent_answer_aliased_when_date_unparseable(self) -> None:
+        result = self._run("Fall 2027", agent_answer="No Go")
+        assert result["replacements"]["exec.c_answer"] == "No"
 
     def test_school_year_deadline_constant(self) -> None:
         assert SCHOOL_YEAR_DEADLINE == date(2026, 9, 8)

--- a/tests/test_site_record.py
+++ b/tests/test_site_record.py
@@ -35,23 +35,15 @@ class TestSiteSlug:
 
 
 class TestClassifySite:
-    """classify_site accepts canonical Go / No Go and legacy Yes / No.
+    """classify_site accepts canonical Yes / No and legacy Go / No Go.
 
     Internal classification labels (yes / yes_if / no / review) are unchanged —
-    they're a routing-level concept separate from the user-facing Go / No Go.
+    they're a routing-level concept separate from the report's user-facing
+    Yes / No on `exec.c_answer` and the publisher's Go / No Go on
+    `dd_recommendation`.
     """
 
-    def test_clear_go(self) -> None:
-        label, confidence, _signals = classify_site({
-            "exec.c_answer": "Go",
-            "exec.acquisition_conditions": "Standard lease protections.",
-            "exec.tradeoffs_and_deficiencies": "",
-        })
-        assert label == "yes"
-        assert confidence >= 0.85
-
-    def test_legacy_yes_still_classifies_as_yes(self) -> None:
-        # Pre-rename data with raw "Yes" must still classify correctly
+    def test_clear_yes(self) -> None:
         label, confidence, _signals = classify_site({
             "exec.c_answer": "Yes",
             "exec.acquisition_conditions": "Standard lease protections.",
@@ -60,17 +52,28 @@ class TestClassifySite:
         assert label == "yes"
         assert confidence >= 0.85
 
-    def test_clear_no_go(self) -> None:
+    def test_legacy_go_still_classifies_as_yes(self) -> None:
+        # Data emitted during the brief Go-on-c_answer experiment must still
+        # classify correctly through the legacy fallthrough.
         label, confidence, _signals = classify_site({
-            "exec.c_answer": "No Go",
+            "exec.c_answer": "Go",
+            "exec.acquisition_conditions": "Standard lease protections.",
+            "exec.tradeoffs_and_deficiencies": "",
+        })
+        assert label == "yes"
+        assert confidence >= 0.85
+
+    def test_clear_no(self) -> None:
+        label, confidence, _signals = classify_site({
+            "exec.c_answer": "No",
             "exec.tradeoffs_and_deficiencies": "Site does not meet occupancy requirements.",
         })
         assert label == "no"
         assert confidence >= 0.85
 
-    def test_legacy_no_still_classifies_as_no(self) -> None:
+    def test_legacy_no_go_still_classifies_as_no(self) -> None:
         label, confidence, _signals = classify_site({
-            "exec.c_answer": "No",
+            "exec.c_answer": "No Go",
             "exec.tradeoffs_and_deficiencies": "Site does not meet occupancy requirements.",
         })
         assert label == "no"
@@ -86,9 +89,9 @@ class TestClassifySite:
         assert confidence >= 0.80
         assert any("yes_if_phrase:tradeoff" == signal for signal in signals)
 
-    def test_go_with_no_phrase_goes_to_review(self) -> None:
+    def test_yes_with_no_phrase_goes_to_review(self) -> None:
         label, confidence, signals = classify_site({
-            "exec.c_answer": "Go",
+            "exec.c_answer": "Yes",
             "exec.tradeoffs_and_deficiencies": "Fatal: zoning does not allow schools.",
         })
         assert label == "review"
@@ -113,7 +116,7 @@ class TestClassifySite:
 
     def test_case_insensitive(self) -> None:
         label, _confidence, _signals = classify_site({
-            "exec.c_answer": "go",
+            "exec.c_answer": "yes",
             "exec.tradeoffs_and_deficiencies": "NEEDS TO GO RIGHT: permit on time.",
         })
         assert label == "yes_if"
@@ -134,7 +137,7 @@ def _full_replacements() -> dict[str, str]:
         "meta.rebl_site_id": "palm-beach-gardens-fl",
         "meta.drive_folder_url": "https://drive.google.com/drive/folders/ABC",
         # Legacy three-state value — still accepted by classify_site for
-        # backfilled data; under the new binary system new reports emit "Go".
+        # backfilled data; under the new binary system new reports emit "Yes".
         "exec.c_answer": "Yes see notes",
         "exec.c_edreg": "Approved - FL nonpublic registration",
         "exec.c_occupancy": "E via minor TI",

--- a/tests/test_site_record.py
+++ b/tests/test_site_record.py
@@ -35,7 +35,23 @@ class TestSiteSlug:
 
 
 class TestClassifySite:
-    def test_clear_yes(self) -> None:
+    """classify_site accepts canonical Go / No Go and legacy Yes / No.
+
+    Internal classification labels (yes / yes_if / no / review) are unchanged —
+    they're a routing-level concept separate from the user-facing Go / No Go.
+    """
+
+    def test_clear_go(self) -> None:
+        label, confidence, _signals = classify_site({
+            "exec.c_answer": "Go",
+            "exec.acquisition_conditions": "Standard lease protections.",
+            "exec.tradeoffs_and_deficiencies": "",
+        })
+        assert label == "yes"
+        assert confidence >= 0.85
+
+    def test_legacy_yes_still_classifies_as_yes(self) -> None:
+        # Pre-rename data with raw "Yes" must still classify correctly
         label, confidence, _signals = classify_site({
             "exec.c_answer": "Yes",
             "exec.acquisition_conditions": "Standard lease protections.",
@@ -44,7 +60,15 @@ class TestClassifySite:
         assert label == "yes"
         assert confidence >= 0.85
 
-    def test_clear_no(self) -> None:
+    def test_clear_no_go(self) -> None:
+        label, confidence, _signals = classify_site({
+            "exec.c_answer": "No Go",
+            "exec.tradeoffs_and_deficiencies": "Site does not meet occupancy requirements.",
+        })
+        assert label == "no"
+        assert confidence >= 0.85
+
+    def test_legacy_no_still_classifies_as_no(self) -> None:
         label, confidence, _signals = classify_site({
             "exec.c_answer": "No",
             "exec.tradeoffs_and_deficiencies": "Site does not meet occupancy requirements.",
@@ -53,6 +77,7 @@ class TestClassifySite:
         assert confidence >= 0.85
 
     def test_yes_see_notes_is_yes_if(self) -> None:
+        # Legacy three-state — still produces yes_if for routing purposes
         label, confidence, signals = classify_site({
             "exec.c_answer": "Yes see notes",
             "exec.tradeoffs_and_deficiencies": "Tradeoff: smaller outdoor space than spec.",
@@ -61,9 +86,9 @@ class TestClassifySite:
         assert confidence >= 0.80
         assert any("yes_if_phrase:tradeoff" == signal for signal in signals)
 
-    def test_yes_with_no_phrase_goes_to_review(self) -> None:
+    def test_go_with_no_phrase_goes_to_review(self) -> None:
         label, confidence, signals = classify_site({
-            "exec.c_answer": "Yes",
+            "exec.c_answer": "Go",
             "exec.tradeoffs_and_deficiencies": "Fatal: zoning does not allow schools.",
         })
         assert label == "review"
@@ -88,7 +113,7 @@ class TestClassifySite:
 
     def test_case_insensitive(self) -> None:
         label, _confidence, _signals = classify_site({
-            "exec.c_answer": "yes",
+            "exec.c_answer": "go",
             "exec.tradeoffs_and_deficiencies": "NEEDS TO GO RIGHT: permit on time.",
         })
         assert label == "yes_if"
@@ -108,6 +133,8 @@ def _full_replacements() -> dict[str, str]:
         "meta.prepared_by": "Greg Foote",
         "meta.rebl_site_id": "palm-beach-gardens-fl",
         "meta.drive_folder_url": "https://drive.google.com/drive/folders/ABC",
+        # Legacy three-state value — still accepted by classify_site for
+        # backfilled data; under the new binary system new reports emit "Go".
         "exec.c_answer": "Yes see notes",
         "exec.c_edreg": "Approved - FL nonpublic registration",
         "exec.c_occupancy": "E via minor TI",

--- a/tests/test_wrike_phase2_fields.py
+++ b/tests/test_wrike_phase2_fields.py
@@ -1,0 +1,105 @@
+"""Tests for Phase 2 Wrike custom-field readers.
+
+Covers:
+  - extract_school_feasibility_from_record (W74)
+  - extract_timeline_confidence_from_record (W81)
+  - _resolve_custom_field_id() short-circuits on hardcoded IDs
+  - _resolve_custom_field_id() caches negative results to avoid repeat calls
+
+Tests don't hit the network — they pre-seed _CUSTOM_FIELD_ID_CACHE with a
+known ID, then construct synthetic Wrike record fixtures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from due_diligence_reporter import wrike as wrike_mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_cache() -> None:
+    """Each test starts with a fresh cache so prior tests don't leak."""
+    wrike_mod._CUSTOM_FIELD_ID_CACHE.clear()
+    yield
+    wrike_mod._CUSTOM_FIELD_ID_CACHE.clear()
+
+
+def _record_with(field_id: str, value: object) -> dict[str, object]:
+    """Build a minimal Wrike Site Record fixture with one custom field."""
+    return {
+        "id": "fakeRecord",
+        "title": "Test Site",
+        "customFields": [{"id": field_id, "value": value}],
+    }
+
+
+class TestSchoolFeasibility:
+    def test_returns_lowercased_value(self) -> None:
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["school_feasibility"] = "FAKE_W74"
+        record = _record_with("FAKE_W74", "High")
+        assert wrike_mod.extract_school_feasibility_from_record(record) == "high"
+
+    def test_returns_none_when_field_absent(self) -> None:
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["school_feasibility"] = "FAKE_W74"
+        record = {"customFields": []}
+        assert wrike_mod.extract_school_feasibility_from_record(record) is None
+
+    def test_returns_none_when_value_blank(self) -> None:
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["school_feasibility"] = "FAKE_W74"
+        record = _record_with("FAKE_W74", "   ")
+        assert wrike_mod.extract_school_feasibility_from_record(record) is None
+
+    def test_returns_none_when_resolver_fails(self) -> None:
+        # Negative cache entry — resolver tried and gave up.
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["school_feasibility"] = None
+        record = _record_with("ANYTHING", "high")
+        assert wrike_mod.extract_school_feasibility_from_record(record) is None
+
+    def test_strips_whitespace_before_lowercasing(self) -> None:
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["school_feasibility"] = "FAKE_W74"
+        record = _record_with("FAKE_W74", "  Medium  ")
+        assert wrike_mod.extract_school_feasibility_from_record(record) == "medium"
+
+
+class TestTimelineConfidence:
+    def test_returns_lowercased_value(self) -> None:
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["timeline_confidence"] = "FAKE_W81"
+        record = _record_with("FAKE_W81", "Low")
+        assert wrike_mod.extract_timeline_confidence_from_record(record) == "low"
+
+    def test_returns_none_when_field_absent(self) -> None:
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["timeline_confidence"] = "FAKE_W81"
+        assert wrike_mod.extract_timeline_confidence_from_record({}) is None
+
+    def test_returns_none_for_non_string_value(self) -> None:
+        """Wrike sometimes returns numeric values for numeric fields. We
+        only handle string-valued fields here; anything else returns None."""
+        wrike_mod._CUSTOM_FIELD_ID_CACHE["timeline_confidence"] = "FAKE_W81"
+        record = _record_with("FAKE_W81", 42)
+        assert wrike_mod.extract_timeline_confidence_from_record(record) is None
+
+
+class TestResolverShortCircuit:
+    def test_hardcoded_id_short_circuits_resolver(self, monkeypatch) -> None:
+        """If WRIKE_CUSTOM_FIELDS has a non-empty ID, no API call is made."""
+        # Replace the dict entry just for this test.
+        monkeypatch.setitem(
+            wrike_mod.WRIKE_CUSTOM_FIELDS,
+            "school_feasibility",
+            "HARDCODED_ID",
+        )
+
+        # If the resolver tried to hit the API we'd raise.
+        def boom(*_a, **_kw):
+            raise AssertionError("network must not be called")
+
+        monkeypatch.setattr(wrike_mod, "_wrike_get", boom)
+        monkeypatch.setattr(
+            wrike_mod, "load_wrike_config", lambda: boom("called!")
+        )
+
+        assert (
+            wrike_mod._resolve_custom_field_id("school_feasibility")
+            == "HARDCODED_ID"
+        )


### PR DESCRIPTION
## Summary

DD Phase 2 fields (`school_feasibility`, `timeline_confidence`, `dd_status`) plus the new **`dd_recommendation`** publisher field, with the locked-in **vocabulary split** between report card and publisher payload.

### Vocabulary split (LOCKED IN)

| Layer | Field | Allowed values | Purpose |
|---|---|---|---|
| Report card | `exec.c_answer` | `Yes` / `No` | Plain-English answer to "Can this be a school by [target date]?" |
| Publisher payload | `dd_recommendation` | `go` / `no_go` | Canonical action verb; consumed by dashboard chip + decision UI |

Derivation is deterministic in `dashboard_publisher.publish_to_dashboard`: `Yes → go`, `No → no_go` (see `DD_RECOMMENDATION_FROM_C_ANSWER` in `report_schema.py`). Caller-wins precedence, so a manual override on `build_site_meta` / `publish_to_dashboard` always sticks.

The conjunction wording in the report card is:
- **`Yes, if:`** — forward-looking conditions that must hold for the timeline
- **`No, because:`** — backward-looking blockers that push past the deadline

## Changes

### Schema (`report_schema.py`)
- `ALLOWED_CAN_WE_ANSWERS = {"Yes", "No"}` (canonical)
- `LEGACY_CAN_WE_ANSWER_ALIASES` expanded: `Go` / `No Go` / `Yes see notes` / `Conditional` → canonical `Yes` / `No`
- NEW `DD_RECOMMENDATION_FROM_C_ANSWER = {"Yes": "go", "No": "no_go"}`
- Deterministic `c_answer` computation emits `Yes` / `No`

### Publisher (`dashboard_publisher.py`)
- `build_site_meta` and `publish_to_dashboard` accept new `dd_recommendation` kwarg
- Auto-derives from `report_data["exec.c_answer"]` via legacy alias map → canonical → derivation map
- Caller-wins (manual override beats derivation)

### Doc builder (`google_doc_builder.py`)
- Conjunction `Yes, if:` / `No, because:` based on classification
- Affirmative set includes legacy `Go` / `Yes see notes` / `Conditional` for backward-compat parsing

### Site record (`site_record.py`)
- `classify_site` accepts both vocabularies; `Yes see notes` and `Conditional` produce internal `yes_if`

### Phase 2 fields
- `school_feasibility`, `timeline_confidence`, `dd_status` plumbed through schema, publisher, and doc builder
- Wrike W74/W81 resolver wired through

### Docs
- `docs/prompts/prompt_v2.md`: `c_answer` Yes/No binary; publisher derivation noted
- `docs/process/HOW-IT-WORKS.md`: vocab split + publisher mapping documented

### Tests
- `TestDeterministicCAnswer` rewritten for Yes/No
- `TestClassifySite` handles dual vocab
- NEW `TestDdRecommendationDerivation` (13 tests, parametrized + edge cases)
- **562 tests pass** (was 543; +13 new derivation, +6 phase2 misc)

```
cd due-diligence-reporter && PYTHONPATH=src python -m pytest --ignore=tests/test_permit_history.py -q
```

## Stacking

Stacked on `feat/dd-phase1-fields` (PR #16). Phase 1 must merge first.

Branch commits:
- `e967de4` Phase 2 base fields
- `1fce5cb` (superseded — Go/No Go on c_answer experiment)
- `da90d96` **vocab split** — current correct state

## Related

- Pipeline skill: EDU-Ops-Team/alpha-dd-pipeline#2
- Dashboard: EDU-Ops-Team/dd-dashboard#3
- Tracking: #17