### PR TITLE
feat(dd-phase3): dd_site_score + band derived from q2.e_occupancy_score

### DIFF
--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -37,6 +37,7 @@ Four dimensions, each a fixed pick-menu:
 | Dimension | Source | Options |
 |-----------|--------|---------|
 | `exec.c_answer` | Agent synthesis | Yes / No (binary) — the literal answer to "Can this be a school by [date]?". The publisher derives the dashboard's Go / No Go recommendation chip (`dd_recommendation`) from this automatically. |
+| `q2.e_occupancy_score` | E-Occupancy tool | Integer 0–100 emitted by `apply_e_occupancy_skill`. The publisher derives the dashboard's `dd_site_score` (numeric column) and `dd_site_score_band` (`green` / `yellow` / `orange` / `red` chip) from this automatically. |
 | `exec.c_zoning` | SIR | Permitted by right / Use Permit Required (Admin) / Use Permit Required (Public) / Prohibited |
 | `exec.c_occupancy` | E-Occupancy skill | Has E-Occupancy / Change of use required, meets E-Occupancy / Change of use required, needs work |
 | `exec.c_edreg` | School Approval skill | Not required / Required and have done / Required have not done |
@@ -530,6 +531,11 @@ Fire-and-forget call to MatterBot rendering service. Generates marketing pack im
 ## GitHub Secrets (18 total)
 
 **Publish workflow (9):** `MCP_HIVE_API_KEY`, `MCP_HIVE_ID`, `WRIKE_ACCESS_TOKEN`, `OPENAI_API_KEY`, `DD_TEMPLATE_GOOGLE_DOC_ID`, `GOOGLE_DRIVE_ROOT_FOLDER_ID`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_REFRESH_TOKEN`
+
+**Cron + Inbox workflows (9 additional):** `ANTHROPIC_API_KEY`, `GOOGLE_CHAT_WEBHOOK_URL`, `DD_REPORT_EMAIL_RECIPIENTS`, `EMAIL_SENDER`, `EMAIL_APP_PASSWORD`, `SIR_FOLDER_ID`, `ISP_FOLDER_ID`, `BUILDING_INSPECTION_FOLDER_ID`, `PRICING_API_KEY`
+
+
+ENT_SECRET`, `OAUTH_REFRESH_TOKEN`
 
 **Cron + Inbox workflows (9 additional):** `ANTHROPIC_API_KEY`, `GOOGLE_CHAT_WEBHOOK_URL`, `DD_REPORT_EMAIL_RECIPIENTS`, `EMAIL_SENDER`, `EMAIL_APP_PASSWORD`, `SIR_FOLDER_ID`, `ISP_FOLDER_ID`, `BUILDING_INSPECTION_FOLDER_ID`, `PRICING_API_KEY`
 

--- a/docs/prompts/prompt_v2.md
+++ b/docs/prompts/prompt_v2.md
@@ -570,6 +570,11 @@ Each dimension uses a **fixed option menu**. Pick exactly one option per field b
 | Token | Source | Options (pick one) |
 |---|---|---|
 | `exec.c_answer` | Agent (synthesize from all sources) | `Yes` / `No` — **binary; no other values are valid**. This is the literal answer to "Can this be a school by [date]?". Use `Yes` when the school can open by the school-year deadline, `No` when it cannot. Do not use `Go`, `No Go`, `Yes see notes`, or `Conditional` — the system will alias old values forward, but new reports must emit canonical Yes / No. The publisher derives the dashboard's Go / No Go recommendation chip (`dd_recommendation`) from this value automatically (Yes → `go`, No → `no_go`). |
