### PR TITLE
Fix DDR timeline calculation and reruns

### DIFF
--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -734,30 +734,50 @@ def _extract_raycon_scenario(
     card_label_hint: str,
 ) -> dict[str, Any]:
     """Extract one scenario from RayCon structured output with card fallback."""
-    structured = response_data.get("structured", {})
-    scenario = structured.get(scenario_key)
-    if isinstance(scenario, dict):
-        return scenario
     cards = response_data.get("estimate_cards", {}).get("cards", [])
+    matching_card: dict[str, Any] | None = None
     for card in cards:
         label = str(card.get("label", "")).lower()
         if card_label_hint in label:
-            timeline = card.get("timeline", {})
-            return {
-                "categories": card.get("costBreakdown", []),
-                "grandTotal": card.get("totals", {}).get("grandTotal", 0),
-                "softCosts": card.get("totals", {}).get("softCosts", 0),
-                "gcFee": card.get("totals", {}).get("gcFee", 0),
-                "contingency": card.get("totals", {}).get("contingency", 0),
-                "furniture": card.get("totals", {}).get("furniture", 0),
-                "timelineWeeks": timeline.get("weeks") if isinstance(timeline, dict) else None,
-                "timelineNote": timeline.get("note", "") if isinstance(timeline, dict) else "",
-            }
+            matching_card = card
+            break
+
+    structured = response_data.get("structured", {})
+    scenario = structured.get(scenario_key)
+    if isinstance(scenario, dict):
+        merged = dict(scenario)
+        if matching_card:
+            timeline = matching_card.get("timeline", {})
+            if isinstance(timeline, dict):
+                weeks = timeline.get("weeks")
+                if isinstance(weeks, (int, float)) and weeks > 0:
+                    merged["estimateCardTimelineWeeks"] = int(weeks)
+                note = str(timeline.get("note", "")).strip()
+                if note:
+                    merged["estimateCardTimelineNote"] = note
+        return merged
+    if matching_card:
+        timeline = matching_card.get("timeline", {})
+        return {
+            "categories": matching_card.get("costBreakdown", []),
+            "grandTotal": matching_card.get("totals", {}).get("grandTotal", 0),
+            "softCosts": matching_card.get("totals", {}).get("softCosts", 0),
+            "gcFee": matching_card.get("totals", {}).get("gcFee", 0),
+            "contingency": matching_card.get("totals", {}).get("contingency", 0),
+            "furniture": matching_card.get("totals", {}).get("furniture", 0),
+            "timelineWeeks": timeline.get("weeks") if isinstance(timeline, dict) else None,
+            "timelineNote": timeline.get("note", "") if isinstance(timeline, dict) else "",
+            "estimateCardTimelineWeeks": timeline.get("weeks") if isinstance(timeline, dict) else None,
+            "estimateCardTimelineNote": timeline.get("note", "") if isinstance(timeline, dict) else "",
+        }
     return {}
 
 
 def _extract_raycon_timeline_weeks(scenario_data: dict[str, Any]) -> int | None:
     """Return an integer timeline week estimate from a RayCon scenario."""
+    estimate_card_weeks = scenario_data.get("estimateCardTimelineWeeks")
+    if isinstance(estimate_card_weeks, (int, float)) and estimate_card_weeks > 0:
+        return int(estimate_card_weeks)
     for key in ("timelineWeeks", "timeline_weeks"):
         value = scenario_data.get(key)
         if isinstance(value, (int, float)) and value > 0:
@@ -775,6 +795,34 @@ def _weeks_to_open_date(weeks: int | None) -> str:
     if weeks is None or weeks <= 0:
         return ""
     return (datetime.now() + timedelta(weeks=weeks)).strftime("%m/%d/%y")
+
+
+def _clear_document_body(
+    gc: GoogleClient,
+    *,
+    doc_id: str,
+) -> None:
+    """Delete all body content from an existing Google Doc before rebuilding it."""
+    doc = gc.docs_service.documents().get(documentId=doc_id).execute()
+    body_content = doc.get("body", {}).get("content", [])
+    if not body_content:
+        return
+    end_index = int(body_content[-1].get("endIndex", 1))
+    if end_index <= 2:
+        return
+    gc.docs_service.documents().batchUpdate(
+        documentId=doc_id,
+        body={
+            "requests": [{
+                "deleteContentRange": {
+                    "range": {
+                        "startIndex": 1,
+                        "endIndex": end_index - 1,
+                    }
+                }
+            }]
+        },
+    ).execute()
 
 
 def _match_breakdown_bucket(category_name: str) -> str:
