### PR TITLE
fix(reprocess): use GoogleClient.from_oauth_config bootstrap

### DIFF
--- a/scripts/reprocess_mislabeled.py
+++ b/scripts/reprocess_mislabeled.py
@@ -87,7 +87,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     settings = get_settings()
-    gc = GoogleClient(settings)
+    gc = GoogleClient.from_oauth_config(
+        client_config_path=str(settings.get_client_config_path()),
+        token_file_path=str(settings.get_token_file_path()),
+        oauth_port=settings.oauth_port,
+        scopes=settings.google_scopes,
+    )
 
     since = args.since
     if not since:


### PR DESCRIPTION
PR #34's reprocess script called `GoogleClient(settings)` directly, but `GoogleClient.__init__` expects `Credentials`. The dry-run [run 25072304563](https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/25072304563) failed with `AttributeError: 'Settings' object has no attribute 'authorize'`.

This patch matches the bootstrap pattern in `scan_inbox.py` (and every other one-off script) — `GoogleClient.from_oauth_config(...)` with the OAuth config / token / scopes from settings.