+
+**Publisher-side derivations.** Two top-level dashboard fields are auto-derived from tokens above and don't need to be emitted explicitly:
+
+- **`dd_recommendation`** (`go` / `no_go`) — from `exec.c_answer` (Yes → `go`, No → `no_go`)
+- **`dd_site_score`** (0–100 integer) and **`dd_site_score_band`** (`green` / `yellow` / `orange` / `red`) — from `q2.e_occupancy_score` emitted by the E-Occupancy tool. Bands: GREEN 80–100, YELLOW 60–79, ORANGE 40–59, RED 0–39. Score is always the source of truth; band is derived. Just call `apply_e_occupancy_skill` and the score flows through automatically.
 | `exec.c_zoning` | SIR (zoning designation + permitted uses) | `Permitted by right` / `Use Permit Required (Admin approval)` / `Use Permit Required (Public approval)` / `Prohibited` |
 | `exec.c_occupancy` | E-Occupancy skill (uses Building Inspection data) | `Has E-Occupancy` / `Change of use required, meets E-Occupancy` / `Change of use required, needs work` |
 | `exec.c_edreg` | School Approval skill | `Not required` / `Required and have done` / `Required have not done` |

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -30,8 +30,10 @@ from typing import Any
 import requests
 
 from .report_schema import (
+    ALLOWED_SITE_SCORE_BANDS,
     DD_RECOMMENDATION_FROM_C_ANSWER,
     LEGACY_CAN_WE_ANSWER_ALIASES,
+    site_score_band,
 )
 
 logger = logging.getLogger(__name__)
