### PR TITLE
Add DD_REPORT_OWNER cutover flag (Phase B-PR3)

### DIFF
--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -593,7 +593,7 @@ class PipelineResult:
     """Structured result from a single-site pipeline run."""
 
     site_title: str
-    status: str  # waiting_on_docs | report_exists | report_created | report_incomplete | generation_failed | error
+    status: str  # waiting_on_docs | report_exists | report_created | report_incomplete | generation_failed | error | yielded_to_pipeline
     missing_docs: list[str] = field(default_factory=list)
     doc_id: str | None = None
     doc_url: str | None = None
@@ -894,6 +894,26 @@ def _run_pipeline_agent(
     settings: Settings,
 ) -> tuple[dict[str, Any] | None, PipelineResult | None]:
     """Run report generation and map failures into a PipelineResult."""
+    # Phase B-PR3 cutover: when DD_REPORT_OWNER=pipeline, the
+    # alpha-dd-pipeline WU-13 is the sole DD-report producer. Short-circuit
+    # before any agent work so reruns and backfills both honor the flag
+    # uniformly. We yield a distinct status ("yielded_to_pipeline") so the
+    # caller can skip the dashboard publish + email/trace side effects that
+    # the Anthropic agent would normally feed. Default "reporter" preserves
+    # legacy behavior until soak passes; "pipeline" is the only value that
+    # disables the agent run. Mirrors DASHBOARD_PUBLISH_OWNER (Phase A5).
+    owner = os.environ.get("DD_REPORT_OWNER", "reporter").strip().lower()
+    if owner == "pipeline":
+        logger.info(
+            "DD_REPORT_OWNER=pipeline; reporter is yielding DD-report "
+            "generation to alpha-dd-pipeline WU-13 for %s",
+            site_title,
+        )
+        return None, PipelineResult(
+            site_title=site_title,
+            status="yielded_to_pipeline",
+        )
+
     logger.info("'%s' - all docs present, generating report...", site_title)
     try:
         agent_result = run_dd_report_agent(

--- a/tests/test_dd_report_owner_cutover.py
+++ b/tests/test_dd_report_owner_cutover.py
@@ -1,0 +1,127 @@
+"""Tests for the DD_REPORT_OWNER cutover flag.
+
+Phase B-PR3 of the DDR -> DD Pipeline migration. Mirrors the existing
+``DASHBOARD_PUBLISH_OWNER`` flag (Phase A5) one-to-one — the reporter
+must keep generating DD reports by default and only yield to the
+alpha-dd-pipeline WU-13 when an operator explicitly flips ownership.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from due_diligence_reporter.report_pipeline import (
+    PipelineResult,
+    _run_pipeline_agent,
+)
+
+
+class TestDdReportOwnerCutover:
+    """The flag is read on every call (not cached) so a flip is live."""
+
+    @staticmethod
+    def _run(env: dict[str, str]) -> tuple[
+        dict[str, object] | None,
+        PipelineResult | None,
+        object,
+    ]:
+        """Run ``_run_pipeline_agent`` under ``env``.
+
+        Returns ``(agent_result, pipeline_result, run_dd_mock)`` so callers
+        can assert both the function's return value and whether the
+        Anthropic-backed agent was invoked.
+        """
+        with patch.dict("os.environ", env, clear=False), patch(
+            "due_diligence_reporter.report_pipeline.run_dd_report_agent",
+        ) as run_dd_mock:
+            run_dd_mock.return_value = {
+                "success": True,
+                "doc_id": "doc-123",
+                "doc_url": "https://docs.google.com/document/d/doc-123",
+                "trace": None,
+            }
+            settings = type("S", (), {"anthropic_report_model": "claude-test"})()
+            agent_result, pipeline_result = _run_pipeline_agent(
+                "Acme Boca Raton 2200",
+                "system prompt",
+                settings,  # type: ignore[arg-type]
+            )
+        return agent_result, pipeline_result, run_dd_mock
+
+    def test_owner_pipeline_short_circuits_without_invoking_agent(self) -> None:
+        """owner=pipeline → ``yielded_to_pipeline`` result, no agent call."""
+        agent_result, pipeline_result, run_dd_mock = self._run(
+            {"DD_REPORT_OWNER": "pipeline"},
+        )
+        assert agent_result is None
+        assert pipeline_result is not None
+        assert pipeline_result.status == "yielded_to_pipeline"
+        assert pipeline_result.site_title == "Acme Boca Raton 2200"
+        run_dd_mock.assert_not_called()
+
+    def test_owner_pipeline_is_case_and_whitespace_tolerant(self) -> None:
+        """Operators frequently mis-case or pad env values; tolerate it.
+
+        Mirrors the DASHBOARD_PUBLISH_OWNER policy so cross-flag behavior
+        is identical and operators can flip both flags from the same
+        runbook without separate normalization rules.
+        """
+        for value in ("PIPELINE", "Pipeline", "  pipeline  ", "pipeline\n"):
+            agent_result, pipeline_result, run_dd_mock = self._run(
+                {"DD_REPORT_OWNER": value},
+            )
+            assert agent_result is None, f"value={value!r} should short-circuit"
+            assert pipeline_result is not None
+            assert pipeline_result.status == "yielded_to_pipeline", (
+                f"value={value!r} should yield"
+            )
+            run_dd_mock.assert_not_called()
+
+    def test_owner_unset_runs_agent_normally(self) -> None:
+        """Default (env unset) must behave exactly like ``reporter``.
+
+        Critical for rollout: deploying the cutover code WITHOUT setting
+        the env var must not change current production behavior.
+        """
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "due_diligence_reporter.report_pipeline.run_dd_report_agent",
+        ) as run_dd_mock:
+            run_dd_mock.return_value = {
+                "success": True,
+                "doc_id": "doc-456",
+                "doc_url": "https://docs.google.com/document/d/doc-456",
+                "trace": None,
+            }
+            settings = type("S", (), {"anthropic_report_model": "claude-test"})()
+            agent_result, pipeline_result = _run_pipeline_agent(
+                "Acme Boca Raton 2200",
+                "system prompt",
+                settings,  # type: ignore[arg-type]
+            )
+        assert pipeline_result is None
+        assert agent_result is not None
+        assert agent_result["doc_id"] == "doc-456"
+        run_dd_mock.assert_called_once()
+
+    def test_owner_reporter_explicit_runs_agent_normally(self) -> None:
+        """owner=reporter (explicit) preserves legacy behavior."""
+        agent_result, pipeline_result, run_dd_mock = self._run(
+            {"DD_REPORT_OWNER": "reporter"},
+        )
+        assert pipeline_result is None
+        assert agent_result is not None
+        assert agent_result["doc_id"] == "doc-123"
+        run_dd_mock.assert_called_once()
+
+    def test_unknown_owner_value_runs_agent_normally(self) -> None:
+        """Unrecognized values are treated as ``reporter`` (fail-safe).
+
+        We never want a typo on the env var to silently kill DD-report
+        generation. Only the literal string ``pipeline`` (case-insensitive,
+        whitespace-tolerant) yields.
+        """
+        agent_result, pipeline_result, run_dd_mock = self._run(
+            {"DD_REPORT_OWNER": "pipline"},  # typo
+        )
+        assert pipeline_result is None
+        assert agent_result is not None
+        run_dd_mock.assert_called_once()


### PR DESCRIPTION
## Add DD_REPORT_OWNER cutover flag (Phase B-PR3)

Mirror of the existing `DASHBOARD_PUBLISH_OWNER` flag (Phase A5) for the DD-report generation hop. Lets the alpha-dd-pipeline WU-13 orchestrator own DD-report production end-to-end during the Phase C cutover.

### What changed

**`src/due_diligence_reporter/report_pipeline.py`**

- `_run_pipeline_agent(...)` now reads `DD_REPORT_OWNER` (default `reporter`) at the top of the function and short-circuits before any Anthropic agent work when the value is `pipeline`.
- Returns a new `PipelineResult` status — `yielded_to_pipeline` — so the caller (`_run_site_pipeline`) can skip the dashboard-publish, trace-save, and email side effects that would normally feed off the agent's output. (`generation_result is not None` already routes to an early return today, so no caller changes are needed.)

**`PipelineResult.status` docstring** updated to enumerate the new variant.

### Behavior contract

Mirrors `DASHBOARD_PUBLISH_OWNER` one-to-one so cross-flag operations are interchangeable:

- Default (env unset) → behaves exactly like `reporter`.
- `pipeline` → yields. Case-insensitive (`PIPELINE`, `Pipeline`), whitespace-tolerant (`  pipeline\n`).
- Any other value (typo, blank-but-set, etc.) → fail-safe to `reporter`. Never silently kill report generation.

### Tests

**New: `tests/test_dd_report_owner_cutover.py`** (5 cases):

1. `test_owner_pipeline_short_circuits_without_invoking_agent` — `pipeline` → no agent call, `status="yielded_to_pipeline"`
2. `test_owner_pipeline_is_case_and_whitespace_tolerant` — 4 variants all yield
3. `test_owner_unset_runs_agent_normally` — env unset preserves legacy
4. `test_owner_reporter_explicit_runs_agent_normally` — `reporter` preserves legacy
5. `test_unknown_owner_value_runs_agent_normally` — typo (`pipline`) fails safe

```
$ PYTHONPATH=src python -m pytest tests/test_dd_report_owner_cutover.py -v
============== 5 passed in 1.02s ==============
```

**No regressions in existing tests:**

```
$ PYTHONPATH=src python -m pytest tests/test_report_pipeline.py
============== 22 passed in 1.56s ==============
```

### Cutover sequence (operator runbook)

The two flags must be flipped together to keep state consistent — there is no automated cross-flag invariant check (called out in alpha-dd-pipeline CLAUDE.md as a manual-invariant). Recommended order during Phase C:

1. Verify pipeline-side production health (dashboard records and DD reports both arriving from WU-15 / WU-13 in shadow mode).
2. Set `DASHBOARD_PUBLISH_OWNER=pipeline` AND `DD_REPORT_OWNER=pipeline` in the reporter's env at the same deploy.
3. Soak ≤ 2 weeks. If issues, unset both flags to revert atomically.
4. After soak, archive the reporter (Phase C step).

### Related

- Pipeline-side PR: alpha-dd-pipeline#19 (the orchestrator that takes over)
- Tracking: alpha-dd-pipeline#9 (Phase B)
- Mirrors: `DASHBOARD_PUBLISH_OWNER` flag added in Phase A5 (already in production)
