### PR TITLE
Portfolio metadata polish: wrike_created_at + roster sync stubs

### DIFF
--- a/.github/workflows/site-roster-sync.yml
+++ b/.github/workflows/site-roster-sync.yml
@@ -1,0 +1,137 @@
+name: Site Roster Sync
+
+# Seeds the dashboard's sites.json with stub rows for any active Wrike Site
+# Record that doesn't yet have a published DD report. Without this, a brand
+# new site (e.g. Sausalito) doesn't appear on the Portfolio table at all
+# until its first report runs - operators can't track doc readiness for
+# pre-DD sites.
+#
+# Idempotent. The script reads the live sites.json first and only publishes
+# stubs for slugs that are missing.
+
+on:
+  schedule:
+    # 8:00 AM Central Time (Mon-Fri). UTC offsets:
+    #   CST (Nov-Mar): UTC-6 -> 14:00 UTC
+    #   CDT (Mar-Nov): UTC-5 -> 13:00 UTC
+    # We schedule for 13:00 UTC because we're in CDT today; CT shifts to
+    # 7am for 4 winter months but that's acceptable noise for a daily job.
+    - cron: '0 13 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Substring filter on Wrike site title (blank = all missing).'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Detect missing sites but do not POST stub publishes.'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync-roster:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.WRIKE_ACCESS_TOKEN }}" ]         || { echo "[ERROR] WRIKE_ACCESS_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}" ] || { echo "[ERROR] GOOGLE_DRIVE_ROOT_FOLDER_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_ID }}" ]            || { echo "[ERROR] OAUTH_CLIENT_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_SECRET }}" ]        || { echo "[ERROR] OAUTH_CLIENT_SECRET missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_REFRESH_TOKEN }}" ]        || { echo "[ERROR] OAUTH_REFRESH_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ]   || { echo "[ERROR] DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
+          echo "[OK] All required secrets are present"
+
+      - name: Create .env file from secrets
+        env:
+          WRIKE_ACCESS_TOKEN: ${{ secrets.WRIKE_ACCESS_TOKEN }}
+          GOOGLE_DRIVE_ROOT_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
+        run: |
+          touch .env
+          echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
+          echo "GOOGLE_DRIVE_ROOT_FOLDER_ID=${GOOGLE_DRIVE_ROOT_FOLDER_ID}" >> .env
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
+          echo "[OK] Created .env file"
+
+      - name: Write Google OAuth client secrets
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          mkdir -p credentials
+          python -c "
+          import json, os
+          data = {
+              'installed': {
+                  'client_id': os.environ['OAUTH_CLIENT_ID'],
+                  'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+                  'redirect_uris': ['http://localhost'],
+                  'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                  'token_uri': 'https://oauth2.googleapis.com/token',
+              }
+          }
+          with open('credentials/client_secrets.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote credentials/client_secrets.json"
+
+      - name: Write Google OAuth refresh token
+        env:
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          python -c "
+          import json, os
+          data = {
+              'token': None,
+              'refresh_token': os.environ['OAUTH_REFRESH_TOKEN'],
+              'token_uri': 'https://oauth2.googleapis.com/token',
+              'client_id': os.environ['OAUTH_CLIENT_ID'],
+              'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+              'scopes': [
+                  'https://www.googleapis.com/auth/drive',
+                  'https://www.googleapis.com/auth/documents',
+                  'https://www.googleapis.com/auth/gmail.modify',
+              ],
+          }
+          with open('.gcp-saved-tokens.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote .gcp-saved-tokens.json"
+
+      - name: Run roster sync
+        run: |
+          ARGS=()
+          if [ -n "${{ inputs.site }}" ]; then
+            ARGS+=("${{ inputs.site }}")
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS+=("--dry-run")
+          fi
+          uv run python scripts/sync_site_roster.py "${ARGS[@]}"
+
+      - name: Done
+        run: echo "Roster sync completed"

--- a/scripts/daily_dd_check.py
+++ b/scripts/daily_dd_check.py
@@ -46,6 +46,7 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
     extract_address_from_record,
+    extract_created_date_from_record,
     extract_google_folder_from_record,
     extract_p1_email_from_record,
     extract_p1_from_record,
@@ -127,6 +128,10 @@ def main(site_filter: str | None = None) -> None:
         # None when the field isn't populated on the Wrike record.
         school_feasibility = extract_school_feasibility_from_record(record)
         timeline_confidence = extract_timeline_confidence_from_record(record)
+        # When the site was first created in Wrike (NOT when the DD report
+        # was generated). Threaded all the way to the dashboard publish so
+        # the Portfolio "Date Created" column tracks the real birth date.
+        wrike_created_at = extract_created_date_from_record(record)
         logger.info("Checking site: %s (match terms: %s, p1: %s)", site_title, match_terms, p1_email)
 
         try:
@@ -136,6 +141,7 @@ def main(site_filter: str | None = None) -> None:
                 p1_email=p1_email, site_address=address, p1_name=p1_name,
                 school_feasibility=school_feasibility,
                 timeline_confidence=timeline_confidence,
+                wrike_created_at=wrike_created_at,
             )
         except Exception as e:
             logger.exception("Unexpected pipeline failure for '%s'", site_title)

