### PR TITLE
fix(ci): plumb DASHBOARD_PUBLISH_SECRET so scans actually update the dashboard

### DIFF
--- a/.github/workflows/daily-dd-check.yml
+++ b/.github/workflows/daily-dd-check.yml
@@ -48,6 +48,7 @@ jobs:
           [ -n "${{ secrets.DD_REPORT_EMAIL_RECIPIENTS }}" ] || { echo "[ERROR] DD_REPORT_EMAIL_RECIPIENTS missing"; exit 1; }
           [ -n "${{ secrets.EMAIL_SENDER }}" ]               || { echo "[ERROR] EMAIL_SENDER missing"; exit 1; }
           [ -n "${{ secrets.EMAIL_APP_PASSWORD }}" ]         || { echo "[ERROR] EMAIL_APP_PASSWORD missing"; exit 1; }
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ]   || { echo "[ERROR] DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
           echo "[OK] All required secrets are present"
 
       - name: Create .env file from secrets
@@ -67,6 +68,7 @@ jobs:
           ISP_FOLDER_ID: ${{ secrets.ISP_FOLDER_ID }}
           BUILDING_INSPECTION_FOLDER_ID: ${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}
           SHOVELS_API_KEY: ${{ secrets.SHOVELS_API_KEY }}
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
         run: |
           touch .env
           echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
@@ -84,6 +86,10 @@ jobs:
           echo "SIR_FOLDER_ID=${SIR_FOLDER_ID}" >> .env
           echo "ISP_FOLDER_ID=${ISP_FOLDER_ID}" >> .env
           echo "BUILDING_INSPECTION_FOLDER_ID=${BUILDING_INSPECTION_FOLDER_ID}" >> .env
+          # Dashboard publish: bearer for POST /api/sites/:slug/publish on dd-dashboard.
+          # Without this the report pipeline silently skips the dashboard write
+          # (see dashboard_publisher.publish_to_dashboard early-return).
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
           echo "[OK] Created .env file"
 
       - name: Write Google OAuth client secrets

--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -46,6 +46,7 @@ jobs:
           [ -n "${{ secrets.SIR_FOLDER_ID }}" ]              || { echo "SIR_FOLDER_ID missing"; exit 1; }
           [ -n "${{ secrets.ISP_FOLDER_ID }}" ]              || { echo "ISP_FOLDER_ID missing"; exit 1; }
           [ -n "${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}" ] || { echo "BUILDING_INSPECTION_FOLDER_ID missing"; exit 1; }
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ]   || { echo "DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
           echo "All required secrets are present"
 
       - name: Create .env file from secrets
@@ -67,6 +68,7 @@ jobs:
           ISP_FOLDER_ID: ${{ secrets.ISP_FOLDER_ID }}
           BUILDING_INSPECTION_FOLDER_ID: ${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}
           SHOVELS_API_KEY: ${{ secrets.SHOVELS_API_KEY }}
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
         run: |
           touch .env
           echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
@@ -86,6 +88,10 @@ jobs:
           echo "SIR_FOLDER_ID=${SIR_FOLDER_ID}" >> .env
           echo "ISP_FOLDER_ID=${ISP_FOLDER_ID}" >> .env
           echo "BUILDING_INSPECTION_FOLDER_ID=${BUILDING_INSPECTION_FOLDER_ID}" >> .env
+          # Dashboard publish: bearer for POST /api/sites/:slug/publish on dd-dashboard.
+          # Without this the report pipeline silently skips the dashboard write
+          # (see dashboard_publisher.publish_to_dashboard early-return).
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
           echo "Created .env file"
 
       - name: Write Google OAuth client secrets


### PR DESCRIPTION
## Why
The hourly inbox scan (`inbox-scan.yml`, every 60 min M\u2013F 6AM\u20138PM Central) is the "DD scan that looks for documents." It runs the report pipeline, which calls `publish_to_dashboard()` to POST each report to dd-dashboard `/api/sites/:slug/publish`.

`publish_to_dashboard` short-circuits when its bearer is missing:
```python
secret = os.environ.get("DASHBOARD_PUBLISH_SECRET")
if not secret:
    logger.warning("DASHBOARD_PUBLISH_SECRET not set; skipping dashboard publish for %s", site_title)
    return False
```

Neither workflow was plumbing the secret into the runtime `.env`. Scans ran successfully, docs got found, reports got generated, **but the dashboard never heard about any of it.** `sites.json` `generated_at` has been stuck at `2026-04-24T20:55:18.357Z` for 4+ days even though scans run every hour.

Verified the dashboard endpoint is alive: `POST /api/sites/test/publish` returns 401 (expects bearer), `/api/health` returns `{ok: true, has_github_pat: true}`.

## What
Identical change in both `inbox-scan.yml` and `daily-dd-check.yml`:
1. Verify-secrets check fails fast if `DASHBOARD_PUBLISH_SECRET` is missing
2. Add to the `env:` block on the .env-creation step
3. Append `DASHBOARD_PUBLISH_SECRET=...` to `.env`

The repo secret was already added out of band (visible in `gh secret list`).

## Verification after merge
- Trigger a manual `workflow_dispatch` on `inbox-scan.yml` (or wait for the next hourly run)
- Watch `https://dd-dashboard-three.vercel.app/sites.json` \u2014 `generated_at` should advance and any newly-found docs should appear in the affected sites
- If a publish fails the run logs will now show `Dashboard publish HTTP <code>` instead of the silent-skip warning

## Risk
Tiny. If the secret is wrong, the dashboard returns 401 and `publish_to_dashboard` logs a warning and returns False \u2014 same observable behavior as today (no publish), no impact on the rest of the pipeline.