### PR TITLE
fix(scanner): use X-Original-Sender for Group-routed mail; revert docx

### DIFF
--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -210,13 +210,16 @@ class Settings(BaseSettings):
     #                                              # in Delivered-To, not
     #                                              # rendered in To/Cc the way
     #                                              # the API matcher expects).
-    #   v4 (current): in:inbox + has:attachment + filename:(pdf OR docx) +
-    #                 negative-category exclusions. Since the scanner runs AS
-    #                 the receiving mailbox, in:inbox is sufficient and reliable.
-    #                 Also expanded filename to include docx -- many SIRs are
-    #                 delivered as Word documents, which were previously invisible.
+    #   v4: in:inbox + filename:(pdf OR docx) + negative-category exclusions.
+    #       Worked for discovery, but the downstream attachment processor only
+    #       handles PDF, so the docx matches surfaced as 10 errors. Reverted
+    #       to pdf-only here; docx support is a separate follow-up that needs
+    #       to touch the classifier, drive uploader, and reporter.
+    #   v5 (current): in:inbox + filename:pdf + negative-category exclusions.
+    #                 Since the scanner runs AS the recipient mailbox,
+    #                 in:inbox is sufficient and reliable for Group-routed mail.
     inbox_scan_query: str = Field(
-        "in:inbox has:attachment filename:(pdf OR docx) "
+        "in:inbox has:attachment filename:pdf "
         "-category:promotions -category:social",
         description=(
             "Gmail search query for incoming DD documents. Scanner is authed "

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -63,10 +63,24 @@ class EmailMetadata:
 
     message_id: str
     subject: str
-    sender: str
+    sender: str  # raw From: header (for display/logging)
     body_snippet: str
     label_ids: list[str]
     attachments: list[dict[str, Any]]  # [{filename, attachment_id?, body_data?, mime_type}]
+    # X-Original-Sender header set by Google Groups when an email is rerouted
+    # through a group. Holds the actual external sender's address. Empty when
+    # the email did not pass through a Google Group.
+    original_sender: str = ""
+
+    @property
+    def effective_sender(self) -> str:
+        """Return the address that should be used for internal/external
+        classification. Prefers X-Original-Sender when set, since Google
+        Groups rewrite the visible From: to the group's domain (e.g.
+        auth.permitting@trilogy.com), which would falsely classify
+        external CDS / regulator / vendor mail as internal.
+        """
+        return self.original_sender.strip() or self.sender
 
 
 @dataclass
@@ -416,11 +430,16 @@ def process_email(
 
     existing_label_ids = metadata.label_ids if isinstance(metadata.label_ids, list) else []
 
-    if _is_internal_sender(metadata.sender, settings):
+    # Use the effective sender for internal/external classification so that
+    # Google-Group-routed mail (where the visible From: is the group address
+    # but X-Original-Sender holds the real external sender) is not falsely
+    # classified as internal. See EmailMetadata.effective_sender.
+    if _is_internal_sender(metadata.effective_sender, settings):
         logger.info(
-            "Skipping internal sender '%s' (subject: '%s') - "
+            "Skipping internal sender '%s' [effective='%s'] (subject: '%s') - "
             "would create false readiness if filed",
             metadata.sender,
+            metadata.effective_sender,
             metadata.subject,
         )
         if not dry_run:
@@ -782,11 +801,15 @@ def _extract_email_metadata(gc: GoogleClient, message_id: str) -> EmailMetadata:
     header_map: dict[str, str] = {}
     for h in headers:
         name = h.get("name", "").lower()
-        if name in ("subject", "from", "to"):
+        # Capture all headers we care about for sender classification.
+        # X-Original-Sender is set by Google Groups when mail is rerouted
+        # through a group; it preserves the actual external sender.
+        if name in ("subject", "from", "to", "x-original-sender"):
             header_map[name] = h.get("value", "")
 
     subject = header_map.get("subject", "")
     sender = header_map.get("from", "")
+    original_sender = header_map.get("x-original-sender", "")
     snippet = message.get("snippet", "")
 
     # Walk MIME parts to find PDF attachments
@@ -800,6 +823,7 @@ def _extract_email_metadata(gc: GoogleClient, message_id: str) -> EmailMetadata:
         body_snippet=snippet,
         label_ids=list(message.get("labelIds", [])),
         attachments=attachments,
+        original_sender=original_sender,
     )
 
 

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -10,7 +10,9 @@ from due_diligence_reporter.inbox_scanner import (
     AUTO_FILE_CONFIDENCE,
     DOC_TYPE_FILENAME_TEMPLATES,
     SUPPORTED_DOC_TYPES,
+    EmailMetadata,
     _generate_drive_filename,
+    _is_internal_sender,
     _run_block_plan_downstream,
     _walk_parts,
     has_site_identity,
@@ -88,6 +90,7 @@ class TestClassification:
             message_id="msg_1",
             subject="Hello",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="Some text",
             attachments=[{"filename": "notes.pdf", "attachment_id": "a1", "mime_type": "application/pdf"}],
         )
@@ -106,6 +109,7 @@ class TestClassification:
             message_id="msg_2",
             subject="Something",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             attachments=[{"filename": "report.pdf", "attachment_id": "a2", "mime_type": "application/pdf"}],
         )
@@ -130,6 +134,7 @@ class TestClassification:
             message_id="msg_3",
             subject="SIR attached",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             attachments=[{"filename": "sir.pdf", "attachment_id": "a3", "mime_type": "application/pdf"}],
         )