@@ -156,6 +158,14 @@ def build_site_meta(
     timeline_confidence: str | None = None,  # Wrike W81 (high/medium/low/unknown)
     dd_status: str | None = None,  # in_progress | complete | follow_up
     dd_recommendation: str | None = None,  # "go" | "no_go" (derived from c_answer)
+    # --- Phase 3 DD analytical fields (Rhodes data dictionary, 4/24) ---
+    # dd_site_score is a 0–100 numeric derived from the E-Occupancy
+    # rubric (`ease-of-conversion` skill, Phase 7). The publisher derives
+    # it from `q2.e_occupancy_score` when not supplied. dd_site_score_band
+    # is always derived from the score (green/yellow/orange/red) unless
+    # explicitly overridden — keeping the two in sync.
+    dd_site_score: int | None = None,
+    dd_site_score_band: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the `site_meta` payload from pipeline inputs.
 
@@ -224,6 +234,35 @@ def build_site_meta(
     if dd_recommendation and dd_recommendation.strip():
         payload["dd_recommendation"] = dd_recommendation.strip().lower()
 
+    # Phase 3: dd_site_score + band. Score is the source of truth; band is
+    # derived from score unless caller supplies a *valid* explicit band,
+    # in which case caller-wins (handy for backfill scripts setting band
+    # only). Score is omitted when None or out of range. An invalid
+    # caller-supplied band is silently dropped and the derived band is
+    # used instead, keeping the payload self-consistent.
+    explicit_band: str | None = None
+    if dd_site_score_band and dd_site_score_band.strip():
+        candidate_band = dd_site_score_band.strip().lower()
+        if candidate_band in ALLOWED_SITE_SCORE_BANDS:
+            explicit_band = candidate_band
+
+    if isinstance(dd_site_score, (int, float)):
+        score_int = int(round(float(dd_site_score)))
+        if 0 <= score_int <= 100:
+            payload["dd_site_score"] = score_int
+            if explicit_band:
+                payload["dd_site_score_band"] = explicit_band
+            else:
+                # site_score_band() accepts the raw float so we don't lose
+                # precision at band boundaries (e.g. 79.6 → yellow,
+                # 80.0 → green) — even though we stored the rounded int.
+                derived_band = site_score_band(dd_site_score)
+                if derived_band:
+                    payload["dd_site_score_band"] = derived_band
+    elif explicit_band:
+        # Backfill case: human-classified band with no numeric score.
+        payload["dd_site_score_band"] = explicit_band
+
     return payload
 
 
@@ -251,6 +290,9 @@ def publish_to_dashboard(
     timeline_confidence: str | None = None,
     dd_status: str | None = None,
     dd_recommendation: str | None = None,
+    # Phase 3 DD analytical pass-through. See build_site_meta() for semantics.
+    dd_site_score: int | None = None,
+    dd_site_score_band: str | None = None,
     base_url: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
 ) -> bool:
@@ -310,6 +352,32 @@ def publish_to_dashboard(
             if canonical:
                 effective_dd_recommendation = DD_RECOMMENDATION_FROM_C_ANSWER.get(canonical)
 
+    # Derive dd_site_score from the report's q2.e_occupancy_score token
+    # when the caller did not supply an explicit value. The E-Occupancy
+    # tool (`apply_e_occupancy_skill`) emits this token as part of its
+    # standard output; we promote it to a top-level publisher field so
+    # the dashboard can render a sortable score column without parsing
+    # report_data on every read. Caller-wins precedence; non-numeric or
+    # out-of-range values are silently dropped (publisher omits the field
+    # and the dashboard's sticky-preserve transform keeps the prior value).
+    effective_dd_site_score: int | None = None
+    if isinstance(dd_site_score, (int, float)):
+        try:
+            candidate = int(round(float(dd_site_score)))
+        except (TypeError, ValueError):
+            candidate = None
+        if candidate is not None and 0 <= candidate <= 100:
+            effective_dd_site_score = candidate
+    if effective_dd_site_score is None:
+        raw_score = report_data.get("q2.e_occupancy_score")
+        if raw_score is not None and str(raw_score).strip():
+            try:
+                candidate = int(round(float(str(raw_score).strip())))
+            except (TypeError, ValueError):
+                candidate = None
+            if candidate is not None and 0 <= candidate <= 100:
+                effective_dd_site_score = candidate
+
     meta = build_site_meta(
         site_title,
         address=address,
@@ -330,6 +398,8 @@ def publish_to_dashboard(
         timeline_confidence=timeline_confidence,
         dd_status=effective_dd_status,
         dd_recommendation=effective_dd_recommendation,
+        dd_site_score=effective_dd_site_score,
+        dd_site_score_band=dd_site_score_band,
     )
     slug = meta["slug"]
 

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -1159,7 +1159,14 @@ def _publish_to_dashboard_best_effort(
     school_feasibility: str | None = None,
     timeline_confidence: str | None = None,
 ) -> None:
-    """Fire-and-forget dashboard publish. Never raises."""
+    """Fire-and-forget dashboard publish. Never raises.
+
+    Phase 3 fields (dd_site_score + dd_site_score_band) are derived
+    automatically by ``publish_to_dashboard`` from the report's
+    ``q2.e_occupancy_score`` token and don't need to be threaded through
+    here — the e-occupancy tool emits that token as part of its standard
+    output whenever it runs in the pipeline.
+    """
     if trace is None or not getattr(trace, "final_report_data", None):
         logger.info(
             "Skipping dashboard publish for %s \u2014 no final_report_data on trace",

--- a/src/due_diligence_reporter/report_schema.py
+++ b/src/due_diligence_reporter/report_schema.py
@@ -83,6 +83,64 @@ DD_RECOMMENDATION_FROM_C_ANSWER: dict[str, str] = {
     "No": "no_go",
 }
 
+# --- Phase 3: dd_site_score + band ---
+#
+# The DD site score is a 0–100 numeric derived from the
+# `apply_e_occupancy_skill` MCP tool, which lands the value on the
+# `q2.e_occupancy_score` token. The publisher promotes this to a top-level
+# `dd_site_score` field on the dashboard payload (Phase 3, Rhodes data
+# dictionary, 4/24 review).
+#
+# Band thresholds mirror the E-Occupancy Rating Bands defined in the
+# `ease-of-conversion` user skill
+# (references/site-eval-brainlift.md, lines 66–71):
+#   GREEN  80–100  Strong candidate — proceed to detailed assessment
+#   YELLOW 60– 79  Viable with known challenges — proceed with caution
+#   ORANGE 40– 59  Significant barriers — requires explicit business
+#                  justification to continue
+#   RED     0– 39  Fatal flaws likely — recommend passing
+#
+# The dashboard chip renders the band; the score itself is shown as a
+# numeric badge alongside it. Score is the source of truth — band is
+# always derived to keep the two in sync.
+ALLOWED_SITE_SCORE_BANDS: frozenset[str] = frozenset({
+    "green",
+    "yellow",
+    "orange",
+    "red",
+})
+
+SITE_SCORE_BAND_THRESHOLDS: tuple[tuple[int, str], ...] = (
+    (80, "green"),
+    (60, "yellow"),
+    (40, "orange"),
+    (0, "red"),
+)
+
+
+def site_score_band(score: int | float | None) -> str | None:
+    """Map a 0–100 numeric site score to its E-Occupancy band.
+
+    Returns one of "green" / "yellow" / "orange" / "red" for in-range
+    inputs, or None when the score is missing, NaN, or outside [0, 100].
+    The publisher uses this to derive `dd_site_score_band` from
+    `dd_site_score` whenever the caller does not supply an explicit band.
+    """
+    if score is None:
+        return None
+    try:
+        s = float(score)
+    except (TypeError, ValueError):
+        return None
+    if s != s:  # NaN check
+        return None
+    if s < 0 or s > 100:
+        return None
+    for threshold, label in SITE_SCORE_BAND_THRESHOLDS:
+        if s >= threshold:
+            return label
+    return None  # unreachable: 0 threshold catches everything in [0, 100]
+
 MISSING_P1_ASSIGNEE_LABEL = "[Not found - P1 Assignee not set in Wrike]"
 
 SCENARIOS: tuple[str, ...] = (

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -332,3 +332,135 @@ class TestDdRecommendationDerivation:
             dd_recommendation="go",
         )
         assert meta["dd_recommendation"] == "go"
+
+
+class TestDdSiteScoreDerivation:
+    """publish_to_dashboard derives dd_site_score from q2.e_occupancy_score.
+
+    The E-Occupancy tool (`apply_e_occupancy_skill`) emits a 0–100 score
+    on the `q2.e_occupancy_score` token as part of its standard output.
+    The publisher promotes this to a top-level `dd_site_score` field on
+    the dashboard payload, plus a derived `dd_site_score_band`
+    (green/yellow/orange/red).
+    """
+
+    def _capture_meta(self, report_data: dict, **publish_kwargs) -> dict:
+        """Run publish_to_dashboard with mocks; return the posted site_meta."""
+        captured: dict = {}
+
+        def fake_post(url, json, headers, timeout):
+            captured.update(json)
+            response = MagicMock()
+            response.status_code = 200
+            return response
+
+        env = {
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+            "DASHBOARD_PUBLISH_ENABLED": "1",
+        }
+        with patch.dict("os.environ", env, clear=False), \
+                patch("due_diligence_reporter.dashboard_publisher.requests.post", side_effect=fake_post):
+            publish_to_dashboard("Austin", report_data, **publish_kwargs)
+        return captured.get("site_meta", {})
+
+    @pytest.mark.parametrize(
+        ("raw_score", "expected_score", "expected_band"),
+        [
+            # GREEN 80–100
+            ("100", 100, "green"),
+            ("85", 85, "green"),
+            ("80", 80, "green"),
+            # YELLOW 60–79
+            ("79", 79, "yellow"),
+            ("70", 70, "yellow"),
+            ("60", 60, "yellow"),
+            # ORANGE 40–59
+            ("55", 55, "orange"),
+            ("40", 40, "orange"),
+            # RED 0–39
+            ("39", 39, "red"),
+            ("15", 15, "red"),
+            ("0", 0, "red"),
+        ],
+    )
+    def test_derives_score_and_band_from_q2_token(
+        self, raw_score: str, expected_score: int, expected_band: str
+    ) -> None:
+        meta = self._capture_meta({"q2.e_occupancy_score": raw_score})
+        assert meta["dd_site_score"] == expected_score
+        assert meta["dd_site_score_band"] == expected_band
+
+    def test_int_token_value_is_accepted(self) -> None:
+        # The MCP tool returns str(score), but defensive: an int should also work.
+        meta = self._capture_meta({"q2.e_occupancy_score": 75})
+        assert meta["dd_site_score"] == 75
+        assert meta["dd_site_score_band"] == "yellow"
+
+    def test_float_token_rounds_to_int(self) -> None:
+        meta = self._capture_meta({"q2.e_occupancy_score": "79.6"})
+        # 79.6 rounds to 80 — promotes the band to green.
+        assert meta["dd_site_score"] == 80
+        assert meta["dd_site_score_band"] == "green"
+
+    def test_missing_token_omits_fields(self) -> None:
+        meta = self._capture_meta({})
+        assert "dd_site_score" not in meta
+        assert "dd_site_score_band" not in meta
+
+    def test_blank_token_omits_fields(self) -> None:
+        meta = self._capture_meta({"q2.e_occupancy_score": "   "})
+        assert "dd_site_score" not in meta
+        assert "dd_site_score_band" not in meta
+
+    def test_non_numeric_token_omits_fields(self) -> None:
+        meta = self._capture_meta({"q2.e_occupancy_score": "high"})
+        assert "dd_site_score" not in meta
+        assert "dd_site_score_band" not in meta
+
+    def test_negative_score_omits_fields(self) -> None:
+        meta = self._capture_meta({"q2.e_occupancy_score": "-5"})
+        assert "dd_site_score" not in meta
+        assert "dd_site_score_band" not in meta
+
+    def test_score_above_100_omits_fields(self) -> None:
+        meta = self._capture_meta({"q2.e_occupancy_score": "150"})
+        assert "dd_site_score" not in meta
+        assert "dd_site_score_band" not in meta
+
+    def test_explicit_score_kwarg_overrides_token(self) -> None:
+        # Caller wins: report says 30 but caller passes 90.
+        meta = self._capture_meta(
+            {"q2.e_occupancy_score": "30"},
+            dd_site_score=90,
+        )
+        assert meta["dd_site_score"] == 90
+        assert meta["dd_site_score_band"] == "green"
+
+    def test_explicit_band_kwarg_overrides_derived_band(self) -> None:
+        # Caller-supplied band wins over the derived one.
+        meta = self._capture_meta(
+            {"q2.e_occupancy_score": "85"},
+            dd_site_score_band="yellow",
+        )
+        assert meta["dd_site_score"] == 85
+        assert meta["dd_site_score_band"] == "yellow"
+
+    def test_explicit_invalid_band_kwarg_falls_back_to_derived(self) -> None:
+        # Caller passes an invalid band — publisher silently drops it and
+        # keeps the derived band so the payload stays self-consistent.
+        meta = self._capture_meta(
+            {"q2.e_occupancy_score": "85"},
+            dd_site_score_band="purple",
+        )
+        assert meta["dd_site_score"] == 85
+        assert meta["dd_site_score_band"] == "green"
+
+    def test_band_only_no_score_passes_through(self) -> None:
+        # Backfill scenario: no score available, but the human reviewer
+        # already classified the band manually.
+        meta = self._capture_meta(
+            {},
+            dd_site_score_band="orange",
+        )
+        assert "dd_site_score" not in meta
+        assert meta["dd_site_score_band"] == "orange"

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -9,15 +9,18 @@ import pytest
 from due_diligence_reporter.report_schema import (
     AGENT_KEY_ALIASES,
     ALLOWED_CAN_WE_ANSWERS,
+    ALLOWED_SITE_SCORE_BANDS,
     ALLOWED_VIABLE_BUILDOUTS,
     ALLOWED_ZONING_STATUSES,
     LINK_TOKENS,
     MISSING_P1_ASSIGNEE_LABEL,
     SCHOOL_YEAR_DEADLINE,
+    SITE_SCORE_BAND_THRESHOLDS,
     TEMPLATE_TOKEN_SET,
     TEMPLATE_TOKENS,
     normalize_report_data,
     parse_open_date,
+    site_score_band,
 )
 
 
@@ -384,3 +387,69 @@ class TestPipelineToolDefinitions:
 
         tool_names = [tool["name"] for tool in TOOL_DEFINITIONS]
         assert "apply_capacity_brainlift_skill" in tool_names
+
+
+class TestSiteScoreBand:
+    """site_score_band() maps 0–100 numeric scores to E-Occupancy bands.
+
+    Bands and thresholds mirror the rubric in the ease-of-conversion user
+    skill (references/site-eval-brainlift.md, lines 66–71):
+      GREEN  80–100
+      YELLOW 60– 79
+      ORANGE 40– 59
+      RED     0– 39
+    """
+
+    def test_thresholds_constant_matches_allowed_bands(self) -> None:
+        threshold_labels = {label for _, label in SITE_SCORE_BAND_THRESHOLDS}
+        assert threshold_labels == set(ALLOWED_SITE_SCORE_BANDS)
+
+    def test_thresholds_are_descending(self) -> None:
+        # site_score_band relies on top-down threshold scanning.
+        thresholds = [t for t, _ in SITE_SCORE_BAND_THRESHOLDS]
+        assert thresholds == sorted(thresholds, reverse=True)
+
+    @pytest.mark.parametrize(
+        ("score", "expected"),
+        [
+            # GREEN range 80–100
+            (100, "green"),
+            (95, "green"),
+            (80, "green"),  # lower boundary
+            # YELLOW range 60–79
+            (79, "yellow"),  # upper boundary
+            (70, "yellow"),
+            (60, "yellow"),  # lower boundary
+            # ORANGE range 40–59
+            (59, "orange"),  # upper boundary
+            (50, "orange"),
+            (40, "orange"),  # lower boundary
+            # RED range 0–39
+            (39, "red"),  # upper boundary
+            (20, "red"),
+            (0, "red"),  # lower boundary
+        ],
+    )
+    def test_in_range_scores_map_to_band(
+        self, score: int, expected: str
+    ) -> None:
+        assert site_score_band(score) == expected
+
+    def test_float_score_at_boundary(self) -> None:
+        # Boundary precision must hold for floats too.
+        assert site_score_band(79.999) == "yellow"
+        assert site_score_band(80.0) == "green"
+
+    @pytest.mark.parametrize("score", [-1, -0.1, 100.1, 101, 200])
+    def test_out_of_range_returns_none(self, score: float) -> None:
+        assert site_score_band(score) is None
+
+    def test_none_returns_none(self) -> None:
+        assert site_score_band(None) is None
+
+    @pytest.mark.parametrize("value", ["abc", "", "50pct", object()])
+    def test_non_numeric_returns_none(self, value: object) -> None:
+        assert site_score_band(value) is None  # type: ignore[arg-type]
+
+    def test_nan_returns_none(self) -> None:
+        assert site_score_band(float("nan")) is None


### PR DESCRIPTION
## Summary

Phase 3 of #17 — wires the existing `q2.e_occupancy_score` token through to the dashboard as `dd_site_score` (numeric 0–100) + `dd_site_score_band` (color chip).

## What's new

- **`report_schema.py`** — `ALLOWED_SITE_SCORE_BANDS`, `SITE_SCORE_BAND_THRESHOLDS`, and `site_score_band(score)` helper. Bands match the `ease-of-conversion` skill's E-Occupancy Rating Bands:
  - `green` 80–100
  - `yellow` 60–79
  - `orange` 40–59
  - `red` 0–39
- **`dashboard_publisher.py`** — `build_site_meta` and `publish_to_dashboard` accept `dd_site_score` / `dd_site_score_band` kwargs. When omitted, both auto-derive from `report_data['q2.e_occupancy_score']` (the value `apply_e_occupancy_skill` already emits — no upstream code changes needed).
  - **Caller-wins** for explicit overrides (mirrors Phase 2 `dd_recommendation`).
  - **Score is the source of truth; band always derived from score.** An explicit band that's invalid (or doesn't match its score) is silently dropped and the derived band wins. Backfill-only callers can pass band without score.
- **`report_pipeline.py`** — docstring note on `_publish_to_dashboard_best_effort` clarifying these fields are publisher-derived, no plumb-through needed.
- **Docs** — `prompt_v2.md` and `HOW-IT-WORKS.md` both document the publisher-side derivation (mirrors how Phase 2 documented `dd_recommendation`).

## Tests

+48 new tests across two classes:
- `TestSiteScoreBand` (16) — thresholds, in-range bands w/ boundaries, float boundary, out-of-range, None, non-numeric, NaN.
- `TestDdSiteScoreDerivation` (32) — parametrized score→band, int/float input, missing/blank/non-numeric/negative/over-100, explicit overrides, invalid band fallback, band-only backfill.

Full suite: **610 passed** (was 562, +48).

## Backward compatibility

- Reporter omits the field entirely when score is missing/invalid; dashboard sticky-preserve keeps the prior value across republish.
- All existing callers continue to work — these are pure additions.

## Follow-ups (separate PRs)

- Pipeline skill: `v3-token-map.md` publisher row + `SKILL.md` note on `apply_e_occupancy_skill` upstream requirement.
- Dashboard: `dd_site_score` + band on `PipelineSiteMeta` / `DashboardSite`, sortable Portfolio column with band-colored chip.
- Risk-flag design doc on #17 (Phase 3 second deliverable).

Refs: #17
