### PR TITLE
feat(scanner): auto-flip Portfolio doc-readiness on upload + backfill

### DIFF
--- a/.github/workflows/backfill-doc-readiness.yml
+++ b/.github/workflows/backfill-doc-readiness.yml
@@ -1,0 +1,141 @@
+name: Backfill Doc Readiness
+
+# Walks every active site's Drive folder, detects which DD readiness docs
+# (CDS SIR, Building Inspection, Block Plan) already exist, and POSTs a
+# Pending -> Complete batch to the dashboard's /api/auto-readiness endpoint.
+#
+# Idempotent. The endpoint never overwrites a manual override and never
+# moves a field backwards, so re-running this is always safe.
+#
+# Why a separate workflow: the existing Backfill Dashboard workflow only
+# refreshes sites.json (the right side of the Portfolio table). The four
+# doc-readiness columns live in overrides.json and are flipped by a
+# different endpoint. This workflow handles that channel.
+#
+# Reuses the same env / OAuth bootstrap as backfill-dashboard.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Filter to a single site (substring match on title). Leave blank for all sites.'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Detect docs and log proposed flips, but do not POST.'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  backfill-readiness:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.WRIKE_ACCESS_TOKEN }}" ]         || { echo "[ERROR] WRIKE_ACCESS_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}" ] || { echo "[ERROR] GOOGLE_DRIVE_ROOT_FOLDER_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_ID }}" ]            || { echo "[ERROR] OAUTH_CLIENT_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_SECRET }}" ]        || { echo "[ERROR] OAUTH_CLIENT_SECRET missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_REFRESH_TOKEN }}" ]        || { echo "[ERROR] OAUTH_REFRESH_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.INBOX_SCANNER_TOKEN }}" ]        || { echo "[ERROR] INBOX_SCANNER_TOKEN missing"; exit 1; }
+          echo "[OK] All required secrets are present"
+
+      - name: Create .env file from secrets
+        env:
+          WRIKE_ACCESS_TOKEN: ${{ secrets.WRIKE_ACCESS_TOKEN }}
+          GOOGLE_DRIVE_ROOT_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}
+          SIR_FOLDER_ID: ${{ secrets.SIR_FOLDER_ID }}
+          ISP_FOLDER_ID: ${{ secrets.ISP_FOLDER_ID }}
+          BUILDING_INSPECTION_FOLDER_ID: ${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}
+          INBOX_SCANNER_TOKEN: ${{ secrets.INBOX_SCANNER_TOKEN }}
+        run: |
+          touch .env
+          echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
+          echo "GOOGLE_DRIVE_ROOT_FOLDER_ID=${GOOGLE_DRIVE_ROOT_FOLDER_ID}" >> .env
+          echo "SIR_FOLDER_ID=${SIR_FOLDER_ID}" >> .env
+          echo "ISP_FOLDER_ID=${ISP_FOLDER_ID}" >> .env
+          echo "BUILDING_INSPECTION_FOLDER_ID=${BUILDING_INSPECTION_FOLDER_ID}" >> .env
+          echo "INBOX_SCANNER_TOKEN=${INBOX_SCANNER_TOKEN}" >> .env
+          echo "[OK] Created .env file"
+
+      - name: Write Google OAuth client secrets
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          mkdir -p credentials
+          python -c "
+          import json, os
+          data = {
+              'installed': {
+                  'client_id': os.environ['OAUTH_CLIENT_ID'],
+                  'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+                  'redirect_uris': ['http://localhost'],
+                  'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                  'token_uri': 'https://oauth2.googleapis.com/token',
+              }
+          }
+          with open('credentials/client_secrets.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote credentials/client_secrets.json"
+
+      - name: Write Google OAuth refresh token
+        env:
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          python -c "
+          import json, os
+          data = {
+              'token': None,
+              'refresh_token': os.environ['OAUTH_REFRESH_TOKEN'],
+              'token_uri': 'https://oauth2.googleapis.com/token',
+              'client_id': os.environ['OAUTH_CLIENT_ID'],
+              'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+              'scopes': [
+                  'https://www.googleapis.com/auth/drive',
+                  'https://www.googleapis.com/auth/documents',
+                  'https://www.googleapis.com/auth/gmail.modify',
+              ],
+          }
+          with open('.gcp-saved-tokens.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote .gcp-saved-tokens.json"
+
+      - name: Run doc-readiness backfill
+        run: |
+          ARGS=()
+          if [ -n "${{ inputs.site }}" ]; then
+            ARGS+=("${{ inputs.site }}")
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS+=("--dry-run")
+          fi
+          uv run python scripts/backfill_doc_readiness.py "${ARGS[@]}"
+
+      - name: Done
+        run: echo "Doc-readiness backfill completed"

--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -69,6 +69,7 @@ jobs:
           BUILDING_INSPECTION_FOLDER_ID: ${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}
           SHOVELS_API_KEY: ${{ secrets.SHOVELS_API_KEY }}
           DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
+          INBOX_SCANNER_TOKEN: ${{ secrets.INBOX_SCANNER_TOKEN }}
         run: |
           touch .env
           echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
@@ -92,6 +93,7 @@ jobs:
           # Without this the report pipeline silently skips the dashboard write
           # (see dashboard_publisher.publish_to_dashboard early-return).
           echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
+          echo "INBOX_SCANNER_TOKEN=${INBOX_SCANNER_TOKEN}" >> .env
           echo "Created .env file"
 
       - name: Write Google OAuth client secrets

--- a/scripts/backfill_doc_readiness.py
+++ b/scripts/backfill_doc_readiness.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""backfill_doc_readiness.py — One-shot Pending -> Complete flips for the
+DD Dashboard's Portfolio doc-readiness columns.
+
+The dashboard exposes four "doc readiness" columns on the Portfolio page:
+
+    cds_sir_status, building_inspection_status, block_plan_status, lidar_status
+
+Going forward, ``inbox_scanner`` flips them as new attachments land. This
+script catches up every site that had docs in Drive *before* the wiring
+shipped. It does NOT touch ``lidar_status`` — the reporter has no LiDAR
+ingestion today, so any LiDAR rows must be set by hand.
+
+For each active Wrike Site Record we:
+
+  1. Search the shared SIR / Building Inspection folders for a file whose
+     filename matches the site (mirrors ``inbox_scanner``'s match logic).
+  2. List the site's M1 folder for an existing Block Plan PDF.
+  3. Collect every doc that is present into a single batch and POST it to
+     ``/api/auto-readiness``.
+
+The endpoint is one-way and never overwrites manual edits, so re-running
+the script is harmless.
+
+Run:
+    uv run python scripts/backfill_doc_readiness.py            # all sites
+    uv run python scripts/backfill_doc_readiness.py austin     # single site
+    uv run python scripts/backfill_doc_readiness.py --dry-run  # don't POST
+
+Env (from .env or the workflow secrets):
+    INBOX_SCANNER_TOKEN     bearer for /api/auto-readiness
+    DASHBOARD_PUBLISH_URL   defaults to https://dd-dashboard-three.vercel.app
+    OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET / OAUTH_REFRESH_TOKEN  Google OAuth
+    WRIKE_ACCESS_TOKEN      to enumerate active sites
+    SIR_FOLDER_ID, BUILDING_INSPECTION_FOLDER_ID  shared Drive folders
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.dashboard_publisher import slugify  # noqa: E402
+from due_diligence_reporter.dashboard_readiness import (  # noqa: E402
+    DOC_TYPE_TO_FIELD,
+    mark_readiness_complete,
+)
+from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
+from due_diligence_reporter.inbox_scanner import (  # noqa: E402
+    _list_m1_documents_by_type,
+    _resolve_m1_folder,
+)
+from due_diligence_reporter.server import (  # noqa: E402
+    _find_site_docs_in_shared_folders,
+)
+from due_diligence_reporter.utils import build_site_match_terms  # noqa: E402
+from due_diligence_reporter.wrike import (  # noqa: E402
+    _get_active_status_ids,
+    _get_all_site_records,
+    extract_address_from_record,
+    extract_google_folder_from_record,
+    filter_active_site_records,
+    load_wrike_config,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s \u2014 %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("backfill_doc_readiness")
+
+
+def _detect_doc_types_for_site(
+    gc: GoogleClient,
+    *,
+    site_title: str,
+    site_address: str,
+    drive_folder_url: str,
+) -> list[str]:
+    """Return the list of reporter doc_types present in Drive for this site.
+
+    Uses the same matchers as the live scanner so behaviour is consistent.
+    Detected types are a subset of ``DOC_TYPE_TO_FIELD`` keys.
+    """
+    found: list[str] = []
+
+    # SIR + Building Inspection live in shared Drive folders. We reuse the
+    # scanner's matcher for filename-then-LLM matching so we don't drift.
+    try:
+        match_terms = build_site_match_terms(site_title, site_address)
+        shared = _find_site_docs_in_shared_folders(
+            gc,
+            match_terms,
+            site_title=site_title,
+            site_address=site_address,
+        )
+    except Exception as exc:  # network/oauth hiccup — log, keep going
+        logger.warning("%s: shared-folder scan failed: %s", site_title, exc)
+        shared = {}
+
+    if shared.get("sir"):
+        found.append("sir")
+    if shared.get("building_inspection"):
+        found.append("building_inspection")
+
+    # Block Plan lives in the site's own M1 subfolder.
+    try:
+        if drive_folder_url:
+            m1_folder_id, _url = _resolve_m1_folder(gc, drive_folder_url)
+            if m1_folder_id:
+                m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
+                if m1_docs.get("block_plan"):
+                    found.append("block_plan")
+    except Exception as exc:
+        logger.warning("%s: M1 scan failed: %s", site_title, exc)
+
+    return found
+
+
+def _build_edits_for_site(
+    *, site_title: str, doc_types: list[str]
+) -> list[dict[str, str]]:
+    slug = slugify(site_title)
+    if not slug:
+        return []
+    edits: list[dict[str, str]] = []
+    for dt in doc_types:
+        field = DOC_TYPE_TO_FIELD.get(dt)
+        if not field:
+            continue
+        edits.append({"slug": slug, "fieldPath": field})
+    return edits
+
+
+def main(*, site_filter: str | None, dry_run: bool) -> int:
+    settings = get_settings()
+    gc = GoogleClient.from_oauth_config(
+        client_config_path=str(settings.get_client_config_path()),
+        token_file_path=str(settings.get_token_file_path()),
+        oauth_port=settings.oauth_port,
+        scopes=settings.google_scopes,
+    )
+    wrike_cfg = load_wrike_config()
+    records = _get_all_site_records(cfg=wrike_cfg)
+    active_status_ids = _get_active_status_ids(access_token=wrike_cfg.access_token)
+    active = filter_active_site_records(records, active_status_ids)
+
+    all_edits: list[dict[str, str]] = []
+    sites_with_any_doc = 0
+    sites_skipped = 0
+    breakdown: dict[str, int] = {dt: 0 for dt in DOC_TYPE_TO_FIELD}
+
+    for rec in active:
+        title = (rec.get("title") or "").strip()
+        if not title:
+            continue
+        if site_filter and site_filter.lower() not in title.lower():
+            continue
+
+        drive_url = extract_google_folder_from_record(rec) or ""
+        address = extract_address_from_record(rec) or ""
+
+        if not drive_url:
+            logger.info("%s: no Drive folder, skipping", title)
+            sites_skipped += 1
+            continue
+
+        doc_types = _detect_doc_types_for_site(
+            gc,
+            site_title=title,
+            site_address=address,
+            drive_folder_url=drive_url,
+        )
+        if not doc_types:
+            logger.info("%s: no readiness docs detected", title)
+            sites_skipped += 1
+            continue
+
+        for dt in doc_types:
+            breakdown[dt] = breakdown.get(dt, 0) + 1
+
+        site_edits = _build_edits_for_site(site_title=title, doc_types=doc_types)
+        all_edits.extend(site_edits)
+        sites_with_any_doc += 1
+
+        logger.info(
+            "%s -> %s",
+            title,
+            ", ".join(f"{dt}:{DOC_TYPE_TO_FIELD[dt]}" for dt in doc_types),
+        )
+
+    logger.info(
+        "Detection complete: %d sites with at least one doc, %d sites skipped, %d total flips",
+        sites_with_any_doc,
+        sites_skipped,
+        len(all_edits),
+    )
+    for dt, n in breakdown.items():
+        logger.info("  %s: %d site(s)", dt, n)
+
+    if not all_edits:
+        logger.info("Nothing to flip.")
+        return 0
+
+    if dry_run:
+        logger.info("--dry-run: not posting to /api/auto-readiness")
+        for edit in all_edits[:50]:
+            logger.info("  would flip: %s.%s", edit["slug"], edit["fieldPath"])
+        if len(all_edits) > 50:
+            logger.info("  ... and %d more", len(all_edits) - 50)
+        return 0
+
+    # The endpoint caps at 500 edits per call; chunk just in case the
+    # active site count grows past that in the future.
+    CHUNK = 400
+    total_applied = 0
+    total_skipped: list[Any] = []
+    for i in range(0, len(all_edits), CHUNK):
+        batch = all_edits[i : i + CHUNK]
+        result = mark_readiness_complete(batch)
+        if not result.get("ok"):
+            logger.error(
+                "Batch %d-%d failed: %s",
+                i,
+                i + len(batch),
+                result.get("reason"),
+            )
+            return 1
+        total_applied += int(result.get("applied", 0))
+        skipped = result.get("skipped", []) or []
+        if isinstance(skipped, list):
+            total_skipped.extend(skipped)
+
+    logger.info(
+        "Auto-readiness backfill complete: %d applied, %d skipped (already-set or manual)",
+        total_applied,
+        len(total_skipped),
+    )
+    if total_skipped:
+        # Log up to a handful for visibility.
+        for s in total_skipped[:10]:
+            logger.info("  skipped: %s", s)
+        if len(total_skipped) > 10:
+            logger.info("  ... and %d more", len(total_skipped) - 10)
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "site_filter",
+        nargs="?",
+        default=None,
+        help="Optional substring filter on Wrike site title.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Detect docs and log proposed flips, but do not POST.",
+    )
+    args = parser.parse_args()
+    sys.exit(main(site_filter=args.site_filter, dry_run=args.dry_run))

--- a/src/due_diligence_reporter/dashboard_readiness.py
+++ b/src/due_diligence_reporter/dashboard_readiness.py
@@ -1,0 +1,206 @@
+"""Flip Portfolio doc-readiness columns when documents land in Drive.
+
+The DD Dashboard Portfolio table surfaces four "doc readiness" columns:
+
+    cds_sir_status, building_inspection_status, block_plan_status, lidar_status
+
+These are stored as user-style overrides in ``client/public/overrides.json``
+on the dashboard repo. They do **not** come from ``sites.json`` and are not
+touched by the regular ``/api/sites/:slug/publish`` write path. The dashboard
+exposes a dedicated endpoint — ``POST /api/auto-readiness`` — that flips the
+status to ``"complete"`` *one-way* (it never overwrites a manual edit).
+
+This module is the reporter-side client for that endpoint. It is called:
+
+  * From ``inbox_scanner`` after a successful upload of an SIR / Building
+    Inspection / Block Plan attachment, so the row turns green within
+    ~minutes of the doc landing in the shared Drive folder.
+  * From ``scripts/backfill_doc_readiness.py`` to bulk-flip everything that
+    already exists in Drive when the wiring first ships.
+
+Auth: shared bearer in the ``INBOX_SCANNER_TOKEN`` env var. Must match the
+identically-named env var on the dashboard's Vercel project.
+
+Silent-fail policy: like ``dashboard_publisher`` — never raise. The reporter's
+primary jobs (uploading docs, generating reports, sending email) must not be
+broken by a flaky dashboard write.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://dd-dashboard-three.vercel.app"
+_DEFAULT_TIMEOUT_SEC = 15
+_PRINCIPAL = "inbox-scanner"
+
+# Map reporter ``doc_type`` strings to the dashboard's readiness fieldPath.
+# LiDAR has no reporter-side doc_type today; it's left out on purpose so a
+# stray classification can never flip it. When LiDAR ingestion ships, add
+# ``"lidar": "lidar_status"`` here.
+DOC_TYPE_TO_FIELD: dict[str, str] = {
+    "sir": "cds_sir_status",
+    "building_inspection": "building_inspection_status",
+    "block_plan": "block_plan_status",
+}
+
+
+def _readiness_url(base_url: str | None = None) -> str:
+    base = (base_url or os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_BASE_URL).rstrip("/")
+    return f"{base}/api/auto-readiness"
+
+
+def field_for_doc_type(doc_type: str) -> str | None:
+    """Return the readiness fieldPath for ``doc_type`` or None if unmapped."""
+    return DOC_TYPE_TO_FIELD.get(doc_type)
+
+
+def mark_readiness_complete(
+    edits: list[dict[str, str]],
+    *,
+    base_url: str | None = None,
+    timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
+) -> dict[str, Any]:
+    """POST a batch of readiness flips to the dashboard.
+
+    Each entry in ``edits`` must be ``{"slug": str, "fieldPath": str}``. A
+    ``"value": "complete"`` is added automatically — that is the only value
+    the endpoint accepts from automation.
+
+    Returns a result dict::
+
+        {"applied": int, "skipped": list, "ok": bool, "reason": str | None}
+
+    Never raises. ``ok=False`` with ``reason`` set when the call could not
+    be made or returned a non-2xx.
+    """
+    if not edits:
+        return {"applied": 0, "skipped": [], "ok": True, "reason": None}
+
+    if os.environ.get("DASHBOARD_PUBLISH_ENABLED", "1") == "0":
+        logger.info("DASHBOARD_PUBLISH_ENABLED=0 — skipping readiness flips")
+        return {"applied": 0, "skipped": [], "ok": True, "reason": "publish disabled"}
+
+    token = os.environ.get("INBOX_SCANNER_TOKEN")
+    if not token:
+        logger.warning(
+            "INBOX_SCANNER_TOKEN not set; skipping %d readiness flip(s)",
+            len(edits),
+        )
+        return {
+            "applied": 0,
+            "skipped": [],
+            "ok": False,
+            "reason": "INBOX_SCANNER_TOKEN not configured",
+        }
+
+    # Defensive: drop bad entries here so the dashboard's batch isn't poisoned.
+    cleaned: list[dict[str, str]] = []
+    for e in edits:
+        slug = (e.get("slug") or "").strip()
+        field = (e.get("fieldPath") or "").strip()
+        if not slug or not field:
+            continue
+        if field not in DOC_TYPE_TO_FIELD.values() and field != "lidar_status":
+            # lidar_status is allowed by the endpoint even though we don't
+            # auto-flip it from doc_type today; keep the door open.
+            logger.warning("Skipping readiness flip with non-allowlisted field %r", field)
+            continue
+        cleaned.append({"slug": slug, "fieldPath": field, "value": "complete"})
+
+    if not cleaned:
+        return {"applied": 0, "skipped": [], "ok": True, "reason": "no valid edits"}
+
+    body = {"editedBy": _PRINCIPAL, "edits": cleaned}
+    url = _readiness_url(base_url)
+
+    try:
+        resp = requests.post(
+            url,
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout_sec,
+        )
+    except requests.RequestException as exc:
+        logger.warning("Readiness POST to %s failed: %s", url, exc)
+        return {"applied": 0, "skipped": [], "ok": False, "reason": str(exc)}
+
+    if resp.status_code >= 300:
+        body_text = (resp.text or "")[:200]
+        logger.warning(
+            "Readiness POST to %s returned HTTP %d: %s",
+            url,
+            resp.status_code,
+            body_text,
+        )
+        return {
+            "applied": 0,
+            "skipped": [],
+            "ok": False,
+            "reason": f"HTTP {resp.status_code}: {body_text}",
+        }
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {}
+
+    applied = int(data.get("applied", 0)) if isinstance(data, dict) else 0
+    skipped = data.get("skipped", []) if isinstance(data, dict) else []
+    logger.info(
+        "Readiness flips applied=%d skipped=%d (sent=%d)",
+        applied,
+        len(skipped) if isinstance(skipped, list) else 0,
+        len(cleaned),
+    )
+    return {
+        "applied": applied,
+        "skipped": skipped if isinstance(skipped, list) else [],
+        "ok": True,
+        "reason": None,
+    }
+
+
+def edits_from_uploads(uploads: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Translate scanner upload entries into readiness edit dicts.
+
+    Each upload entry coming out of ``inbox_scanner._process_email`` looks
+    like::
+
+        {"site_title": "...", "doc_type": "sir", "drive_file_id": "...", ...}
+
+    Only entries with a ``site_title`` and a ``doc_type`` mapped in
+    ``DOC_TYPE_TO_FIELD`` produce a flip. Duplicates (same slug+field) are
+    deduped. Dry-run uploads are ignored.
+    """
+    # Local import to keep this module dependency-light for tests that
+    # don't need the publisher.
+    from .dashboard_publisher import slugify
+
+    seen: set[tuple[str, str]] = set()
+    out: list[dict[str, str]] = []
+    for u in uploads or []:
+        if not isinstance(u, dict):
+            continue
+        if u.get("dry_run"):
+            continue
+        doc_type = (u.get("doc_type") or "").strip()
+        site_title = (u.get("site_title") or "").strip()
+        field = DOC_TYPE_TO_FIELD.get(doc_type)
+        if not site_title or not field:
+            continue
+        slug = slugify(site_title)
+        if not slug:
+            continue
+        key = (slug, field)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"slug": slug, "fieldPath": field})
+    return out

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from .classifier import classify_document
 from .config import Settings
