### PR TITLE
feat(ddr-migration): Phase A5 - DASHBOARD_PUBLISH_OWNER cutover flag

### DIFF
--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -17,6 +17,16 @@ Environment:
                               https://dd-dashboard-three.vercel.app)
     DASHBOARD_PUBLISH_SECRET  Bearer token (must match Vercel env var)
     DASHBOARD_PUBLISH_ENABLED Set to "0" to disable publishing entirely.
+    DASHBOARD_PUBLISH_OWNER   Cutover flag for the DDR → DD Pipeline
+                              migration (Phase A5). Values:
+                                "reporter" — (default) reporter publishes
+                                  as it always has.
+                                "pipeline" — the alpha-dd-pipeline WU-15
+                                  is the sole publisher; the reporter
+                                  short-circuits its POST to avoid double
+                                  writes during cutover.
+                              The flag is read on every call so an operator
+                              can flip ownership live without redeploying.
 """
 
 from __future__ import annotations
@@ -322,9 +332,24 @@ def publish_to_dashboard(
 ) -> bool:
     """Publish one site's report_data to the dashboard.
 
-    Returns True on HTTP 200, False otherwise (including disabled or
-    missing-secret cases).
+    Returns True on HTTP 200, False otherwise (including disabled,
+    missing-secret, or pipeline-owns-this-hop cutover cases).
     """
+    # Phase A5 cutover: when DASHBOARD_PUBLISH_OWNER=pipeline, the
+    # alpha-dd-pipeline WU-15 is the sole publisher. Short-circuit before
+    # any other work so reruns and backfills both honor the flag uniformly,
+    # and so the reporter's call sites don't need to know who's currently
+    # in charge. Default "reporter" preserves legacy behavior until soak
+    # passes; "pipeline" is the only value that disables the POST.
+    owner = os.environ.get("DASHBOARD_PUBLISH_OWNER", "reporter").strip().lower()
+    if owner == "pipeline":
+        logger.info(
+            "DASHBOARD_PUBLISH_OWNER=pipeline; reporter is yielding dashboard "
+            "publish to alpha-dd-pipeline WU-15 for %s",
+            site_title,
+        )
+        return False
+
     if os.environ.get("DASHBOARD_PUBLISH_ENABLED", "1") == "0":
         logger.info("Dashboard publish disabled via env; skipping %s", site_title)
         return False

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -587,3 +587,141 @@ class TestDdRiskFlagsDerivation:
         flags = meta["dd_risk_flags"]
         assert len(flags) == 1
         assert flags[0]["category"] == "occupancy"
+
+
+class TestDashboardPublishOwnerCutover:
+    """Phase A5 cutover flag: DASHBOARD_PUBLISH_OWNER gates the POST.
+
+    The reporter must keep publishing by default and yield to the pipeline
+    only when an operator explicitly flips ownership. The flag is read on
+    every call — not cached — so the flip is live, no redeploy required.
+    """
+
+    @staticmethod
+    def _run(env: dict[str, str]) -> tuple[bool, MagicMock]:
+        """Run publish_to_dashboard under ``env`` and return (returned, post_mock)."""
+        post_mock = MagicMock()
+        post_mock.return_value.status_code = 200
+        with patch.dict("os.environ", env, clear=False), patch(
+            "due_diligence_reporter.dashboard_publisher.requests.post",
+            new=post_mock,
+        ):
+            returned = publish_to_dashboard(
+                "Austin",
+                {"exec.c_answer": "Yes"},
+                address="123 Main St, Austin, TX 78701",
+            )
+        return returned, post_mock
+
+    def test_owner_pipeline_short_circuits_without_post(self) -> None:
+        """owner=pipeline → returns False, no HTTP call, no secret needed."""
+        returned, post_mock = self._run({
+            "DASHBOARD_PUBLISH_OWNER": "pipeline",
+            # Secret + enabled set so we know the cutover gate is what's
+            # short-circuiting, not one of the legacy gates.
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+            "DASHBOARD_PUBLISH_ENABLED": "1",
+        })
+        assert returned is False
+        post_mock.assert_not_called()
+
+    def test_owner_pipeline_is_case_insensitive(self) -> None:
+        """Operators frequently mis-case env values; tolerate it."""
+        for value in ("PIPELINE", "Pipeline", "  pipeline  "):
+            returned, post_mock = self._run({
+                "DASHBOARD_PUBLISH_OWNER": value,
+                "DASHBOARD_PUBLISH_SECRET": "test-secret",
+                "DASHBOARD_PUBLISH_ENABLED": "1",
+            })
+            assert returned is False, f"value={value!r} should short-circuit"
+            post_mock.assert_not_called()
+
+    def test_owner_reporter_publishes_normally(self) -> None:
+        """owner=reporter (the default) preserves legacy behavior."""
+        returned, post_mock = self._run({
+            "DASHBOARD_PUBLISH_OWNER": "reporter",
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+            "DASHBOARD_PUBLISH_ENABLED": "1",
+        })
+        assert returned is True
+        post_mock.assert_called_once()
+
+    def test_owner_unset_publishes_normally(self) -> None:
+        """Default (env unset) must behave exactly like ``reporter``.
+
+        Critical for the rollout: deploying the cutover code without
+        setting the env must not change current production behavior.
+        """
+        # Use clear=True to ensure the env var is unset for this test even
+        # if it leaks from the host environment.
+        post_mock = MagicMock()
+        post_mock.return_value.status_code = 200
+        with patch.dict(
+            "os.environ",
+            {
+                "DASHBOARD_PUBLISH_SECRET": "test-secret",
+                "DASHBOARD_PUBLISH_ENABLED": "1",
+            },
+            clear=True,
+        ), patch(
+            "due_diligence_reporter.dashboard_publisher.requests.post",
+            new=post_mock,
+        ):
+            returned = publish_to_dashboard(
+                "Austin",
+                {"exec.c_answer": "Yes"},
+                address="123 Main St, Austin, TX 78701",
+            )
+        assert returned is True
+        post_mock.assert_called_once()
+
+    def test_unknown_owner_value_publishes_normally(self) -> None:
+        """Unrecognized values are treated as ``reporter`` (fail-safe to legacy).
+
+        We never want a typo on the env var to silently kill publishing.
+        Only the literal string ``pipeline`` (case-insensitive) yields.
+        """
+        returned, post_mock = self._run({
+            "DASHBOARD_PUBLISH_OWNER": "pipline",  # typo
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+            "DASHBOARD_PUBLISH_ENABLED": "1",
+        })
+        assert returned is True
+        post_mock.assert_called_once()
+
+    def test_owner_pipeline_takes_precedence_over_enabled(self) -> None:
+        """owner=pipeline short-circuits before the ENABLED check, so the
+        end state is identical regardless of which flag is set first."""
+        returned, post_mock = self._run({
+            "DASHBOARD_PUBLISH_OWNER": "pipeline",
+            "DASHBOARD_PUBLISH_ENABLED": "0",
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+        })
+        assert returned is False
+        post_mock.assert_not_called()
+
+    def test_owner_pipeline_takes_precedence_over_missing_secret(self) -> None:
+        """owner=pipeline must short-circuit even with no secret configured.
+
+        Operators flipping to pipeline ownership often delete the secret
+        from the reporter's env at the same time — we should not raise
+        or warn about that.
+        """
+        # Use clear=True so a host-level DASHBOARD_PUBLISH_SECRET can't
+        # leak in and turn this into a missing-secret-path test.
+        post_mock = MagicMock()
+        with patch.dict(
+            "os.environ",
+            {"DASHBOARD_PUBLISH_OWNER": "pipeline"},
+            clear=True,
+        ), patch(
+            "due_diligence_reporter.dashboard_publisher.requests.post",
+            new=post_mock,
+        ):
+            returned = publish_to_dashboard(
+                "Austin",
+                {"exec.c_answer": "Yes"},
+                address="123 Main St, Austin, TX 78701",
+            )
+        assert returned is False
+        post_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Phase A5 of the DDR → DD Pipeline migration. Adds the reporter half of the cutover. The flag gates the POST inside `publish_to_dashboard()` at the single chokepoint that both call sites (`report_pipeline.py` and `scripts/backfill_dashboard.py`) flow through, so reruns and backfills both honor it uniformly.

Refs **EDU-Ops-Team/alpha-dd-pipeline#7** and **#8**.

## Behavior

| `DASHBOARD_PUBLISH_OWNER` | Reporter behavior | When to use |
|---|---|---|
| (unset) | Publish (legacy) | Production today, until soak passes |
| `reporter` | Publish (legacy) | Explicit legacy; same as unset |
| `pipeline` | Short-circuit (no POST, no warnings) | Cutover — alpha-dd-pipeline WU-15 owns the hop |
| Unknown value | Publish (fail-safe to legacy) | A typo must never silently kill publishing |

The flag is read on **every call**, not cached at import — so the flip is live and rollback is one env-var change away, no redeploy required.

When `pipeline` is set, the gate runs **before** the existing `DASHBOARD_PUBLISH_ENABLED` and `DASHBOARD_PUBLISH_SECRET` checks. Operators flipping ownership often delete the secret at the same time; that path no longer logs warnings.

## Safety properties

- **Deploying this code without setting the env var changes nothing in production.** Default is `reporter`.
- **Match is case-insensitive and whitespace-tolerant** (`PIPELINE`, `Pipeline`, `  pipeline  ` all work). Operators frequently mis-case env values; tolerate it.
- **Unknown values fail safe to legacy.** Only the literal string `pipeline` (case-insensitive) yields. A typo (`pipline`) keeps publishing.
- **Single chokepoint.** Call sites don't need to know who's currently in charge.

## Test results

```
tests/test_dashboard_publisher.py: 69/69 ✅
  - 62 pre-existing tests still passing
  - 7 new tests in TestDashboardPublishOwnerCutover:
    • test_owner_pipeline_short_circuits_without_post
    • test_owner_pipeline_is_case_insensitive
    • test_owner_reporter_publishes_normally
    • test_owner_unset_publishes_normally
    • test_unknown_owner_value_publishes_normally
    • test_owner_pipeline_takes_precedence_over_enabled
    • test_owner_pipeline_takes_precedence_over_missing_secret

Full repo: 686 passed (3 pre-existing failures in test_permit_history.py
unchanged from main, unrelated to this PR — _build_report_trace_data
signature drift).
```

## Rollout plan

1. Merge this PR. Default unchanged → no production impact.
2. Merge alpha-dd-pipeline #14 (WU-15 implementation) and #15 (env docs). Wire the WU-15 entry into the pipeline orchestrator with the dashboard secret configured on the pipeline side.
3. Soak: confirm WU-15 publishes successfully on a few real runs (verify `dashboard_publish_receipt` lands in Sindri with `status=published` and the dashboard's `sites.json` updates).
4. Flip: `DASHBOARD_PUBLISH_OWNER=pipeline` on the reporter. Reporter yields immediately on the next run.
5. If anything goes sideways: unset the env var. Reporter resumes publishing on the next run.