@@ -3296,36 +3344,28 @@ async def create_dd_report(
         try:
             gc = _make_google_client()
             existing_doc = _find_existing_report_doc(gc, folder_id=folder_id, doc_name=doc_name)
+            doc_id: str | None = None
+            doc_url: str | None = None
             if existing_doc:
                 existing_doc_id = existing_doc.get("id")
-                existing_doc_url = existing_doc.get("webViewLink")
-                logger.info("Existing DD report found, reusing: %s (id=%s)", doc_name, existing_doc_id)
-                return {
-                    "status": "success",
-                    "document": {
-                        "id": existing_doc_id,
-                        "name": doc_name,
-                        "url": existing_doc_url,
-                    },
-                    "replacements_applied": 0,
-                    "unmatched_agent_keys": 0,
-                    "unfilled_template_tokens": 0,
-                    "hyperlinks_applied": 0,
-                    "message": f"DD report already exists: {existing_doc_url}",
-                }
-
-            logger.info("Creating blank document in folder %s as '%s'", folder_id, doc_name)
-            new_doc = gc.create_document(
-                name=doc_name,
-                folder_id=folder_id,
-                text_content="",
-            )
-            doc_id = new_doc.get("id")
-            doc_url = new_doc.get("webViewLink")
-            if not doc_id or not isinstance(doc_id, str):
-                raise RuntimeError("Invalid document ID returned from create operation")
-
-            logger.info("Created blank document: %s (id=%s)", doc_name, doc_id)
+                if not isinstance(existing_doc_id, str) or not existing_doc_id:
+                    raise RuntimeError(f"Existing DD report is missing a valid document ID: {doc_name}")
+                doc_id = existing_doc_id
+                doc_url = existing_doc.get("webViewLink")
+                logger.info("Existing DD report found, rebuilding in place: %s (id=%s)", doc_name, doc_id)
+                _clear_document_body(gc, doc_id=doc_id)
+            else:
+                logger.info("Creating blank document in folder %s as '%s'", folder_id, doc_name)
+                new_doc = gc.create_document(
+                    name=doc_name,
+                    folder_id=folder_id,
+                    text_content="",
+                )
+                doc_id = new_doc.get("id")
+                doc_url = new_doc.get("webViewLink")
+                if not doc_id or not isinstance(doc_id, str):
+                    raise RuntimeError("Invalid document ID returned from create operation")
+                logger.info("Created blank document: %s (id=%s)", doc_name, doc_id)
             replacements, unmatched, unfilled, _token_sources, rebl_resolution = _normalize_report_replacements(
                 report_data=report_data,
                 site_name=site_name.strip(),
@@ -3433,7 +3473,7 @@ async def create_dd_report(
                 "unfilled_template_tokens": len(unfilled),
                 "hyperlinks_applied": hyperlink_trace["applied"],
                 "normalized_report_data": replacements,
-                "message": f"DD report created: {doc_url}",
+                "message": f"DD report built: {doc_url}",
             }
             if dashboard_payload is not None:
                 response["dashboard_payload"] = {

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -857,6 +857,63 @@ class TestAsyncOffloading:
         assert "exec.cost_grand_total_max_value" not in result["report_data_fields"]
         mock_to_thread.assert_awaited_once()
 
+    def test_get_cost_estimate_prefers_total_timeline_from_estimate_card(self) -> None:
+        from datetime import datetime as real_datetime
+
+        from due_diligence_reporter.server import get_cost_estimate
+
+        async def run_inline(func: Any, *args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        with patch(
+            "due_diligence_reporter.server.asyncio.to_thread",
+            new=AsyncMock(side_effect=run_inline),
+        ), patch(
+            "due_diligence_reporter.server._call_raycon_api",
+            return_value={
+                "structured": {
+                    "costs_mvp": {
+                        "grandTotal": 86000,
+                        "timelineWeeks": 4,
+                        "categories": [],
+                    },
+                    "costs_ideal": {
+                        "grandTotal": 245000,
+                        "timelineWeeks": 8,
+                        "categories": [],
+                    },
+                },
+                "estimate_cards": {
+                    "cards": [
+                        {
+                            "label": "Fastest Open (MVP - As-Is + Code)",
+                            "timeline": {
+                                "weeks": 24,
+                                "note": "16 weeks permitting + 8 weeks construction",
+                            },
+                        },
+                        {
+                            "label": "Max Capacity (Ideal - Purpose-Built School)",
+                            "timeline": {
+                                "weeks": 28,
+                                "note": "16 weeks permitting + 12 weeks construction",
+                            },
+                        },
+                    ],
+                },
+            },
+        ), patch(
+            "due_diligence_reporter.server.datetime",
+        ) as mock_datetime:
+            mock_datetime.now.return_value = real_datetime(2026, 4, 27)
+            result = asyncio.run(get_cost_estimate(total_building_sf=1000, classroom_count=2))
+
+        assert result["status"] == "success"
+        assert result["timeline_summary"]["fastest_open_weeks"] == 24
+        assert result["timeline_summary"]["max_capacity_weeks"] == 28
+        assert result["report_data_fields"]["exec.fastest_open_open_date"] == "10/12/26"
+        assert result["report_data_fields"]["exec.max_capacity_open_date"] == "11/09/26"
+
     def test_save_skill_report_uses_to_thread(self) -> None:
         from due_diligence_reporter.server import save_skill_report
 
@@ -906,8 +963,8 @@ class TestAsyncOffloading:
             "due_diligence_reporter.server._make_google_client",
             return_value=gc,
         ), patch(
-            "due_diligence_reporter.server.normalize_report_data",
-            return_value=({}, [], [], {}),
+            "due_diligence_reporter.server._normalize_report_replacements",
+            return_value=({}, [], [], {}, MagicMock()),
         ), patch(
             "due_diligence_reporter.server.build_dd_report_doc",
             return_value={"applied": 0, "found_tokens": [], "not_found_tokens": []},
@@ -922,7 +979,7 @@ class TestAsyncOffloading:
         gc.create_document.assert_called_once()
         mock_to_thread.assert_awaited_once()
 
-    def test_create_dd_report_reuses_existing_same_day_doc(self) -> None:
+    def test_create_dd_report_rebuilds_existing_same_day_doc(self) -> None:
         from due_diligence_reporter.server import create_dd_report
 
         gc = MagicMock()
@@ -931,6 +988,9 @@ class TestAsyncOffloading:
             "name": "Alpha DD Report - 04/02/2026",
             "webViewLink": "https://docs.google.com/document/d/doc-existing",
         }]
+        gc.docs_service = MagicMock()
+        gc.drive_service = MagicMock()
+        gc.upload_file_to_folder.return_value = {"webViewLink": ""}
 
         async def run_inline(func: Any, *args: Any, **kwargs: Any) -> Any:
             return func(*args, **kwargs)
@@ -942,8 +1002,16 @@ class TestAsyncOffloading:
             "due_diligence_reporter.server._make_google_client",
             return_value=gc,
         ), patch(
+            "due_diligence_reporter.server._clear_document_body",
+        ) as mock_clear, patch(
             "due_diligence_reporter.server.datetime",
-        ) as mock_datetime:
+        ) as mock_datetime, patch(
+            "due_diligence_reporter.server._normalize_report_replacements",
+            return_value=({}, [], [], {}, MagicMock()),
+        ), patch(
+            "due_diligence_reporter.server.build_dd_report_doc",
+            return_value={"applied": 0, "found_tokens": [], "not_found_tokens": []},
+        ):
             mock_datetime.now.return_value.strftime.return_value = "04/02/2026"
             result = asyncio.run(create_dd_report(
                 site_name="Alpha",
@@ -954,5 +1022,6 @@ class TestAsyncOffloading:
         assert result["status"] == "success"
         assert result["document"]["id"] == "doc-existing"
         gc.create_document.assert_not_called()
+        mock_clear.assert_called_once_with(gc, doc_id="doc-existing")
 
 

--- a/tests/test_raycon_costs.py
+++ b/tests/test_raycon_costs.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from due_diligence_reporter.server import (
     _build_breakdown_fields,
     _build_raycon_request_payload,
+    _extract_raycon_scenario,
+    _extract_raycon_timeline_weeks,
     _read_raycon_done_event,
 )
 
@@ -80,4 +82,42 @@ def test_build_raycon_request_payload_includes_source_documents() -> None:
     assert payload["drive_doc_summaries"]["inspection"] == "BUILDING INSPECTION FULL TEXT"
     assert payload["drive_doc_summaries"]["sir"] == "SIR FULL TEXT"
     assert payload["drive_doc_summaries"]["block_plan"] == "BLOCK PLAN FULL TEXT"
+
+
+def test_extract_raycon_scenario_merges_matching_estimate_card_timeline() -> None:
+    scenario = _extract_raycon_scenario(
+        {
+            "structured": {
+                "costs_mvp": {
+                    "grandTotal": 123000,
+                    "timelineWeeks": 4,
+                },
+            },
+            "estimate_cards": {
+                "cards": [{
+                    "label": "Fastest Open (MVP - As-Is + Code)",
+                    "timeline": {
+                        "weeks": 24,
+                        "note": "16 weeks permitting + 8 weeks construction",
+                    },
+                }],
+            },
+        },
+        "costs_mvp",
+        "mvp",
+    )
+
+    assert scenario["grandTotal"] == 123000
+    assert scenario["timelineWeeks"] == 4
+    assert scenario["estimateCardTimelineWeeks"] == 24
+    assert scenario["estimateCardTimelineNote"] == "16 weeks permitting + 8 weeks construction"
+
+
+def test_extract_raycon_timeline_weeks_prefers_total_card_timeline() -> None:
+    weeks = _extract_raycon_timeline_weeks({
+        "timelineWeeks": 4,
+        "estimateCardTimelineWeeks": 24,
+    })
+
+    assert weeks == 24
 


### PR DESCRIPTION
Use RayCon estimate-card total schedule weeks when they are available so open dates reflect permit plus construction time instead of construction-only weeks.

Rebuild an existing same-day DD report in place rather than silently reusing stale document content, and cover both behaviors with regression tests.