### PR TITLE
fix(scanner): non-destructive internal-skip + reprocess script for mislabeled mail

### DIFF
--- a/.github/workflows/reprocess-mislabeled.yml
+++ b/.github/workflows/reprocess-mislabeled.yml
@@ -1,0 +1,119 @@
+name: Reprocess Mislabeled
+
+# One-off recovery workflow: clears DD-Processed from emails that the buggy
+# pre-X-Original-Sender internal-sender heuristic mislabeled. Manual trigger
+# only -- this should not run on a schedule.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually remove labels (false = dry-run report only)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      since:
+        description: 'Only consider mail received after YYYY-MM-DD (default: 14 days ago)'
+        required: false
+        default: ''
+        type: string
+      max_results:
+        description: 'Max emails to inspect'
+        required: false
+        default: '200'
+        type: string
+
+concurrency:
+  group: reprocess-mislabeled
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  reprocess:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.OAUTH_CLIENT_ID }}" ]            || { echo "OAUTH_CLIENT_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_SECRET }}" ]        || { echo "OAUTH_CLIENT_SECRET missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_REFRESH_TOKEN }}" ]        || { echo "OAUTH_REFRESH_TOKEN missing"; exit 1; }
+          echo "All required secrets are present"
+
+      - name: Write Google OAuth client secrets
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          mkdir -p credentials
+          python -c "
+          import json, os
+          data = {
+              'installed': {
+                  'client_id': os.environ['OAUTH_CLIENT_ID'],
+                  'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+                  'redirect_uris': ['http://localhost'],
+                  'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                  'token_uri': 'https://oauth2.googleapis.com/token',
+              }
+          }
+          with open('credentials/client_secrets.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+
+      - name: Write Google OAuth refresh token
+        env:
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          python -c "
+          import json, os
+          data = {
+              'token': None,
+              'refresh_token': os.environ['OAUTH_REFRESH_TOKEN'],
+              'token_uri': 'https://oauth2.googleapis.com/token',
+              'client_id': os.environ['OAUTH_CLIENT_ID'],
+              'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+              'scopes': [
+                  'https://www.googleapis.com/auth/drive',
+                  'https://www.googleapis.com/auth/documents',
+                  'https://www.googleapis.com/auth/gmail.modify',
+              ],
+          }
+          with open('.gcp-saved-tokens.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+
+      - name: Run reprocess
+        run: |
+          ARGS=""
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            ARGS="--apply"
+          fi
+          if [ -n "${{ inputs.since }}" ]; then
+            ARGS="$ARGS --since ${{ inputs.since }}"
+          fi
+          if [ -n "${{ inputs.max_results }}" ]; then
+            ARGS="$ARGS --max-results ${{ inputs.max_results }}"
+          fi
+          uv run python scripts/reprocess_mislabeled.py $ARGS
+
+      - name: Done
+        run: echo "Reprocess completed (apply=${{ inputs.apply }})"

--- a/scripts/reprocess_mislabeled.py
+++ b/scripts/reprocess_mislabeled.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+reprocess_mislabeled.py — One-off backfill: clear DD-Processed from emails
+that were wrongly skipped by the buggy internal-sender heuristic.
+
+Background: Before the X-Original-Sender fix landed, the catch-up sweep
+(run 25070313003) labeled ~40 Group-routed external emails (CDS, regulators,
+vendors, Docusign, etc.) as DD-Processed because their visible From: was
+the auth.permitting@trilogy.com group address.
+
+This script:
+  1. Searches for emails labeled DD-Processed that contain a PDF and are
+     in :inbox (the original scan's universe).
+  2. For each, fetches headers and inspects the X-Original-Sender header.
+  3. If X-Original-Sender exists and its domain is NOT in the internal
+     domain list, the email was misclassified — remove DD-Processed so the
+     next scan picks it up.
+  4. Optionally applies an audit label (DD-Reprocessed-2026-04-28) so we can
+     track exactly which emails were touched.
+
+Run:
+    uv run python scripts/reprocess_mislabeled.py            # dry-run by default
+    uv run python scripts/reprocess_mislabeled.py --apply    # actually unlabel
+    uv run python scripts/reprocess_mislabeled.py --apply --since 2026-04-20
+
+Environment (from .env): same as scan_inbox.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Ensure project src is on path when running as a script
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
+from due_diligence_reporter.inbox_scanner import (  # noqa: E402
+    _extract_email_metadata,
+    _is_internal_sender,
+    _parse_sender_email,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] [%(name)s] %(message)s",
+)
+logger = logging.getLogger("reprocess_mislabeled")
+
+
+AUDIT_LABEL = "DD-Reprocessed-2026-04-28"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually remove labels (default is dry-run).",
+    )
+    p.add_argument(
+        "--since",
+        default=None,
+        help=(
+            "Only reprocess emails received after this date (YYYY-MM-DD). "
+            "Defaults to 14 days ago."
+        ),
+    )
+    p.add_argument(
+        "--max-results",
+        type=int,
+        default=200,
+        help="Max emails to inspect (default 200).",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    settings = get_settings()
+    gc = GoogleClient(settings)
+
+    since = args.since
+    if not since:
+        since = (datetime.now(timezone.utc) - timedelta(days=14)).strftime("%Y/%m/%d")
+    else:
+        # Gmail accepts YYYY/MM/DD
+        since = since.replace("-", "/")
+
+    processed_label = settings.inbox_processed_label
+
+    # Search for already-labeled emails that match the original scan universe.
+    query = (
+        f"label:{processed_label} has:attachment filename:pdf "
+        f"after:{since} -category:promotions -category:social"
+    )
+    logger.info("Reprocess query: %s (apply=%s)", query, args.apply)
+
+    messages = gc.gmail_search(query, max_results=args.max_results)
+    logger.info("Found %d candidates labeled %s", len(messages), processed_label)
+
+    processed_label_id = gc.gmail_get_or_create_label(processed_label)
+    audit_label_id = gc.gmail_get_or_create_label(AUDIT_LABEL)
+
+    n_inspected = 0
+    n_misclassified = 0
+    n_already_external = 0  # had no X-Original-Sender (legitimately processed)
+    n_correctly_internal = 0
+    examples_to_unlabel: list[dict[str, str]] = []
+
+    for stub in messages:
+        msg_id = stub["id"]
+        try:
+            meta = _extract_email_metadata(gc, msg_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not fetch %s: %s", msg_id, exc)
+            continue
+
+        n_inspected += 1
+        # Only consider emails that have an X-Original-Sender (i.e., they
+        # arrived via a Google Group). Direct-to-trilogy mail has no
+        # X-Original-Sender and the prior label is correct.
+        if not meta.original_sender.strip():
+            n_already_external += 1
+            continue
+
+        # If the original sender's domain is internal, the prior label is
+        # still correct.
+        if _is_internal_sender(meta.original_sender, settings):
+            n_correctly_internal += 1
+            continue
+
+        # Mismatch! The email was Group-routed from an external sender but
+        # got labeled DD-Processed because the visible From: was internal.
+        n_misclassified += 1
+        original_email = _parse_sender_email(meta.original_sender)
+        logger.info(
+            "MISCLASSIFIED %s | from='%s' x-orig='%s' subject='%s'",
+            msg_id,
+            meta.sender,
+            original_email,
+            meta.subject,
+        )
+        examples_to_unlabel.append(
+            {
+                "id": msg_id,
+                "subject": meta.subject,
+                "original_sender": original_email,
+            }
+        )
+
+        if args.apply:
+            try:
+                gc.gmail_modify_labels(
+                    msg_id,
+                    add_labels=[audit_label_id],
+                    remove_labels=[processed_label_id],
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Failed to unlabel %s: %s", msg_id, exc)
+
+    logger.info("=" * 60)
+    logger.info("Inspected:               %d", n_inspected)
+    logger.info("No X-Original-Sender:    %d (kept labeled)", n_already_external)
+    logger.info("Internal X-Orig-Sender:  %d (kept labeled)", n_correctly_internal)
+    logger.info("MISCLASSIFIED:           %d", n_misclassified)
+    logger.info("Apply mode:              %s", args.apply)
+    logger.info("=" * 60)
+
+    if examples_to_unlabel and not args.apply:
+        logger.info("Sample misclassified (first 10):")
+        for ex in examples_to_unlabel[:10]:
+            logger.info("  %s | %s | %s", ex["id"], ex["original_sender"], ex["subject"])
+        logger.info("Re-run with --apply to actually clear DD-Processed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -252,6 +252,15 @@ class Settings(BaseSettings):
         "DD-Manual-Review",
         description="Gmail label applied to emails needing human review",
     )
+    inbox_internal_skip_label: str = Field(
+        "DD-Internal-Skipped",
+        description=(
+            "Gmail label applied to emails skipped by the internal-sender "
+            "heuristic. Kept distinct from DD-Processed so heuristic bugs do "
+            "not burn real DD deliveries: if the heuristic later flips for "
+            "a sender, only this label needs clearing, not DD-Processed."
+        ),
+    )
     inbox_scan_max_results: int = Field(
         50,
         description="Maximum number of emails to process per inbox scan run",

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -344,12 +344,26 @@ def scan_inbox(
     logger.info("Starting inbox scan (dry_run=%s)", dry_run)
     site_records = site_records or []
 
-    # Get or create the DD-Processed label
+    # Get or create the labels.
+    # - DD-Processed: applied to emails the scanner has finished with (uploaded
+    #   or had a real reason to skip an attachment).
+    # - DD-Manual-Review: applied when human review is needed.
+    # - DD-Internal-Skipped: applied to emails skipped by the internal-sender
+    #   heuristic. Distinct from DD-Processed so heuristic bugs do not burn
+    #   real DD deliveries (recoverable by clearing this one label).
     label_id = gc.gmail_get_or_create_label(settings.inbox_processed_label)
     review_label_id = gc.gmail_get_or_create_label(settings.inbox_manual_review_label)
+    internal_skip_label_id = gc.gmail_get_or_create_label(
+        settings.inbox_internal_skip_label
+    )
 
-    # Exclude already-labeled messages from search
-    query = f"{settings.inbox_scan_query} -label:{settings.inbox_processed_label}"
+    # Exclude already-labeled messages from search (both completed and internal-
+    # skipped, so we don't re-scan them every run).
+    query = (
+        f"{settings.inbox_scan_query}"
+        f" -label:{settings.inbox_processed_label}"
+        f" -label:{settings.inbox_internal_skip_label}"
+    )
     logger.info("Inbox scan query (resolved): %s", query)
     messages = gc.gmail_search(query, max_results=settings.inbox_scan_max_results)
     logger.info("Found %d unprocessed emails", len(messages))
@@ -376,6 +390,7 @@ def scan_inbox(
                 review_label_id,
                 site_records=site_records,
                 dry_run=dry_run,
+                internal_skip_label_id=internal_skip_label_id,
             )
             if email_result.get("internal_skipped"):
                 results["internal_skipped"] += 1
@@ -414,6 +429,7 @@ def process_email(
     review_label_id: str,
     *,
     site_records: list[dict[str, Any]] | None = None,
+    internal_skip_label_id: str | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Process a single email: classify attachments by filename, upload, mark done.
@@ -442,8 +458,13 @@ def process_email(
             metadata.effective_sender,
             metadata.subject,
         )
+        # Apply DD-Internal-Skipped (NOT DD-Processed) so future heuristic
+        # bugs only require clearing this single label to recover. Falls back
+        # to DD-Processed only if the new label id wasn't supplied (legacy
+        # callers).
         if not dry_run:
-            _mark_email_processed(gc, message_id, label_id)
+            skip_label = internal_skip_label_id or label_id
+            _mark_email_processed(gc, message_id, skip_label)
         return {"internal_skipped": True, "marked": not dry_run}
 
     uploaded: list[dict[str, Any]] = []

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -673,6 +673,86 @@ class TestEffectiveSender:
         )
         assert _is_internal_sender(m.effective_sender, settings)
 
+    @patch("due_diligence_reporter.inbox_scanner._mark_email_processed")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_internal_skip_applies_internal_label_not_processed(
+        self, mock_extract, mock_mark
+    ):
+        """Internal-skip path must apply DD-Internal-Skipped, NOT DD-Processed.
+
+        Keeping the label distinct from DD-Processed means future heuristic
+        bugs are recoverable by clearing this single label, without burning
+        the audit trail of legitimate uploads.
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        mock_extract.return_value = MagicMock(
+            message_id="msg_int",
+            subject="Internal note",
+            sender="Greg Foote <greg.foote@trilogy.com>",
+            effective_sender="Greg Foote <greg.foote@trilogy.com>",
+            body_snippet="",
+            attachments=[],
+            label_ids=[],
+        )
+
+        gc = MagicMock()
+        result = process_email(
+            gc,
+            "msg_int",
+            settings,
+            label_id="PROCESSED_LABEL_ID",
+            review_label_id="REVIEW_LABEL_ID",
+            internal_skip_label_id="INTERNAL_SKIP_LABEL_ID",
+        )
+
+        assert result["internal_skipped"] is True
+        # _mark_email_processed should be called with the internal-skip label,
+        # NOT the processed label.
+        mock_mark.assert_called_once()
+        called_with_label = mock_mark.call_args[0][2]
+        assert called_with_label == "INTERNAL_SKIP_LABEL_ID", (
+            f"Expected internal-skip label, got {called_with_label!r}"
+        )
+
+    @patch("due_diligence_reporter.inbox_scanner._mark_email_processed")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_internal_skip_falls_back_to_processed_label_if_unset(
+        self, mock_extract, mock_mark
+    ):
+        """Backward-compat: legacy callers that don't pass
+        internal_skip_label_id should still get a label applied (the
+        processed label, since they pre-date the new label).
+        """
+        from due_diligence_reporter.config import Settings
+
+        settings = Settings()
+        mock_extract.return_value = MagicMock(
+            message_id="msg_int2",
+            subject="Internal note",
+            sender="greg.foote@trilogy.com",
+            effective_sender="greg.foote@trilogy.com",
+            body_snippet="",
+            attachments=[],
+            label_ids=[],
+        )
+
+        gc = MagicMock()
+        result = process_email(
+            gc,
+            "msg_int2",
+            settings,
+            label_id="PROCESSED_LABEL_ID",
+            review_label_id="REVIEW_LABEL_ID",
+            # internal_skip_label_id intentionally omitted
+        )
+
+        assert result["internal_skipped"] is True
+        mock_mark.assert_called_once()
+        called_with_label = mock_mark.call_args[0][2]
+        assert called_with_label == "PROCESSED_LABEL_ID"
+
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
     def test_unknown_doc_type_email_marked_processed(self, mock_extract, mock_classify):


### PR DESCRIPTION
## Why

Run [25070313003](https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/25070313003) (pre-PR #33) skipped 40 emails as "internal" because the heuristic looked at the visible `From:` header. Google Groups (e.g. `auth.permitting@trilogy.com`) rewrite `From:` so every CDS / regulator / vendor email routed through the group looked internal. PR #33 fixed the heuristic to use `X-Original-Sender`, but the 40 already-skipped emails are now stuck with `DD-Processed` and won't be re-scanned. That includes the Croft / Lawndale / Edmond SIRs.

## What

Two-part fix:

### 1. Non-destructive internal-skip (prevents recurrence)

- New label `DD-Internal-Skipped` (config: `inbox_internal_skip_label`).
- `scan_inbox` now creates 3 labels and excludes BOTH `DD-Processed` and `DD-Internal-Skipped` from the search query.
- `process_email` takes a new `internal_skip_label_id` kwarg. When the email is classified as internal, it gets `DD-Internal-Skipped` instead of `DD-Processed`. Falls back to the processed label if the new label is unavailable (backward compatible).
- Result: if the internal heuristic misfires again, the mail is recoverable by simply removing the label — no audit script needed.

### 2. One-off recovery (`reprocess-mislabeled.yml`)

- `scripts/reprocess_mislabeled.py`: walks `label:DD-Processed`, fetches headers, and for each email where `X-Original-Sender` is external (and visible `From:` is internal), removes `DD-Processed` and applies `DD-Reprocessed-2026-04-28` (audit trail).
- Workflow inputs:
  - `apply` (default `false`) — dry-run prints would-be actions
  - `since` (default `14d ago`) — Gmail date filter
  - `max_results` (default `200`)
- Plan: dispatch `apply=false, since=2026-04-20` first to confirm the target set, then `apply=true`, then re-run `inbox-scan.yml` to actually upload the SIRs.

## Tests

- 38/38 in `tests/test_inbox_scanner.py` (added 2):
  - `test_internal_skip_applies_internal_label_not_processed`
  - `test_internal_skip_falls_back_to_processed_label_if_unset`

## Files

- `src/due_diligence_reporter/config.py` — `inbox_internal_skip_label` setting
- `src/due_diligence_reporter/inbox_scanner.py` — 3-label setup + routing
- `tests/test_inbox_scanner.py` — 2 new tests
- `scripts/reprocess_mislabeled.py` — recovery script
- `.github/workflows/reprocess-mislabeled.yml` — workflow_dispatch entrypoint
