### PR TITLE
fix(scanner): drop self-referencing to:/cc: filter; use in:inbox + docx

### DIFF
--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -188,22 +188,42 @@ class Settings(BaseSettings):
     )
 
     # Inbox Scanner
-    # NOTE: emails routed via Google Groups (e.g. auth.permitting@trilogy.com)
-    # are tagged CATEGORY_FORUMS by Gmail. The default Gmail search returns
-    # only the Primary tab, so Group-routed mail is silently excluded.
+    # The scanner runs OAuth-authed AS edu.ops@trilogy.com (the shared inbox
+    # that receives all DD deliveries from CDS, brokers, vendors). Confirmed
+    # via diagnostic run 25069756638 (getProfile emailAddress was redacted by
+    # the EMAIL_SENDER secret mask, and messagesTotal=1226 matches a small
+    # operational mailbox; all scanner-sent automated emails come from
+    # edu.ops@trilogy.com).
     #
-    # Fix: explicitly EXCLUDE the Promotions and Social tabs (instead of
-    # implicitly limiting to Primary). This catches Primary + Forums + Updates
-    # without dragging in marketing/social noise. The positive-form
-    # `category:{primary forums updates}` is honored by the Gmail UI search
-    # bar but NOT by the Gmail REST API users.messages.list q parameter,
-    # which silently returned 0 when we tried it.
-    # See: https://support.google.com/mail/answer/7190 (search operators).
+    # History of this query:
+    #   v1: {to:edu.ops cc:edu.ops} ...           # silently dropped Forums tab
+    #   v2: ... category:{primary forums updates} # Gmail UI syntax, REST API
+    #                                              ignored it -> 0 results
+    #   v3: {to:edu.ops cc:edu.ops} -category:promotions -category:social
+    #                                              # negative form is REST-API
+    #                                              # safe BUT to:/cc:self-
+    #                                              # reference returns 0 when
+    #                                              # run from inside that
+    #                                              # mailbox (especially for
+    #                                              # Group-routed mail where
+    #                                              # the recipient address is
+    #                                              # in Delivered-To, not
+    #                                              # rendered in To/Cc the way
+    #                                              # the API matcher expects).
+    #   v4 (current): in:inbox + has:attachment + filename:(pdf OR docx) +
+    #                 negative-category exclusions. Since the scanner runs AS
+    #                 the receiving mailbox, in:inbox is sufficient and reliable.
+    #                 Also expanded filename to include docx -- many SIRs are
+    #                 delivered as Word documents, which were previously invisible.
     inbox_scan_query: str = Field(
-        "{to:edu.ops@trilogy.com cc:edu.ops@trilogy.com} "
-        "has:attachment filename:pdf "
+        "in:inbox has:attachment filename:(pdf OR docx) "
         "-category:promotions -category:social",
-        description="Gmail search query for incoming DD documents (to or cc)",
+        description=(
+            "Gmail search query for incoming DD documents. Scanner is authed "
+            "as the recipient mailbox, so in:inbox + attachment filters is "
+            "sufficient. Negative category exclusions cover Forums/Updates "
+            "(REST-API safe) without dragging in marketing/social noise."
+        ),
     )
     inbox_internal_sender_domains: str = Field(
         "trilogy.com",

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -549,6 +549,50 @@ class TestIdempotency:
             f"default inbox_scan_query does not cover CATEGORY_FORUMS: {q!r}"
         )
 
+    def test_gmail_search_query_does_not_self_reference_recipient(self):
+        """The scanner runs OAuth-authed AS the recipient mailbox
+        (edu.ops@trilogy.com). Querying `to:edu.ops cc:edu.ops` from inside
+        that same mailbox returns 0 messages -- especially for Group-routed
+        mail where the recipient appears in Delivered-To rather than the
+        rendered To/Cc headers the API matcher inspects.
+
+        The default query must therefore rely on in:inbox (or equivalent)
+        rather than self-referencing to:/cc: filters.
+
+        Regression: 2026-04-28 catch-up sweeps (runs 25068686981 and
+        25068942447) returned 0 messages despite the same query strings
+        returning matches when run from a third-party mailbox via the
+        Gmail connector.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        q = settings.inbox_scan_query
+        assert "to:edu.ops" not in q, (
+            f"inbox_scan_query must not self-reference to:edu.ops: {q!r}"
+        )
+        assert "cc:edu.ops" not in q, (
+            f"inbox_scan_query must not self-reference cc:edu.ops: {q!r}"
+        )
+        assert "in:inbox" in q, (
+            f"inbox_scan_query must use in:inbox to scope to received mail: {q!r}"
+        )
+
+    def test_gmail_search_query_includes_docx_attachments(self):
+        """Many SIRs (and other DD deliverables) are sent as .docx, not .pdf.
+        The default query must accept both filename extensions.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        q = settings.inbox_scan_query
+        assert "docx" in q, (
+            f"inbox_scan_query must include docx attachments: {q!r}"
+        )
+        assert "pdf" in q, (
+            f"inbox_scan_query must still include pdf attachments: {q!r}"
+        )
+
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
     def test_unknown_doc_type_email_marked_processed(self, mock_extract, mock_classify):


### PR DESCRIPTION
## Root cause (finally)

Diagnostic run [25069756638](https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/25069756638) confirmed the scanner is OAuth-authed AS **edu.ops@trilogy.com**:

```
2026-04-28 18:09:49,448 [INFO] [google_client] — Gmail search auth identity: emailAddress=*** messagesTotal=1226
```

(emailAddress redacted because it matches the `EMAIL_SENDER` secret; messagesTotal=1226 + the From-headers on all scanner-sent automation emails confirm it's edu.ops.)

The previous query `{to:edu.ops cc:edu.ops}` self-references the same mailbox the search runs from. Gmail's REST API does not match this the way the UI does — especially for Google Group-routed mail (auth.permitting@trilogy.com, edu.ops@trilogy.com Group), where the recipient address appears in `Delivered-To:` rather than the literal `To:`/`Cc:` headers the API matcher inspects.

That's why PRs #29 and #30 both came back as 0 even though the same query strings returned matches when run against a third-party mailbox via my personal Gmail connector.

## Fix

- Drop the `{to: cc:}` self-reference. Use `in:inbox` — sufficient since the scanner already runs AS the recipient mailbox.
- Expand `filename:pdf` -> `filename:(pdf OR docx)`. Many SIRs (and CDS deliverables) come as Word docs and were previously invisible.
- Keep negative-category exclusions (`-category:promotions -category:social`) so Forums/Updates tabs are still covered.

New default:
```
in:inbox has:attachment filename:(pdf OR docx) -category:promotions -category:social
```

Validated against the missed Croft email via my Gmail connector: the new query returns the email + all 3 Providence SIRs, despite `CATEGORY_FORUMS`.

## Tests
- `test_gmail_search_query_does_not_self_reference_recipient` — ensures we never go back to to:/cc:edu.ops
- `test_gmail_search_query_includes_docx_attachments` — ensures docx stays in
- Existing `test_gmail_search_query_covers_forums_category` still passes (negative form preserved)

All 4 query tests green locally.