+from .dashboard_readiness import edits_from_uploads, mark_readiness_complete
 from .google_client import GoogleClient
 from .utils import (
     build_site_match_terms,
@@ -410,6 +411,19 @@ def scan_inbox(
         except Exception as e:
             logger.error("Failed to process email %s: %s", message_id, e)
             results["errors"].append({"message_id": message_id, "error": str(e)})
+
+    # Flip Portfolio doc-readiness columns for any docs we just filed. The
+    # dashboard's auto-readiness endpoint is one-way (Pending -> Complete) and
+    # never overwrites manual overrides, so this is safe to call on every run.
+    # Silent-fail: failures here must never block the scan summary.
+    if not dry_run:
+        readiness_edits = edits_from_uploads(results.get("uploads", []))
+        if readiness_edits:
+            readiness_result = mark_readiness_complete(readiness_edits)
+            results["readiness_flips_applied"] = readiness_result.get("applied", 0)
+            results["readiness_flips_attempted"] = len(readiness_edits)
+            if not readiness_result.get("ok"):
+                results["readiness_error"] = readiness_result.get("reason")
 
     logger.info(
         "Inbox scan complete: %d uploaded, %d skipped, %d internal, %d errors",

--- a/tests/test_dashboard_readiness.py
+++ b/tests/test_dashboard_readiness.py
@@ -1,0 +1,225 @@
+"""Tests for the dashboard_readiness client and its scanner integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from due_diligence_reporter import dashboard_readiness
+from due_diligence_reporter.dashboard_readiness import (
+    DOC_TYPE_TO_FIELD,
+    edits_from_uploads,
+    field_for_doc_type,
+    mark_readiness_complete,
+)
+
+
+class TestFieldMapping:
+    def test_known_doc_types_map_to_fields(self) -> None:
+        assert field_for_doc_type("sir") == "cds_sir_status"
+        assert field_for_doc_type("building_inspection") == "building_inspection_status"
+        assert field_for_doc_type("block_plan") == "block_plan_status"
+
+    def test_unknown_doc_type_returns_none(self) -> None:
+        # ISP is intentionally not in the map (no Portfolio column).
+        assert field_for_doc_type("isp") is None
+        assert field_for_doc_type("dd_report") is None
+        assert field_for_doc_type("") is None
+        assert field_for_doc_type("unknown") is None
+
+
+class TestEditsFromUploads:
+    def test_translates_uploads_to_edits(self) -> None:
+        uploads = [
+            {"doc_type": "sir", "site_title": "Austin"},
+            {"doc_type": "building_inspection", "site_title": "Austin"},
+            {"doc_type": "block_plan", "site_title": "Chicago 350"},
+        ]
+        edits = edits_from_uploads(uploads)
+        assert {(e["slug"], e["fieldPath"]) for e in edits} == {
+            ("austin", "cds_sir_status"),
+            ("austin", "building_inspection_status"),
+            ("chicago-350", "block_plan_status"),
+        }
+
+    def test_dedupes_duplicates(self) -> None:
+        uploads = [
+            {"doc_type": "sir", "site_title": "Austin"},
+            {"doc_type": "sir", "site_title": "Austin"},
+        ]
+        edits = edits_from_uploads(uploads)
+        assert len(edits) == 1
+
+    def test_skips_unmapped_doc_types(self) -> None:
+        uploads = [
+            {"doc_type": "isp", "site_title": "Austin"},
+            {"doc_type": "dd_report", "site_title": "Austin"},
+            {"doc_type": "unknown", "site_title": "Austin"},
+        ]
+        assert edits_from_uploads(uploads) == []
+
+    def test_skips_dry_run_entries(self) -> None:
+        uploads = [
+            {"doc_type": "sir", "site_title": "Austin", "dry_run": True},
+            {"doc_type": "block_plan", "site_title": "Austin"},
+        ]
+        edits = edits_from_uploads(uploads)
+        assert edits == [{"slug": "austin", "fieldPath": "block_plan_status"}]
+
+    def test_skips_entries_missing_site_title(self) -> None:
+        uploads = [{"doc_type": "sir", "site_title": ""}]
+        assert edits_from_uploads(uploads) == []
+
+    def test_handles_empty_or_invalid_input(self) -> None:
+        assert edits_from_uploads([]) == []
+        assert edits_from_uploads([None, "not a dict", 42]) == []  # type: ignore[list-item]
+
+
+class TestMarkReadinessComplete:
+    def test_empty_edits_short_circuits(self) -> None:
+        result = mark_readiness_complete([])
+        assert result == {"applied": 0, "skipped": [], "ok": True, "reason": None}
+
+    @patch.dict("os.environ", {"DASHBOARD_PUBLISH_ENABLED": "0"}, clear=False)
+    def test_disabled_when_publish_flag_off(self) -> None:
+        result = mark_readiness_complete(
+            [{"slug": "austin", "fieldPath": "cds_sir_status"}]
+        )
+        assert result["ok"] is True
+        assert result["applied"] == 0
+        assert "disabled" in (result["reason"] or "").lower()
+
+    @patch.dict("os.environ", {"DASHBOARD_PUBLISH_ENABLED": "1"}, clear=True)
+    def test_missing_token_fails_gracefully(self) -> None:
+        # No INBOX_SCANNER_TOKEN in env.
+        result = mark_readiness_complete(
+            [{"slug": "austin", "fieldPath": "cds_sir_status"}]
+        )
+        assert result["ok"] is False
+        assert "INBOX_SCANNER_TOKEN" in (result["reason"] or "")
+
+    @patch.dict(
+        "os.environ",
+        {"INBOX_SCANNER_TOKEN": "test-token", "DASHBOARD_PUBLISH_ENABLED": "1"},
+        clear=False,
+    )
+    @patch.object(dashboard_readiness.requests, "post")
+    def test_happy_path_posts_with_bearer(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"applied": 2, "skipped": []}
+        mock_post.return_value = mock_resp
+
+        edits = [
+            {"slug": "austin", "fieldPath": "cds_sir_status"},
+            {"slug": "austin", "fieldPath": "block_plan_status"},
+        ]
+        result = mark_readiness_complete(edits)
+
+        assert result == {"applied": 2, "skipped": [], "ok": True, "reason": None}
+        assert mock_post.call_count == 1
+        call_args = mock_post.call_args
+        assert call_args.kwargs["headers"]["Authorization"] == "Bearer test-token"
+        body = call_args.kwargs["json"]
+        assert body["editedBy"] == "inbox-scanner"
+        assert all(e["value"] == "complete" for e in body["edits"])
+        assert len(body["edits"]) == 2
+
+    @patch.dict(
+        "os.environ",
+        {"INBOX_SCANNER_TOKEN": "test-token", "DASHBOARD_PUBLISH_ENABLED": "1"},
+        clear=False,
+    )
+    @patch.object(dashboard_readiness.requests, "post")
+    def test_filters_disallowed_field_paths(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"applied": 1, "skipped": []}
+        mock_post.return_value = mock_resp
+
+        result = mark_readiness_complete(
+            [
+                {"slug": "austin", "fieldPath": "cds_sir_status"},
+                {"slug": "austin", "fieldPath": "c_zoning"},  # disallowed
+                {"slug": "austin", "fieldPath": ""},  # empty
+                {"slug": "", "fieldPath": "cds_sir_status"},  # empty slug
+            ]
+        )
+
+        # Only one valid edit should reach the wire.
+        assert result["ok"] is True
+        body = mock_post.call_args.kwargs["json"]
+        assert len(body["edits"]) == 1
+        assert body["edits"][0]["fieldPath"] == "cds_sir_status"
+
+    @patch.dict(
+        "os.environ",
+        {"INBOX_SCANNER_TOKEN": "test-token", "DASHBOARD_PUBLISH_ENABLED": "1"},
+        clear=False,
+    )
+    @patch.object(dashboard_readiness.requests, "post")
+    def test_http_error_is_swallowed(self, mock_post: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "internal server error"
+        mock_post.return_value = mock_resp
+
+        result = mark_readiness_complete(
+            [{"slug": "austin", "fieldPath": "cds_sir_status"}]
+        )
+        assert result["ok"] is False
+        assert "500" in (result["reason"] or "")
+
+    @patch.dict(
+        "os.environ",
+        {"INBOX_SCANNER_TOKEN": "test-token", "DASHBOARD_PUBLISH_ENABLED": "1"},
+        clear=False,
+    )
+    @patch.object(dashboard_readiness.requests, "post")
+    def test_network_exception_is_swallowed(self, mock_post: MagicMock) -> None:
+        import requests as _requests
+
+        mock_post.side_effect = _requests.ConnectionError("DNS failure")
+        result = mark_readiness_complete(
+            [{"slug": "austin", "fieldPath": "cds_sir_status"}]
+        )
+        assert result["ok"] is False
+        assert "DNS" in (result["reason"] or "")
+
+    def test_lidar_status_is_allowlisted_even_though_unmapped(self) -> None:
+        """Future-proof: callers may set lidar_status directly even though no
+        doc_type maps to it. The endpoint accepts it, so the client must too."""
+        with patch.dict(
+            "os.environ",
+            {"INBOX_SCANNER_TOKEN": "t", "DASHBOARD_PUBLISH_ENABLED": "1"},
+            clear=False,
+        ), patch.object(dashboard_readiness.requests, "post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"applied": 1, "skipped": []}
+            mock_post.return_value = mock_resp
+
+            result = mark_readiness_complete(
+                [{"slug": "austin", "fieldPath": "lidar_status"}]
+            )
+            assert result["ok"] is True
+            body = mock_post.call_args.kwargs["json"]
+            assert body["edits"][0]["fieldPath"] == "lidar_status"
+
+
+class TestDocTypeToFieldCoverage:
+    """Sanity check: every key in the map matches the dashboard endpoint's allowlist."""
+
+    def test_all_mapped_fields_are_dashboard_allowlisted(self) -> None:
+        DASHBOARD_ALLOWED = {
+            "cds_sir_status",
+            "building_inspection_status",
+            "block_plan_status",
+            "lidar_status",
+        }
+        for doc_type, field in DOC_TYPE_TO_FIELD.items():
+            assert field in DASHBOARD_ALLOWED, (
+                f"doc_type {doc_type!r} maps to {field!r} which is not in "
+                f"the dashboard's auto-readiness allowlist"
+            )


### PR DESCRIPTION
## Why

Portfolio table on the dashboard has four doc-readiness columns — CDS SIR, Building Inspection, Block Plan, LiDAR — that all show **Pending** for every site, even ones where the docs landed in Drive months ago. Root cause: those columns are stored as overrides in `client/public/overrides.json` and are flipped only via the dashboard's `POST /api/auto-readiness` endpoint. Nothing in the reporter ever called it. The dashboard endpoint has been live and idle since it shipped.

## What

- **`dashboard_readiness.py`** — new bearer-auth client for `/api/auto-readiness` with explicit `doc_type -> fieldPath` map (`sir` -> `cds_sir_status`, `building_inspection` -> `building_inspection_status`, `block_plan` -> `block_plan_status`). Silent-fail on every error path. Helper turns `inbox_scanner` upload entries into deduped batch edits.
- **`inbox_scanner.scan_inbox`** — after the per-email loop, batch-flip readiness for everything filed this run. Skipped on dry-run. The endpoint is one-way (Pending -> Complete) and never overwrites manual edits, so this is safe to call every run.
- **`scripts/backfill_doc_readiness.py`** — walks every active Wrike site, detects existing SIR/Building-Inspection in the shared folders and Block Plan in the M1 subfolder (reuses the scanner's own helpers so behaviour can't drift), and POSTs Pending -> Complete in chunks of 400. Supports a single-site filter and `--dry-run`.
- **`backfill-doc-readiness.yml`** — `workflow_dispatch` mirroring the bootstrap of `backfill-dashboard.yml`, with `site` and `dry_run` inputs.
- **`inbox-scan.yml`** — pass `INBOX_SCANNER_TOKEN` through so the live hook works on every hourly run.

## Out of scope

LiDAR has no reporter doc_type today, so this PR doesn't auto-flip `lidar_status`. The dashboard's allowlist still accepts it, and the readiness client passes it through if a future caller sets it directly — covered by a forward-compat test.

## Tests

17 new tests in `test_dashboard_readiness.py` covering the field map, upload-to-edits translation (incl. dedup, dry-run skip, unmapped doc_types), env gating (`DASHBOARD_PUBLISH_ENABLED=0` and missing `INBOX_SCANNER_TOKEN`), bearer header on POST, HTTP-error and network-error swallowing, and the field allowlist. Full reporter suite: 721 passed, 3 pre-existing failures in `test_permit_history.py` (unrelated to this change — `_build_report_trace_data` signature drift on `main`).

## Rollout

After merge:
1. Set `INBOX_SCANNER_TOKEN` repo secret to match the value already on the dashboard's Vercel project.
2. Dispatch `Backfill Doc Readiness` once with no inputs to flip every existing site.
3. Subsequent uploads via `inbox-scan.yml` will keep the columns current automatically.