### PR TITLE
fix(scanner): use REST-API-safe negative-category form to include Forums tab

### DIFF
--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -188,14 +188,21 @@ class Settings(BaseSettings):
     )
 
     # Inbox Scanner
-    # NOTE: include category:{primary forums updates} so emails routed via
-    # Google Groups (e.g. auth.permitting@trilogy.com) — which Gmail tags
-    # CATEGORY_FORUMS — are not silently excluded by the default search.
-    # See: https://support.google.com/mail/answer/3094499 (category: operator).
+    # NOTE: emails routed via Google Groups (e.g. auth.permitting@trilogy.com)
+    # are tagged CATEGORY_FORUMS by Gmail. The default Gmail search returns
+    # only the Primary tab, so Group-routed mail is silently excluded.
+    #
+    # Fix: explicitly EXCLUDE the Promotions and Social tabs (instead of
+    # implicitly limiting to Primary). This catches Primary + Forums + Updates
+    # without dragging in marketing/social noise. The positive-form
+    # `category:{primary forums updates}` is honored by the Gmail UI search
+    # bar but NOT by the Gmail REST API users.messages.list q parameter,
+    # which silently returned 0 when we tried it.
+    # See: https://support.google.com/mail/answer/7190 (search operators).
     inbox_scan_query: str = Field(
         "{to:edu.ops@trilogy.com cc:edu.ops@trilogy.com} "
         "has:attachment filename:pdf "
-        "category:{primary forums updates}",
+        "-category:promotions -category:social",
         description="Gmail search query for incoming DD documents (to or cc)",
     )
     inbox_internal_sender_domains: str = Field(

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -522,25 +522,32 @@ class TestIdempotency:
         query = f"{settings.inbox_scan_query} -label:{settings.inbox_processed_label}"
         assert "-label:DD-Processed" in query
 
-    def test_gmail_search_query_includes_forums_category(self):
-        """The default scan query must include category:forums so Google Group-routed
+    def test_gmail_search_query_covers_forums_category(self):
+        """The default scan query must cover CATEGORY_FORUMS so Google Group-routed
         emails (e.g. via auth.permitting@trilogy.com) are not silently dropped.
 
         Regression: 2026-04-23 Providence Croft Schools SIRs (and several other CDS
         deliveries via the auth.permitting Google Group) landed in CATEGORY_FORUMS
-        and were never picked up by the default Gmail search, which only includes
+        and were never picked up by the default Gmail search, which only returns
         the Primary tab.
+
+        Acceptable forms:
+          - explicit positive: contains 'category:forums' (UI-bar form, not
+            honored by the REST API but kept here for forward-compat).
+          - negative-form: excludes promotions and social (REST-API safe; this
+            is the form the production default uses).
         """
         from due_diligence_reporter.config import Settings
 
         settings = Settings()
-        # Either a multi-value category clause or an explicit category:forums must
-        # appear in the default query.
         q = settings.inbox_scan_query
-        assert (
-            "category:{primary forums updates}" in q
-            or "category:forums" in q
-        ), f"default inbox_scan_query missing forums category: {q!r}"
+        positive_form = "category:forums" in q
+        negative_form = (
+            "-category:promotions" in q and "-category:social" in q
+        )
+        assert positive_form or negative_form, (
+            f"default inbox_scan_query does not cover CATEGORY_FORUMS: {q!r}"
+        )
 
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")


### PR DESCRIPTION
## Why this is needed (follow-up to #29)

PR #29 set the default query to `category:{primary forums updates}`. That form works in the **Gmail UI search bar** but is **silently ignored by the Gmail REST API** `users.messages.list` `q` parameter — the post-merge scan run still returned 0 messages even though Monica's Croft email was right there in `CATEGORY_FORUMS`.

Verified directly against the Gmail API:

| Query form | Result |
|---|---|
| `... category:{primary forums updates}` | **0 messages** |
| `... -category:promotions -category:social` | **all SIRs returned** including Croft |

## Fix

Switch the default to the **negative-form**:

```
{to:edu.ops@trilogy.com cc:edu.ops@trilogy.com} has:attachment filename:pdf -category:promotions -category:social
```

This excludes Promotions/Social explicitly, which means we keep Primary + Forums + Updates.

## Tests

- 76/76 pass
- Regression test `test_gmail_search_query_covers_forums_category` relaxed to accept either positive (`category:forums`) or negative (`-category:promotions -category:social`) form, so it stays meaningful as the only thing it cares about is Forums coverage.

## Next

Merge → dispatch a manual catch-up sweep → confirm the missed Providence/Lawndale/Edmond SIRs flow through to the dashboard.