### PR TITLE
fix(scanner): include category:forums so Google Group-routed SIRs are seen

### DIFF
--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -188,8 +188,14 @@ class Settings(BaseSettings):
     )
 
     # Inbox Scanner
+    # NOTE: include category:{primary forums updates} so emails routed via
+    # Google Groups (e.g. auth.permitting@trilogy.com) — which Gmail tags
+    # CATEGORY_FORUMS — are not silently excluded by the default search.
+    # See: https://support.google.com/mail/answer/3094499 (category: operator).
     inbox_scan_query: str = Field(
-        "{to:edu.ops@trilogy.com cc:edu.ops@trilogy.com} has:attachment filename:pdf",
+        "{to:edu.ops@trilogy.com cc:edu.ops@trilogy.com} "
+        "has:attachment filename:pdf "
+        "category:{primary forums updates}",
         description="Gmail search query for incoming DD documents (to or cc)",
     )
     inbox_internal_sender_domains: str = Field(

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -522,6 +522,26 @@ class TestIdempotency:
         query = f"{settings.inbox_scan_query} -label:{settings.inbox_processed_label}"
         assert "-label:DD-Processed" in query
 
+    def test_gmail_search_query_includes_forums_category(self):
+        """The default scan query must include category:forums so Google Group-routed
+        emails (e.g. via auth.permitting@trilogy.com) are not silently dropped.
+
+        Regression: 2026-04-23 Providence Croft Schools SIRs (and several other CDS
+        deliveries via the auth.permitting Google Group) landed in CATEGORY_FORUMS
+        and were never picked up by the default Gmail search, which only includes
+        the Primary tab.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        # Either a multi-value category clause or an explicit category:forums must
+        # appear in the default query.
+        q = settings.inbox_scan_query
+        assert (
+            "category:{primary forums updates}" in q
+            or "category:forums" in q
+        ), f"default inbox_scan_query missing forums category: {q!r}"
+
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
     def test_unknown_doc_type_email_marked_processed(self, mock_extract, mock_classify):


### PR DESCRIPTION
## Why we missed the Croft Schools email

Greg flagged Monica Swannie's **2026-04-23 'Providence, RI - Croft Schools'** email (3 PDF SIRs attached: 144 Wayland, 179 Wayland, 144 Medway). The scanner ran six times that day and reported `Found 0 unprocessed emails` every time.

### Root cause

The email was sent through the **`auth.permitting@trilogy.com` Google Group**. Gmail tags Group-delivered mail with `CATEGORY_FORUMS`. Gmail's default search **only returns the Primary tab** — meaning our scan query silently excluded the email.

Verified directly against Gmail:
- `from: 'Monica Swannie' via Alpha Authorization and Permitting <auth.permitting@trilogy.com>`
- `labels: [CATEGORY_FORUMS, INBOX]`

This isn't a one-off. The same routing affected:
- 2026-04-22 Lawndale CA SIR (Hannah Batson)
- 2026-04-21 Edmond OK SIR (Monica Swannie)
- Likely a backlog of CDS deliveries going back further

## Fix

Scope the default scan query to `category:{primary forums updates}` so Group-routed mail is included without dragging in Spam/Trash/Promotions/Social.

```
{to:edu.ops@trilogy.com cc:edu.ops@trilogy.com} has:attachment filename:pdf category:{primary forums updates}
```

## Tests

- 29/29 `test_inbox_scanner.py` pass
- Added regression test `test_gmail_search_query_includes_forums_category` that asserts `category:forums` coverage in the default query so this can't silently regress

## Backfill plan

Once merged, I'll trigger a manual scan run; the affected emails are still unlabeled in the inbox so they'll be processed on the next run.