--- a/scripts/sync_site_roster.py
+++ b/scripts/sync_site_roster.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""sync_site_roster.py - Seed dashboard rows for active Wrike sites that
+don't have a DD report yet.
+
+The Portfolio table is built from ``client/public/sites.json`` on the
+dashboard repo. ``sites.json`` is populated by the per-report publish path,
+which means a brand-new Wrike site (e.g. Sausalito) doesn't appear on the
+dashboard at all until its first DD report runs. Operators want a single
+view of every active site so doc readiness can be tracked from day one.
+
+This script closes the gap. It:
+
+  1. Fetches the live ``sites.json`` from the dashboard.
+  2. Walks every active Wrike Site Record.
+  3. For each Wrike record whose slug is NOT in ``sites.json``, calls
+     ``publish_to_dashboard`` with ``report_data={}`` and ``dd_status =
+     "not_ready"``. The publisher emits a full SiteRecord shape with
+     identity fields populated (site_name, address, state, school_type,
+     site_owner, drive_folder_url, wrike_created_at) and analytical
+     fields blank.
+  4. Skips slugs that already exist - the dashboard's sticky-preserve
+     transform would treat blanks as "no change", but we'd still bump
+     ``published_at`` and trigger a Vercel rebuild for nothing. Better
+     to no-op cleanly.
+
+Idempotent. Safe to run on any cadence. The dashboard's
+``/api/sites/:slug/publish`` endpoint never overwrites manual overrides
+or doc-readiness flips, so re-publishing a stub for an existing slug
+would be harmless if we did it; we just don't, to keep diffs tiny.
+
+Run:
+    uv run python scripts/sync_site_roster.py            # all missing sites
+    uv run python scripts/sync_site_roster.py austin     # single site filter
+    uv run python scripts/sync_site_roster.py --dry-run  # don't POST
+
+Env (from .env or workflow secrets):
+    DASHBOARD_PUBLISH_SECRET   bearer for /api/sites/:slug/publish
+    DASHBOARD_PUBLISH_URL      defaults to https://dd-dashboard-three.vercel.app
+    WRIKE_ACCESS_TOKEN         Wrike API
+    OAUTH_*                    Google OAuth (not strictly required here, but
+                               GoogleClient bootstrap touches them)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+from due_diligence_reporter.dashboard_publisher import (  # noqa: E402
+    publish_to_dashboard,
+    slugify,
+)
+from due_diligence_reporter.wrike import (  # noqa: E402
+    _get_active_status_ids,
+    _get_all_site_records,
+    extract_address_from_record,
+    extract_created_date_from_record,
+    extract_google_folder_from_record,
+    extract_p1_from_record,
+    extract_school_type_from_record,
+    filter_active_site_records,
+    load_wrike_config,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("sync_site_roster")
+
+_DEFAULT_BASE_URL = "https://dd-dashboard-three.vercel.app"
+
+
+def _existing_slugs() -> set[str]:
+    """Pull the live sites.json and return the set of slugs already on it."""
+    base = (
+        os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_BASE_URL
+    ).rstrip("/")
+    url = f"{base}/sites.json"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Could not fetch %s: %s", url, exc)
+        # Fail loud rather than seed everything (which would re-publish 27
+        # rows and clobber published_at on every existing site).
+        raise SystemExit(1)
+    data = resp.json()
+    slugs = {
+        s.get("slug")
+        for s in data.get("sites", [])
+        if isinstance(s, dict) and s.get("slug")
+    }
+    logger.info("Live sites.json carries %d slugs", len(slugs))
+    return slugs
+
+
+def _publish_stub(
+    *,
+    site_title: str,
+    address: str,
+    school_type: str | None,
+    drive_folder_url: str,
+    site_owner: str,
+    wrike_created_at: str | None,
+) -> bool:
+    """Publish an empty-report stub for one site. Returns True on success."""
+    return publish_to_dashboard(
+        site_title,
+        report_data={},
+        address=address or None,
+        school_type=school_type,
+        drive_folder_url=drive_folder_url or None,
+        site_owner=site_owner or None,
+        wrike_created_at=wrike_created_at,
+        # Force the not_ready label - without this the publisher auto-stamps
+        # "complete" since it normally only runs after a finished report.
+        dd_status="not_ready",
+    )
+
+
+def main(*, site_filter: str | None, dry_run: bool) -> int:
+    if not os.environ.get("DASHBOARD_PUBLISH_SECRET"):
+        logger.error(
+            "DASHBOARD_PUBLISH_SECRET not set - cannot publish to the dashboard"
+        )
+        return 1
+
+    existing = _existing_slugs()
+
+    wrike_cfg = load_wrike_config()
+    records = _get_all_site_records(cfg=wrike_cfg)
+    active_status_ids = _get_active_status_ids(access_token=wrike_cfg.access_token)
+    active = filter_active_site_records(records, active_status_ids)
+    logger.info("Wrike returned %d active site record(s)", len(active))
+
+    missing: list[dict] = []
+    for rec in active:
+        title = (rec.get("title") or "").strip()
+        if not title:
+            continue
+        if site_filter and site_filter.lower() not in title.lower():
+            continue
+        slug = slugify(title)
+        if not slug:
+            continue
+        if slug in existing:
+            continue
+        missing.append(rec)
+
+    logger.info("%d Wrike site(s) missing from the dashboard", len(missing))
+    if not missing:
+        return 0
+
+    failures = 0
+    succeeded = 0
+
+    for rec in missing:
+        title = (rec.get("title") or "").strip()
+        address = extract_address_from_record(rec) or ""
+        school_type = extract_school_type_from_record(rec)
+        drive = extract_google_folder_from_record(rec) or ""
+        p1 = extract_p1_from_record(rec) or {}
+        owner = p1.get("name") or ""
+        created = extract_created_date_from_record(rec)
+
+        logger.info(
+            "Stub publish: %s | addr=%r | type=%r | owner=%r | created=%s",
+            title,
+            address,
+            school_type,
+            owner,
+            created,
+        )
+
+        if dry_run:
+            continue
+
+        try:
+            ok = _publish_stub(
+                site_title=title,
+                address=address,
+                school_type=school_type,
+                drive_folder_url=drive,
+                site_owner=owner,
+                wrike_created_at=created,
+            )
+        except Exception as exc:  # publish_to_dashboard already swallows;
+            # belt-and-suspenders.
+            logger.warning("Publish raised for %s: %s", title, exc)
+            ok = False
+
+        if ok:
+            succeeded += 1
+        else:
+            failures += 1
+
+    logger.info(
+        "Roster sync complete: %d stub(s) published, %d failed", succeeded, failures
+    )
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "site_filter",
+        nargs="?",
+        default=None,
+        help="Substring filter on Wrike site title.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Detect missing sites but do not POST stub publishes.",
+    )
+    args = parser.parse_args()
+    sys.exit(main(site_filter=args.site_filter, dry_run=args.dry_run))

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -144,6 +144,11 @@ def build_site_meta(
     rebl_url: str | None = None,
     report_date: date | None = None,
     site_owner: str | None = None,
+    # ISO 8601 timestamp from Wrike's Site Record `createdDate`. When set,
+    # the dashboard renders this in the "Date Created" column instead of
+    # `report_date`. The dashboard's `formatDateCreated` already prefers
+    # this field; the publisher just had to start sending it.
+    wrike_created_at: str | None = None,
     # --- Phase 1 DD provenance fields (Rhodes data dictionary, 4/24) ---
     # All optional. Pipeline auto-runs leave them blank for now; explicit
     # callers (backfill scripts, future MCP integrations, manual reruns)
@@ -216,6 +221,7 @@ def build_site_meta(
         "site_owner": (site_owner or "").strip(),
         "report_date": rd,
         "published_at": datetime.now(UTC).isoformat(),
+        "wrike_created_at": (wrike_created_at or "").strip(),
         "drive_folder_url": drive_folder_url or "",
         "dd_report_url": dd_report_url or "",
         "rebl": {
@@ -310,6 +316,10 @@ def publish_to_dashboard(
     rebl_url: str | None = None,
     report_date: date | None = None,
     site_owner: str | None = None,
+    # ISO 8601 timestamp from Wrike's Site Record `createdDate`. Pass-through
+    # to the dashboard so the Portfolio "Date Created" column reflects the
+    # site's birth date in Wrike rather than the report's birth date.
+    wrike_created_at: str | None = None,
     # Phase 1 DD provenance pass-through. See build_site_meta() for semantics.
     dd_author: str | None = None,
     dd_owner: str | None = None,
@@ -450,6 +460,10 @@ def publish_to_dashboard(
         rebl_url=rebl_url or str(report_data.get("sources.rebl_link") or ""),
         report_date=report_date,
         site_owner=site_owner,
+        wrike_created_at=wrike_created_at
+        or (
+            str(report_data.get("meta.wrike_created_at") or "").strip() or None
+        ),
         dd_author=dd_author,
         dd_owner=dd_owner,
         dd_version=dd_version,

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -1079,6 +1079,10 @@ def process_site_pipeline(
     # step. None means "don't override the dashboard's stored value".
     school_feasibility: str | None = None,
     timeline_confidence: str | None = None,
+    # ISO 8601 createdDate from the Wrike Site Record. Forwarded to the
+    # dashboard so the Portfolio "Date Created" column reflects when the
+    # site itself was added in Wrike, not when the DD report was generated.
+    wrike_created_at: str | None = None,
 ) -> PipelineResult:
     """Full single-site pipeline: readiness -> report generation -> completeness -> email.
 
@@ -1153,6 +1157,7 @@ def process_site_pipeline(
         p1_name=p1_name,
         school_feasibility=school_feasibility,
         timeline_confidence=timeline_confidence,
+        wrike_created_at=wrike_created_at,
     )
 
     return PipelineResult(
@@ -1178,6 +1183,7 @@ def _publish_to_dashboard_best_effort(
     # dd_status="complete" so it's not threaded through here.
     school_feasibility: str | None = None,
     timeline_confidence: str | None = None,
+    wrike_created_at: str | None = None,
 ) -> None:
     """Fire-and-forget dashboard publish. Never raises.
 
@@ -1210,6 +1216,7 @@ def _publish_to_dashboard_best_effort(
             site_owner=p1_name,
             school_feasibility=school_feasibility,
             timeline_confidence=timeline_confidence,
+            wrike_created_at=wrike_created_at,
         )
     except Exception as e:
         # publish_to_dashboard already swallows requests errors; this is a

--- a/src/due_diligence_reporter/wrike.py
+++ b/src/due_diligence_reporter/wrike.py
@@ -194,6 +194,20 @@ def extract_address_from_record(record: dict[str, Any]) -> str | None:
     return None
 
 
+def extract_created_date_from_record(record: dict[str, Any]) -> str | None:
+    """Return the Wrike Site Record creation date as ISO 8601, or None.
+
+    Wrike's API exposes ``createdDate`` at the top level of every Folder/
+    Project record (e.g. ``"2025-09-12T18:04:21Z"``). We surface it raw so
+    callers can either render the full timestamp or slice the date prefix.
+    The dashboard's ``formatDateCreated`` accepts both shapes.
+    """
+    raw = record.get("createdDate")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
 def extract_school_type_from_record(record: dict[str, Any]) -> str | None:
     """Extract and normalise school_type from Wrike Site Record."""
     custom_fields = record.get("customFields", [])

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -10,6 +10,7 @@ from due_diligence_reporter.dashboard_publisher import (
     build_site_meta,
     publish_to_dashboard,
 )
+from due_diligence_reporter.wrike import extract_created_date_from_record
 
 
 class TestBuildSiteMeta:
@@ -92,6 +93,63 @@ class TestBuildSiteMeta:
             dd_report_length=0,
         )
         assert meta["dd_report_length"] == 0
+
+    def test_wrike_created_at_carried_through(self) -> None:
+        """wrike_created_at distinct from report_date — the dashboard's
+        Date Created column reads it instead of report_date so newly-
+        synced sites show the day they entered Wrike, not the day the
+        first DD report was published.
+        """
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            wrike_created_at="2026-02-14T08:30:00Z",
+            report_date=date(2026, 4, 23),
+        )
+        assert meta["wrike_created_at"] == "2026-02-14T08:30:00Z"
+        assert meta["report_date"] == "2026-04-23"
+
+    def test_wrike_created_at_defaults_to_empty(self) -> None:
+        """Field is always present on the wire (so the dashboard schema
+        is stable) but defaults to an empty string when not provided.
+        """
+        meta = build_site_meta("Austin", address="123 Main St, Austin, TX")
+        assert meta["wrike_created_at"] == ""
+
+    def test_wrike_created_at_is_stripped(self) -> None:
+        meta = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX",
+            wrike_created_at="  2026-02-14T08:30:00Z  ",
+        )
+        assert meta["wrike_created_at"] == "2026-02-14T08:30:00Z"
+
+
+class TestExtractCreatedDateFromRecord:
+    """Wrike Folder/Project records carry createdDate at the top level.
+    The dashboard's Date Created column reads this through the
+    wrike_created_at meta field, so the extractor needs to be tolerant
+    of missing/empty/whitespace values without raising.
+    """
+
+    def test_returns_iso_string(self) -> None:
+        rec = {"id": "abc", "createdDate": "2025-09-12T18:04:21Z"}
+        assert extract_created_date_from_record(rec) == "2025-09-12T18:04:21Z"
+
+    def test_strips_whitespace(self) -> None:
+        rec = {"createdDate": "  2025-09-12T18:04:21Z  "}
+        assert extract_created_date_from_record(rec) == "2025-09-12T18:04:21Z"
+
+    def test_missing_returns_none(self) -> None:
+        assert extract_created_date_from_record({"id": "abc"}) is None
+
+    def test_empty_returns_none(self) -> None:
+        assert extract_created_date_from_record({"createdDate": ""}) is None
+        assert extract_created_date_from_record({"createdDate": "   "}) is None
+
+    def test_non_string_returns_none(self) -> None:
+        assert extract_created_date_from_record({"createdDate": 12345}) is None
+        assert extract_created_date_from_record({"createdDate": None}) is None
 
 
 class TestDeriveDDDates:


### PR DESCRIPTION
## Why

User flagged three Portfolio-side gaps:
1. **Date Created** column showed report-creation date instead of the date the site entered Wrike
2. **Sausalito** (and any future Wrike-only sites) never appeared on the dashboard
3. Need a 3-state DD Status filter on Portfolio (Not Ready / Follow Up / Complete)

This PR fixes (1) and (2) on the reporter side. Dashboard PR ([dd-dashboard #TBD](https://github.com/EDU-Ops-Team/dd-dashboard)) handles (3) and consumes the new field.

## What

### 1. wrike_created_at threaded through publish
- New `extract_created_date_from_record(record)` in `wrike.py` returns Wrike's top-level `createdDate` ISO string
- `build_site_meta` and `publish_to_dashboard` accept `wrike_created_at`; payload carries it under `meta.wrike_created_at`
- `scripts/daily_dd_check.py` extracts createdDate per site and threads it through the pipeline
- Dashboard's `formatDateCreated` already prefers `site.wrike_created_at` over `report_date` — this PR fills the missing field

### 2. Site roster sync (Sausalito fix)
- New `scripts/sync_site_roster.py` fetches live `sites.json`, walks active Wrike records, and posts stub publishes for any slug missing
- Stubs use `report_data={}` and `dd_status="not_ready"` — full schema, fields nullable, so the dashboard can distinguish them from real reports
- New `.github/workflows/site-roster-sync.yml`: cron `0 13 * * 1-5` (8 AM CT M-F) + `workflow_dispatch` with `site` filter and `dry_run` inputs

## Tests

```
PYTHONPATH=src python -m pytest -q --ignore=tests/test_permit_history.py
708 passed in 24.61s
```

8 new tests cover the wrike_created_at plumbing and createdDate extractor edge cases. The 3 pre-existing failures in `test_permit_history.py` are unrelated `_build_report_trace_data` signature drift on main.

## Rollout

After merge:
1. Dispatch `Site Roster Sync` workflow (will create stub entries for any Wrike sites missing from sites.json — Sausalito etc.)
2. Wait for next `daily-dd-check` run (or dispatch manually) — Date Created column will fill in with Wrike createdDate as sites republish
3. Daily 8 AM CT cron keeps the roster in sync going forward