@@ -161,6 +166,7 @@ class TestClassification:
             message_id="msg_block_1",
             subject="Block Plan attached",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             attachments=[{"filename": "Alpha Keller Block Plan.pdf", "attachment_id": "bp1", "mime_type": "application/pdf"}],
         )
@@ -193,6 +199,7 @@ class TestClassification:
             message_id="msg_block_2",
             subject="Alpha Keller Block Plan",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             attachments=[{"filename": "Alpha Keller Block Plan.pdf", "attachment_id": "bp2", "mime_type": "application/pdf"}],
         )
@@ -259,6 +266,7 @@ class TestClassification:
             message_id="msg_block_3",
             subject="Alpha Keller Block Plan",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             label_ids=[],
             attachments=[{"filename": "Alpha Keller Block Plan.pdf", "attachment_id": "bp3", "mime_type": "application/pdf"}],
@@ -317,6 +325,7 @@ class TestClassification:
             message_id="msg_block_retry",
             subject="Alpha Keller Block Plan",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             label_ids=[],
             attachments=[{"filename": "Alpha Keller Block Plan.pdf", "attachment_id": "bp4", "mime_type": "application/pdf"}],
@@ -382,6 +391,7 @@ class TestClassification:
             message_id="msg_block_fail",
             subject="Alpha Keller Block Plan",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             label_ids=[],
             attachments=[{"filename": "Alpha Keller Block Plan.pdf", "attachment_id": "bp5", "mime_type": "application/pdf"}],
@@ -578,20 +588,90 @@ class TestIdempotency:
             f"inbox_scan_query must use in:inbox to scope to received mail: {q!r}"
         )
 
-    def test_gmail_search_query_includes_docx_attachments(self):
-        """Many SIRs (and other DD deliverables) are sent as .docx, not .pdf.
-        The default query must accept both filename extensions.
+    def test_gmail_search_query_includes_pdf_attachments(self):
+        """Default query must filter for PDF attachments.
+
+        DOCX support is a known follow-up: it requires touching the
+        attachment processor (_walk_parts), classifier, drive uploader
+        filename templates, and reporter. Tracked separately.
         """
         from due_diligence_reporter.config import Settings
 
         settings = Settings()
         q = settings.inbox_scan_query
-        assert "docx" in q, (
-            f"inbox_scan_query must include docx attachments: {q!r}"
-        )
         assert "pdf" in q, (
-            f"inbox_scan_query must still include pdf attachments: {q!r}"
+            f"inbox_scan_query must include pdf attachments: {q!r}"
         )
+
+
+class TestEffectiveSender:
+    """Sender classification must use X-Original-Sender for Group-routed mail.
+
+    Regression: 2026-04-28 the catch-up sweep skipped 40 emails as 'internal
+    sender' because Google-Group-routed CDS / regulator / vendor deliveries
+    have their visible From: rewritten to auth.permitting@trilogy.com (the
+    group address), which matches inbox_internal_sender_domains=trilogy.com.
+    The actual external sender is preserved in X-Original-Sender.
+    """
+
+    def _meta(self, sender: str, original_sender: str = "") -> EmailMetadata:
+        return EmailMetadata(
+            message_id="m1",
+            subject="Test",
+            sender=sender,
+            body_snippet="",
+            label_ids=[],
+            attachments=[],
+            original_sender=original_sender,
+        )
+
+    def test_effective_sender_falls_back_to_from_when_no_original(self):
+        m = self._meta("alice@external.com")
+        assert m.effective_sender == "alice@external.com"
+
+    def test_effective_sender_prefers_x_original_sender(self):
+        m = self._meta(
+            "'Monica Swannie' via Alpha Authorization and Permitting <auth.permitting@trilogy.com>",
+            original_sender="mswannie@cdsdevelopment.com",
+        )
+        assert m.effective_sender == "mswannie@cdsdevelopment.com"
+
+    def test_group_routed_external_is_not_classified_internal(self):
+        """The Croft-pattern email: visible From: is a trilogy.com group,
+        but the actual sender is mswannie@cdsdevelopment.com. Must NOT be
+        classified internal.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()  # default inbox_internal_sender_domains=trilogy.com
+        m = self._meta(
+            "'Monica Swannie' via Alpha Authorization and Permitting <auth.permitting@trilogy.com>",
+            original_sender="mswannie@cdsdevelopment.com",
+        )
+        assert not _is_internal_sender(m.effective_sender, settings)
+
+    def test_genuinely_internal_still_classified_internal(self):
+        """Direct internal mail (no Group routing) must still be skipped
+        so AI-generated documents do not create false readiness.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        m = self._meta("Greg Foote <greg.foote@trilogy.com>")
+        assert _is_internal_sender(m.effective_sender, settings)
+
+    def test_internal_via_group_still_internal(self):
+        """If an internal trilogy person posts to a trilogy group, the
+        X-Original-Sender will also be internal -- still skip.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        m = self._meta(
+            "'Greg Foote' via Alpha Authorization and Permitting <auth.permitting@trilogy.com>",
+            original_sender="greg.foote@trilogy.com",
+        )
+        assert _is_internal_sender(m.effective_sender, settings)
 
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
@@ -601,6 +681,7 @@ class TestIdempotency:
             message_id="msg_1",
             subject="Hello",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="Some text",
             attachments=[{"filename": "notes.pdf", "attachment_id": "a1", "mime_type": "application/pdf"}],
         )
