### PR TITLE
debug(scanner): log Gmail identity + resolved query

### DIFF
--- a/src/due_diligence_reporter/google_client.py
+++ b/src/due_diligence_reporter/google_client.py
@@ -577,6 +577,19 @@ class GoogleClient:
         """
         logger.info("Gmail search: %s (max %d)", query, max_results)
 
+        # Diagnostic: log authenticated identity so we can debug identity-vs-query issues.
+        try:
+            profile = _google_api_execute(
+                self.gmail_service.users().getProfile(userId="me")
+            )
+            logger.info(
+                "Gmail search auth identity: emailAddress=%s messagesTotal=%s",
+                profile.get("emailAddress"),
+                profile.get("messagesTotal"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not fetch Gmail profile for diagnostics: %s", exc)
+
         try:
             messages: list[dict[str, Any]] = []
             page_token: str | None = None

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -336,6 +336,7 @@ def scan_inbox(
 
     # Exclude already-labeled messages from search
     query = f"{settings.inbox_scan_query} -label:{settings.inbox_processed_label}"
+    logger.info("Inbox scan query (resolved): %s", query)
     messages = gc.gmail_search(query, max_results=settings.inbox_scan_max_results)
     logger.info("Found %d unprocessed emails", len(messages))
 


### PR DESCRIPTION
Diagnostic-only. Logs:
- `users.getProfile` emailAddress + messagesTotal at search time
- The resolved scan query string just before `gmail_search` runs

Why: catch-up sweeps after PRs #29 and #30 still return 0 despite the REST-API-safe negative-form query returning the missed Croft / Lawndale / Edmond SIRs when tested via my personal Gmail connector. Strongly suggests an identity mismatch between the scanner's OAuth token and my connector context. This logging will confirm which mailbox the scanner is authed as.