### PR TITLE
Route SIR/BI/ISP uploads into per-site M1 folders

### DIFF
--- a/.github/workflows/copy-legacy-docs-to-m1.yml
+++ b/.github/workflows/copy-legacy-docs-to-m1.yml
@@ -1,0 +1,136 @@
+name: Copy Legacy Docs to M1
+
+# One-shot migration. For every active Wrike site, finds the matching
+# SIR / Building Inspection / ISP file in the legacy shared Drive folders
+# and COPIES it into the site's own M1 subfolder. Originals are retained
+# in the shared folders as a backup.
+#
+# Idempotent. Files already present in M1 (by classified doc_type) are
+# skipped, so re-running is harmless.
+#
+# Reuses the same env / OAuth bootstrap as backfill-doc-readiness.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Filter to a single site (substring match on title). Leave blank for all sites.'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Detect matches and log proposed copies, but do not call Drive API.'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  copy-legacy-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.WRIKE_ACCESS_TOKEN }}" ]         || { echo "[ERROR] WRIKE_ACCESS_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}" ] || { echo "[ERROR] GOOGLE_DRIVE_ROOT_FOLDER_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_ID }}" ]            || { echo "[ERROR] OAUTH_CLIENT_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_SECRET }}" ]        || { echo "[ERROR] OAUTH_CLIENT_SECRET missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_REFRESH_TOKEN }}" ]        || { echo "[ERROR] OAUTH_REFRESH_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.SIR_FOLDER_ID }}" ]              || { echo "[ERROR] SIR_FOLDER_ID missing"; exit 1; }
+          [ -n "${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}" ] || { echo "[ERROR] BUILDING_INSPECTION_FOLDER_ID missing"; exit 1; }
+          echo "[OK] All required secrets are present"
+
+      - name: Create .env file from secrets
+        env:
+          WRIKE_ACCESS_TOKEN: ${{ secrets.WRIKE_ACCESS_TOKEN }}
+          GOOGLE_DRIVE_ROOT_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}
+          SIR_FOLDER_ID: ${{ secrets.SIR_FOLDER_ID }}
+          ISP_FOLDER_ID: ${{ secrets.ISP_FOLDER_ID }}
+          BUILDING_INSPECTION_FOLDER_ID: ${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}
+        run: |
+          touch .env
+          echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
+          echo "GOOGLE_DRIVE_ROOT_FOLDER_ID=${GOOGLE_DRIVE_ROOT_FOLDER_ID}" >> .env
+          echo "SIR_FOLDER_ID=${SIR_FOLDER_ID}" >> .env
+          echo "ISP_FOLDER_ID=${ISP_FOLDER_ID}" >> .env
+          echo "BUILDING_INSPECTION_FOLDER_ID=${BUILDING_INSPECTION_FOLDER_ID}" >> .env
+          echo "[OK] Created .env file"
+
+      - name: Write Google OAuth client secrets
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          mkdir -p credentials
+          python -c "
+          import json, os
+          data = {
+              'installed': {
+                  'client_id': os.environ['OAUTH_CLIENT_ID'],
+                  'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+                  'redirect_uris': ['http://localhost'],
+                  'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                  'token_uri': 'https://oauth2.googleapis.com/token',
+              }
+          }
+          with open('credentials/client_secrets.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote credentials/client_secrets.json"
+
+      - name: Write Google OAuth refresh token
+        env:
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          python -c "
+          import json, os
+          data = {
+              'token': None,
+              'refresh_token': os.environ['OAUTH_REFRESH_TOKEN'],
+              'token_uri': 'https://oauth2.googleapis.com/token',
+              'client_id': os.environ['OAUTH_CLIENT_ID'],
+              'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+              'scopes': [
+                  'https://www.googleapis.com/auth/drive',
+                  'https://www.googleapis.com/auth/documents',
+                  'https://www.googleapis.com/auth/gmail.modify',
+              ],
+          }
+          with open('.gcp-saved-tokens.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote .gcp-saved-tokens.json"
+
+      - name: Run legacy docs migration
+        run: |
+          ARGS=()
+          if [ -n "${{ inputs.site }}" ]; then
+            ARGS+=("${{ inputs.site }}")
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS+=("--dry-run")
+          fi
+          uv run python scripts/copy_legacy_docs_to_m1.py "${ARGS[@]}"
+
+      - name: Done
+        run: echo "Legacy docs migration completed"

--- a/scripts/backfill_doc_readiness.py
+++ b/scripts/backfill_doc_readiness.py
@@ -93,11 +93,30 @@ def _detect_doc_types_for_site(
 
     Uses the same matchers as the live scanner so behaviour is consistent.
     Detected types are a subset of ``DOC_TYPE_TO_FIELD`` keys.
-    """
-    found: list[str] = []
 
-    # SIR + Building Inspection live in shared Drive folders. We reuse the
-    # scanner's matcher for filename-then-LLM matching so we don't drift.
+    Detection order:
+      1. The site's own M1 subfolder — the canonical location going forward.
+         All four readiness doc_types (SIR, Building Inspection, Block Plan,
+         and ISP-as-needed) live here once the migration has run.
+      2. The legacy shared SIR / Building Inspection folders — still read so
+         that pre-migration state continues to flip Pending→Complete and the
+         endpoint's one-way guard makes re-runs harmless.
+    """
+    found: set[str] = set()
+
+    # 1) M1 subfolder (canonical post-migration location).
+    try:
+        if drive_folder_url:
+            m1_folder_id, _url = _resolve_m1_folder(gc, drive_folder_url)
+            if m1_folder_id:
+                m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
+                for dt in ("sir", "building_inspection", "block_plan"):
+                    if m1_docs.get(dt):
+                        found.add(dt)
+    except Exception as exc:
+        logger.warning("%s: M1 scan failed: %s", site_title, exc)
+
+    # 2) Legacy shared SIR / Building Inspection folders — fallback path.
     try:
         match_terms = build_site_match_terms(site_title, site_address)
         shared = _find_site_docs_in_shared_folders(
@@ -111,22 +130,12 @@ def _detect_doc_types_for_site(
         shared = {}
 
     if shared.get("sir"):
-        found.append("sir")
+        found.add("sir")
     if shared.get("building_inspection"):
-        found.append("building_inspection")
+        found.add("building_inspection")
 
-    # Block Plan lives in the site's own M1 subfolder.
-    try:
-        if drive_folder_url:
-            m1_folder_id, _url = _resolve_m1_folder(gc, drive_folder_url)
-            if m1_folder_id:
-                m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
-                if m1_docs.get("block_plan"):
-                    found.append("block_plan")
-    except Exception as exc:
-        logger.warning("%s: M1 scan failed: %s", site_title, exc)
-
-    return found
+    # Preserve a stable ordering for log output.
+    return [dt for dt in ("sir", "building_inspection", "block_plan") if dt in found]
 
 
 def _build_edits_for_site(

--- a/scripts/copy_legacy_docs_to_m1.py
+++ b/scripts/copy_legacy_docs_to_m1.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""copy_legacy_docs_to_m1.py — One-shot migration to copy SIR / Building
+Inspection / ISP files from the legacy shared Drive folders into each site's
+own M1 subfolder.
+
+Going forward, ``inbox_scanner`` writes new uploads straight into the per-site
+M1 folder. This script catches up the historical state by COPYING the matching
+files from the three shared folders (SIR / ISP / Building Inspection) into
+each active Wrike site's M1. Originals are intentionally left in place as a
+backup.
+
+For each active Wrike Site Record we:
+
+  1. Ensure the site has a Drive folder URL (else skip with a warning).
+  2. Resolve / create the per-site M1 subfolder.
+  3. Run the same ``_find_site_docs_in_shared_folders`` matcher the scanner
+     and report pipeline use, so we never invent a match the live system
+     wouldn't make.
+  4. For each (sir / building_inspection / isp) hit, list M1 contents through
+     ``_list_m1_documents_by_type``. If the doc_type is already present in M1
+     we skip — the scanner has already deposited a copy.
+  5. Otherwise call ``gc.copy_document`` to put the file in M1, preserving
+     the original filename.
+
+The script is idempotent: re-runs only copy files that aren't already in M1.
+
+Run:
+    uv run python scripts/copy_legacy_docs_to_m1.py            # all sites
+    uv run python scripts/copy_legacy_docs_to_m1.py austin     # single site
+    uv run python scripts/copy_legacy_docs_to_m1.py --dry-run  # log only
+
+Env (from .env or the workflow secrets):
+    OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET / OAUTH_REFRESH_TOKEN  Google OAuth
+    WRIKE_ACCESS_TOKEN      to enumerate active sites
+    SIR_FOLDER_ID, ISP_FOLDER_ID, BUILDING_INSPECTION_FOLDER_ID  shared folders
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
+from due_diligence_reporter.inbox_scanner import (  # noqa: E402
+    _list_m1_documents_by_type,
+    _resolve_m1_folder,
+)
+from due_diligence_reporter.server import (  # noqa: E402
+    _find_site_docs_in_shared_folders,
+)
+from due_diligence_reporter.utils import build_site_match_terms  # noqa: E402
+from due_diligence_reporter.wrike import (  # noqa: E402
+    _get_active_status_ids,
+    _get_all_site_records,
+    extract_address_from_record,
+    extract_google_folder_from_record,
+    filter_active_site_records,
+    load_wrike_config,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s \u2014 %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("copy_legacy_docs_to_m1")
+
+# Doc types we mirror into M1. Block Plan never lived in a shared folder, so
+# it's not part of this migration.
+MIGRATED_DOC_TYPES: tuple[str, ...] = ("sir", "building_inspection", "isp")
+
+
+def _copy_one_site(
+    gc: GoogleClient,
+    *,
+    site_title: str,
+    site_address: str,
+    drive_folder_url: str,
+    dry_run: bool,
+) -> tuple[int, int, int]:
+    """Return ``(copied, skipped_already_present, skipped_not_found)`` for one site."""
+
+    m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+    if not m1_folder_id:
+        logger.warning("%s: could not resolve M1 folder, skipping", site_title)
+        return 0, 0, 0
+
+    # Existing M1 contents — keyed by doc_type.
+    try:
+        existing = _list_m1_documents_by_type(gc, m1_folder_id)
+    except Exception as exc:
+        logger.warning("%s: M1 listing failed (%s); proceeding without dedup", site_title, exc)
+        existing = {}
+
+    # Same matcher the scanner & reporter use.
+    match_terms = build_site_match_terms(site_title, site_address)
+    try:
+        shared = _find_site_docs_in_shared_folders(
+            gc,
+            match_terms,
+            site_title=site_title,
+            site_address=site_address,
+        )
+    except Exception as exc:
+        logger.warning("%s: shared-folder scan failed: %s", site_title, exc)
+        return 0, 0, 0
+
+    copied = 0
+    skipped_present = 0
+    skipped_missing = 0
+
+    for doc_type in MIGRATED_DOC_TYPES:
+        match = shared.get(doc_type)
+        if not match:
+            skipped_missing += 1
+            continue
+        if doc_type in existing:
+            logger.info(
+                "%s: %s already in M1 (%s) - skip",
+                site_title,
+                doc_type,
+                existing[doc_type].get("name"),
+            )
+            skipped_present += 1
+            continue
+
+        src_id = match.get("id")
+        src_name = match.get("name") or f"{site_title} {doc_type}"
+        if not src_id:
+            logger.warning("%s: %s match missing file id, skipping", site_title, doc_type)
+            continue
+
+        if dry_run:
+            logger.info(
+                "%s: would copy %s '%s' (%s) -> M1 (%s)",
+                site_title,
+                doc_type,
+                src_name,
+                src_id,
+                m1_folder_id,
+            )
+            copied += 1
+            continue
+
+        try:
+            new_doc = gc.copy_document(
+                template_id=src_id,
+                name=src_name,
+                parent_folder_id=m1_folder_id,
+            )
+            logger.info(
+                "%s: copied %s '%s' -> M1 (new id %s)",
+                site_title,
+                doc_type,
+                src_name,
+                new_doc.get("id"),
+            )
+            copied += 1
+        except Exception as exc:
+            logger.error(
+                "%s: failed to copy %s '%s' (%s): %s",
+                site_title,
+                doc_type,
+                src_name,
+                src_id,
+                exc,
+            )
+
+    return copied, skipped_present, skipped_missing
+
+
+def main(*, site_filter: str | None, dry_run: bool) -> int:
+    settings = get_settings()
+    gc = GoogleClient.from_oauth_config(
+        client_config_path=str(settings.get_client_config_path()),
+        token_file_path=str(settings.get_token_file_path()),
+        oauth_port=settings.oauth_port,
+        scopes=settings.google_scopes,
+    )
+    wrike_cfg = load_wrike_config()
+    records = _get_all_site_records(cfg=wrike_cfg)
+    active_status_ids = _get_active_status_ids(access_token=wrike_cfg.access_token)
+    active = filter_active_site_records(records, active_status_ids)
+
+    sites_processed = 0
+    sites_with_no_drive = 0
+    total_copied = 0
+    total_skipped_present = 0
+    total_skipped_missing = 0
+
+    for rec in active:
+        title = (rec.get("title") or "").strip()
+        if not title:
+            continue
+        if site_filter and site_filter.lower() not in title.lower():
+            continue
+
+        drive_url = extract_google_folder_from_record(rec) or ""
+        address = extract_address_from_record(rec) or ""
+
+        if not drive_url:
+            logger.info("%s: no Drive folder URL, skipping", title)
+            sites_with_no_drive += 1
+            continue
+
+        copied, skipped_present, skipped_missing = _copy_one_site(
+            gc,
+            site_title=title,
+            site_address=address,
+            drive_folder_url=drive_url,
+            dry_run=dry_run,
+        )
+        sites_processed += 1
+        total_copied += copied
+        total_skipped_present += skipped_present
+        total_skipped_missing += skipped_missing
+
+    verb = "would copy" if dry_run else "copied"
+    logger.info(
+        "Migration complete: %d sites processed, %d sites without Drive folder. "
+        "%s %d files; skipped %d already-in-M1, %d not-found-in-shared.",
+        sites_processed,
+        sites_with_no_drive,
+        verb,
+        total_copied,
+        total_skipped_present,
+        total_skipped_missing,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "site_filter",
+        nargs="?",
+        default=None,
+        help="Optional substring filter on Wrike site title.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Detect matches and log proposed copies, but do not call Drive API.",
+    )
+    args = parser.parse_args()
+    sys.exit(main(site_filter=args.site_filter, dry_run=args.dry_run))

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -42,12 +42,18 @@ AUTO_FILE_CONFIDENCE = 0.7
 # Doc types we handle (others are skipped silently)
 SUPPORTED_DOC_TYPES = {"sir", "building_inspection", "isp", "block_plan"}
 
-# Map doc_type to the Settings field name for the target folder ID
-DOC_TYPE_FOLDER_MAP = {
+# Legacy: doc_type -> Settings attr for the dedicated shared Drive folder.
+# As of the M1-routing change, the live scanner uploads all supported doc
+# types into the matched site's `M1` subfolder. This map is retained only
+# so the one-shot migration script (`scripts/copy_legacy_docs_to_m1.py`)
+# knows which shared folders to read from.
+LEGACY_DOC_TYPE_FOLDER_MAP = {
     "sir": "sir_folder_id",
     "building_inspection": "building_inspection_folder_id",
     "isp": "isp_folder_id",
 }
+# Backwards-compatibility alias (older imports/tests).
+DOC_TYPE_FOLDER_MAP = LEGACY_DOC_TYPE_FOLDER_MAP
 
 # Filename templates per doc_type
 DOC_TYPE_FILENAME_TEMPLATES = {
@@ -108,18 +114,46 @@ def _resolve_m1_folder(gc: GoogleClient, drive_folder_url: str) -> tuple[str | N
     return created.get("id"), created.get("webViewLink")
 
 
+# Doc types the scanner now persists into per-site M1 folders, plus the
+# downstream reports the Block Plan pipeline derives. `_list_m1_documents_by_type`
+# returns any of these keyed by doc_type so dedup, readiness backfill, and
+# the Block Plan rerun guard can all introspect a single source of truth.
+M1_RECOGNIZED_DOC_TYPES = {
+    "sir",
+    "building_inspection",
+    "isp",
+    "block_plan",
+    "capacity_brainlift_report",
+    "raycon_scenario_report",
+}
+
+
 def _list_m1_documents_by_type(
     gc: GoogleClient,
     folder_id: str,
 ) -> dict[str, dict[str, Any]]:
-    """Return recognized report files in an M1 folder keyed by doc_type."""
+    """Return recognized report files in an M1 folder keyed by doc_type.
+
+    When multiple files of the same doc_type exist (e.g. an older copy and a
+    newly uploaded one), the most recently modified one wins so callers see
+    the freshest version.
+    """
     files_by_type: dict[str, dict[str, Any]] = {}
     for file_info in gc.list_files_in_folder(folder_id):
         name = str(file_info.get("name", "")).strip()
         if not name:
             continue
         doc_type, _confidence = classify_document(name)
-        if doc_type in {"block_plan", "capacity_brainlift_report", "raycon_scenario_report"}:
+        if doc_type not in M1_RECOGNIZED_DOC_TYPES:
+            continue
+        existing = files_by_type.get(doc_type)
+        if existing is None:
+            files_by_type[doc_type] = file_info
+            continue
+        # Prefer the most recently modified file when duplicates exist.
+        prev_mtime = str(existing.get("modifiedTime") or "")
+        new_mtime = str(file_info.get("modifiedTime") or "")
+        if new_mtime > prev_mtime:
             files_by_type[doc_type] = file_info
     return files_by_type
 
@@ -540,8 +574,12 @@ def process_email(
             review_needed = True
             continue
 
-        if doc_type == "block_plan" and matched_record is None:
-            logger.warning("Block Plan '%s' could not be matched to a site", filename)
+        if matched_record is None:
+            logger.warning(
+                "%s '%s' could not be matched to a site - flagging for manual review",
+                doc_type,
+                filename,
+            )
             low_confidence.append({
                 "filename": filename,
                 "doc_type": doc_type,
@@ -554,56 +592,43 @@ def process_email(
             continue
 
         site_summary = build_site_summary(matched_record) if matched_record else {}
-        if doc_type == "block_plan":
-            drive_folder_url = str(site_summary.get("drive_folder_url", "")).strip()
-            if not drive_folder_url:
-                errors.append({
-                    "message_id": message_id,
-                    "filename": filename,
-                    "doc_type": doc_type,
-                    "error": "Matched site has no Google Drive folder URL",
-                })
-                all_succeeded = False
-                review_needed = True
-                continue
-            try:
-                target_folder_id, _target_folder_url = _resolve_m1_folder(gc, drive_folder_url)
-            except Exception as e:
-                errors.append({
-                    "message_id": message_id,
-                    "filename": filename,
-                    "doc_type": doc_type,
-                    "error": f"Failed to resolve M1 folder: {e}",
-                })
-                all_succeeded = False
-                review_needed = True
-                continue
-            if not target_folder_id:
-                errors.append({
-                    "message_id": message_id,
-                    "filename": filename,
-                    "doc_type": doc_type,
-                    "error": "Could not resolve M1 folder ID",
-                })
-                all_succeeded = False
-                review_needed = True
-                continue
-        else:
-            folder_attr = DOC_TYPE_FOLDER_MAP.get(doc_type)
-            if not folder_attr:
-                skipped += 1
-                continue
-            target_folder_id = getattr(settings, folder_attr, "")
-            if not target_folder_id:
-                logger.error("No folder ID configured for %s", doc_type)
-                errors.append({
-                    "message_id": message_id,
-                    "filename": filename,
-                    "doc_type": doc_type,
-                    "error": f"No folder ID configured for {doc_type}",
-                })
-                all_succeeded = False
-                continue
+        # All supported doc types route to the matched site's M1 subfolder.
+        # The legacy shared-folder targets (sir_folder_id, building_inspection_folder_id,
+        # isp_folder_id) are no longer used by the live scanner — they remain
+        # configured only so the migration script can read from them.
+        drive_folder_url = str(site_summary.get("drive_folder_url", "")).strip()
+        if not drive_folder_url:
+            errors.append({
+                "message_id": message_id,
+                "filename": filename,
+                "doc_type": doc_type,
+                "error": "Matched site has no Google Drive folder URL",
+            })
+            all_succeeded = False
+            review_needed = True
+            continue
+        try:
+            target_folder_id, _target_folder_url = _resolve_m1_folder(gc, drive_folder_url)
+        except Exception as e:
+            errors.append({
+                "message_id": message_id,
+                "filename": filename,
+                "doc_type": doc_type,
+                "error": f"Failed to resolve M1 folder: {e}",
+            })
+            all_succeeded = False
+            review_needed = True
+            continue
+        if not target_folder_id:
+            errors.append({
+                "message_id": message_id,
+                "filename": filename,
+                "doc_type": doc_type,
+                "error": "Could not resolve M1 folder ID",
+            })
+            all_succeeded = False
+            review_needed = True
+            continue
 
         drive_filename = (
             _generate_drive_filename(site_title, doc_type)

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -127,37 +127,204 @@ class TestClassification:
             remove_labels=[],
         )
 
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
-    def test_upload_failure_is_returned_as_error(self, mock_extract, mock_classify):
+    def test_upload_failure_is_returned_as_error(
+        self, mock_extract, mock_classify, mock_resolve_m1, mock_build_summary
+    ):
         mock_extract.return_value = MagicMock(
             message_id="msg_3",
-            subject="SIR attached",
+            subject="Alpha Keller SIR",
             sender="test@example.com",
             effective_sender="test@example.com",
             body_snippet="",
-            attachments=[{"filename": "sir.pdf", "attachment_id": "a3", "mime_type": "application/pdf"}],
+            attachments=[{"filename": "Alpha Keller SIR.pdf", "attachment_id": "a3", "mime_type": "application/pdf"}],
         )
         mock_classify.return_value = ("sir", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_build_summary.return_value = {
+            "title": "Alpha Keller",
+            "address": "123 Main St, Keller, TX 76248",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site123",
+        }
 
         gc = MagicMock()
         gc.file_exists_in_folder.return_value = False
         gc.gmail_get_attachment.return_value = b"pdf"
         gc.upload_file_to_folder.side_effect = RuntimeError("upload boom")
 
+        site_records = [{"id": "IESIR123", "title": "Alpha Keller", "customFields": []}]
+
         result = process_email(
             gc,
             "msg_3",
-            MagicMock(sir_folder_id="folder123"),
+            MagicMock(),
             "label_123",
             "review_123",
+            site_records=site_records,
         )
 
         assert result["marked"] is True
         assert len(result["uploaded"]) == 0
         assert len(result["errors"]) == 1
-        assert result["errors"][0]["filename"] == "sir.pdf"
+        assert result["errors"][0]["filename"] == "Alpha Keller SIR.pdf"
         assert result["errors"][0]["error"] == "upload boom"
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_sir_routes_to_m1_subfolder(
+        self, mock_extract, mock_classify, mock_resolve_m1, mock_build_summary
+    ):
+        """SIRs land in the matched site's M1 folder, not the legacy SIR folder."""
+        mock_extract.return_value = MagicMock(
+            message_id="msg_sir_m1",
+            subject="Alpha Keller SIR",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="",
+            attachments=[{"filename": "Alpha Keller SIR.pdf", "attachment_id": "sir1", "mime_type": "application/pdf"}],
+        )
+        mock_classify.return_value = ("sir", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_build_summary.return_value = {
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site123",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {"id": "sir_id", "webViewLink": "https://drive.google.com/file/d/sir_id"}
+
+        site_records = [{"id": "IEKELLER", "title": "Alpha Keller", "customFields": []}]
+
+        result = process_email(
+            gc, "msg_sir_m1", MagicMock(), "label_123", "review_123",
+            site_records=site_records,
+        )
+
+        assert result["marked"] is True
+        assert len(result["uploaded"]) == 1
+        upload = result["uploaded"][0]
+        assert upload["doc_type"] == "sir"
+        assert upload["site_title"] == "Alpha Keller"
+        gc.upload_file_to_folder.assert_called_once_with(
+            folder_id="m1_folder_id",
+            file_name=upload["drive_filename"],
+            file_bytes=b"pdf",
+        )
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_building_inspection_routes_to_m1_subfolder(
+        self, mock_extract, mock_classify, mock_resolve_m1, mock_build_summary
+    ):
+        """Building Inspection PDFs land in M1, mirroring SIR/Block Plan routing."""
+        mock_extract.return_value = MagicMock(
+            message_id="msg_bi_m1",
+            subject="Building Inspection Report - Alpha Keller",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="",
+            attachments=[{"filename": "Alpha Keller Building Inspection Report.pdf", "attachment_id": "bi1", "mime_type": "application/pdf"}],
+        )
+        mock_classify.return_value = ("building_inspection", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_build_summary.return_value = {
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site123",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {"id": "bi_id", "webViewLink": "https://drive.google.com/file/d/bi_id"}
+
+        site_records = [{"id": "IEKELLER", "title": "Alpha Keller", "customFields": []}]
+
+        result = process_email(
+            gc, "msg_bi_m1", MagicMock(), "label_123", "review_123",
+            site_records=site_records,
+        )
+
+        assert len(result["uploaded"]) == 1
+        gc.upload_file_to_folder.assert_called_once()
+        call_kwargs = gc.upload_file_to_folder.call_args.kwargs
+        assert call_kwargs["folder_id"] == "m1_folder_id"
+
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_unmatched_sir_goes_to_manual_review(self, mock_extract, mock_classify):
+        """With no Wrike match, SIR/BI/ISP follow the same review path as Block Plan.
+
+        This guards the uniform fallback: every supported doc type now needs
+        a matched site to know which M1 to upload into; without one, we leave
+        the email in review rather than dumping the file in a generic folder.
+        """
+        mock_extract.return_value = MagicMock(
+            message_id="msg_sir_unmatched",
+            subject="SIR for unknown site",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="",
+            attachments=[{"filename": "Random SIR.pdf", "attachment_id": "u1", "mime_type": "application/pdf"}],
+        )
+        mock_classify.return_value = ("sir", 0.95)
+
+        gc = MagicMock()
+        result = process_email(gc, "msg_sir_unmatched", MagicMock(), "label_123", "review_123")
+
+        assert result["uploaded"] == []
+        assert result["skipped"] == 1
+        assert result["marked"] is True
+        assert result["low_confidence"][0]["doc_type"] == "sir"
+        # The scanner must NOT have tried to upload anything when site is unmatched.
+        gc.upload_file_to_folder.assert_not_called()
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_sir_with_no_drive_folder_flags_review(
+        self, mock_extract, mock_classify, mock_resolve_m1, mock_build_summary
+    ):
+        """Matched site missing a Drive folder URL flags review, never falls back to a shared folder."""
+        mock_extract.return_value = MagicMock(
+            message_id="msg_no_drive",
+            subject="Alpha Keller SIR",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="",
+            attachments=[{"filename": "Alpha Keller SIR.pdf", "attachment_id": "nd1", "mime_type": "application/pdf"}],
+        )
+        mock_classify.return_value = ("sir", 0.95)
+        # Site exists in Wrike but has no drive_folder_url — the upstream gap
+        # we explicitly want surfaced rather than papered over.
+        mock_build_summary.return_value = {"title": "Alpha Keller", "drive_folder_url": ""}
+
+        gc = MagicMock()
+        site_records = [{"id": "IEKELLER", "title": "Alpha Keller", "customFields": []}]
+        result = process_email(
+            gc, "msg_no_drive", MagicMock(), "label_123", "review_123",
+            site_records=site_records,
+        )
+
+        assert result["uploaded"] == []
+        assert result["marked"] is True
+        assert any(
+            err.get("error") == "Matched site has no Google Drive folder URL"
+            for err in result["errors"]
+        )
+        mock_resolve_m1.assert_not_called()
+        gc.upload_file_to_folder.assert_not_called()
 
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
@@ -774,9 +941,13 @@ class TestEffectiveSender:
         assert len(result["uploaded"]) == 0
         assert result["marked"] is True  # mark so we don't re-scan it forever
 
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
-    def test_site_identity_is_attached_to_uploads(self, mock_extract, mock_classify):
+    def test_site_identity_is_attached_to_uploads(
+        self, mock_extract, mock_classify, mock_resolve_m1, mock_build_summary
+    ):
         mock_extract.return_value = MagicMock(
             message_id="msg_4",
             subject="Alpha Keller SIR",
@@ -786,19 +957,24 @@ class TestEffectiveSender:
             attachments=[{"filename": "Alpha Keller SIR.pdf", "attachment_id": "a4", "mime_type": "application/pdf"}],
         )
         mock_classify.return_value = ("sir", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_build_summary.return_value = {
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site123",
+        }
 
         gc = MagicMock()
         gc.file_exists_in_folder.return_value = False
         gc.gmail_get_attachment.return_value = b"pdf"
         gc.upload_file_to_folder.return_value = {"id": "file123", "webViewLink": "https://drive/file123"}
 
-        settings = MagicMock(sir_folder_id="folder123")
         site_records = [{"id": "IEABCD123", "title": "Alpha Keller", "customFields": []}]
 
         result = process_email(
             gc,
             "msg_4",
-            settings,
+            MagicMock(),
             "label_123",
             "review_123",
             site_records=site_records,

--- a/tests/test_sender_filter.py
+++ b/tests/test_sender_filter.py
@@ -178,8 +178,16 @@ class TestProcessEmailInternalSenderSkip:
         assert result["marked"] is False
         gc.gmail_modify_labels.assert_not_called()
 
-    def test_vendor_sender_proceeds_normally(self, settings):
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    def test_vendor_sender_proceeds_normally(self, mock_resolve_m1, mock_build_summary, settings):
         """Vendor email should NOT be short-circuited."""
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_build_summary.return_value = {
+            "title": "Boca Raton",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site123",
+        }
         gc = MagicMock()
         gc.gmail_get_message.return_value = {
             "payload": {
@@ -205,7 +213,7 @@ class TestProcessEmailInternalSenderSkip:
         result = process_email(
             gc, "msg002", settings,
             label_id="lbl1", review_label_id="rlbl1",
-            site_records=[{"title": "Boca Raton", "id": "w1"}],
+            site_records=[{"title": "Boca Raton", "id": "w1", "customFields": []}],
             dry_run=False,
         )
         assert result.get("internal_skipped") is not True
@@ -388,7 +396,9 @@ class TestServiceAccountAddresses:
 class TestScanInboxInternalCounter:
     """Verify internal_skipped is properly accumulated in scan_inbox results."""
 
-    def test_mixed_internal_and_vendor_emails(self):
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    def test_mixed_internal_and_vendor_emails(self, mock_resolve_m1, mock_build_summary):
         settings = Settings(
             inbox_internal_sender_domains="trilogy.com",
             inbox_internal_sender_addresses="",
@@ -440,7 +450,19 @@ class TestScanInboxInternalCounter:
         gc.gmail_get_attachment.return_value = b"%PDF-fake"
         gc.upload_file_to_folder.return_value = {"id": "f1", "webViewLink": "https://..."}
 
-        results = scan_inbox(gc, site_records=[], settings=settings, dry_run=False)
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_build_summary.return_value = {
+            "title": "Tampa",
+            "address": "",
+            "drive_folder_url": "https://drive.google.com/drive/folders/tampa",
+        }
+
+        results = scan_inbox(
+            gc,
+            site_records=[{"id": "WTAMPA", "title": "Tampa", "customFields": []}],
+            settings=settings,
+            dry_run=False,
+        )
 
         assert results["internal_skipped"] == 1
         assert results["attachments_uploaded"] == 1


### PR DESCRIPTION
## What

All four DD doc types (SIR, Building Inspection, ISP, Block Plan) now land in the matched site's **M1 subfolder** instead of the legacy shared SIR / BI / ISP folders.

## Why

Per-site M1 is the canonical location going forward — it keeps a site's evidence colocated with its other artifacts, lines up with how the Block Plan pipeline already works, and means downstream consumers only need to look in one place.

## Changes

**Live scanner** (`inbox_scanner.py`)
- Collapses upload routing: every supported doc_type uses `_resolve_m1_folder` against the matched site's Drive folder.
- Generalizes "no site match → review_needed" to all doc types.
- Adds a new fallback: when a site is matched but has no Drive folder URL, flag for manual review (never falls back to the legacy shared folder).
- Broadens `M1_RECOGNIZED_DOC_TYPES` + `_list_m1_documents_by_type` to recognize `sir`, `building_inspection`, `isp` alongside Block Plan and the derived reports. Prefers the most recently modified file when duplicates exist.
- Renames `DOC_TYPE_FOLDER_MAP` → `LEGACY_DOC_TYPE_FOLDER_MAP` (alias kept).

**Readiness backfill** (`backfill_doc_readiness.py`)
- Detects docs in M1 **first**, then in legacy shared folders as a fallback so pre-migration state still flips Pending→Complete.

**Migration**
- `scripts/copy_legacy_docs_to_m1.py` — idempotent one-shot. For every active Wrike site, runs the same matcher the live scanner uses, then **copies** any SIR / BI / ISP hit into the site's M1. Skips files already present in M1 (by classified doc_type). **Originals are retained** in the shared folders as a backup.
- `.github/workflows/copy-legacy-docs-to-m1.yml` — workflow_dispatch with site filter + dry-run inputs.

## Tests

```
712 passed in 23.39s
```

New / updated coverage:
- `test_sir_routes_to_m1_subfolder`
- `test_building_inspection_routes_to_m1_subfolder`
- `test_unmatched_sir_goes_to_manual_review`
- `test_sir_with_no_drive_folder_flags_review`
- `test_site_identity_is_attached_to_uploads` updated with M1 mocks
- `test_upload_failure_is_returned_as_error` updated with M1 mocks
- `test_vendor_sender_proceeds_normally` and `test_mixed_internal_and_vendor_emails` updated with M1 mocks + matching `site_records`

## Rollout

After merge:
1. Dispatch **Copy Legacy Docs to M1** (`workflow_dispatch`) with no filter, `dry_run=false`. Originals stay in the shared folders.
2. Re-dispatch **Backfill Doc Readiness** with no `--dry-run` to flip the 53 pending readiness statuses caught by the prior dry-run audit.