@@ -620,6 +701,7 @@ class TestIdempotency:
             message_id="msg_4",
             subject="Alpha Keller SIR",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             attachments=[{"filename": "Alpha Keller SIR.pdf", "attachment_id": "a4", "mime_type": "application/pdf"}],
         )
@@ -654,6 +736,7 @@ class TestIdempotency:
             message_id="msg_5",
             subject="Has PDF",
             sender="test@example.com",
+            effective_sender="test@example.com",
             body_snippet="",
             attachments=[],
         )


### PR DESCRIPTION
## Catch-up sweep finally surfaced data — and revealed two more bugs

Run [25070313003](https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/25070313003) (full sweep on the merged in:inbox query) found **50 unprocessed emails**. Result breakdown:
- **0 uploaded**
- **40 'internal sender' skips** -- silently dropped
- **10 'No PDF attachments' errors**

### Bug 1 — Group-routing breaks the internal-sender filter

Google Groups rewrite the visible `From:` header to the group address. So a CDS email like:

```
From: 'Monica Swannie' via Alpha Authorization and Permitting <auth.permitting@trilogy.com>
X-Original-Sender: mswannie@cdsdevelopment.com
```

…is classified as 'internal' (matches `inbox_internal_sender_domains=trilogy.com`) and skipped, even though the actual sender is external CDS. Same problem for SF gov, Docusign, utilities, and every other vendor/regulator that goes through the auth.permitting group.

**Fix:** `EmailMetadata` now exposes an `effective_sender` property that prefers `X-Original-Sender` when set, falling back to `From:`. The internal-sender check uses that. The visible `From:` is still logged for debugging:

```
Skipping internal sender '...via Alpha Authorization and Permitting <auth.permitting@trilogy.com>' [effective='greg.foote@trilogy.com'] (subject: ...)
```

### Bug 2 — docx in query but not in processor

The v4 query `filename:(pdf OR docx)` matched .docx-only emails, but the downstream attachment processor only handles PDF. Result: 10 errors instead of 10 uploads.

**Fix:** Reverted query to `filename:pdf`. DOCX support is a separate follow-up that needs to touch the attachment processor, classifier, Drive uploader filename templates, and reporter — too much for an inline fix.

## Tests
- New `TestEffectiveSender` class with 5 tests covering Group-routing, fallback, and all 4 internal/external × direct/Group combinations.
- 11 existing `MagicMock` metadata fixtures updated to set `effective_sender` alongside `sender`.
- All 36 tests pass locally.

## What this unblocks
After this merges, the catch-up sweep should actually upload the missed Croft / Lawndale / Edmond SIRs (they're CDS Group-routed, which is exactly the case this PR fixes).