### PR TITLE
Make RAYCON_WEBHOOK_SECRET optional; sign only when configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,11 +25,16 @@ OPS_SKILLS_REPO_PATH=
 # RayCon async hand-off — DDR pings /v1/jobs when a Block Plan lands in M1.
 # RayCon writes raycon_scenario.json back into the same M1 folder; the
 # raycon-followup workflow publishes the report Doc.
-# Auth (per spec §1.1): HMAC-SHA256 of the raw request body, signed with
-# RAYCON_WEBHOOK_SECRET, sent in the X-RayCon-Signature header.
-RAYCON_WEBHOOK_SECRET=your_raycon_webhook_secret_here
-# Optional fallback for environments still using the legacy static API key
-# while RayCon rolls HMAC enforcement. Leave blank in production.
+#
+# Auth: RayCon's /v1/jobs is currently public under the /v1/* rollout (per
+# RayCon team 2026-04-30) — no secret required to make calls work. When
+# RAYCON_WEBHOOK_SECRET is set, DDR HMAC-SHA256-signs the raw body with it
+# and sends X-RayCon-Signature, so the canonical signing path is exercised
+# and ready for the day RayCon enables verification. Leave blank otherwise.
+RAYCON_WEBHOOK_SECRET=
+# Optional. Sent in X-RayCon-API-Key for the RayCon Firebase auth path,
+# which is gated by RAYCON_REQUIRE_FIREBASE_AUTH=true on RayCon's side
+# (currently disabled). Leave blank in production.
 RAYCON_API_KEY=
 # RAYCON_JOBS_URL defaults to https://raycon-api-dkxp2hji2q-uc.a.run.app/v1/jobs (optional override)
 

--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -47,7 +47,10 @@ jobs:
           [ -n "${{ secrets.ISP_FOLDER_ID }}" ]              || { echo "ISP_FOLDER_ID missing"; exit 1; }
           [ -n "${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}" ] || { echo "BUILDING_INSPECTION_FOLDER_ID missing"; exit 1; }
           [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ]   || { echo "DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
-          [ -n "${{ secrets.RAYCON_WEBHOOK_SECRET }}" ]     || { echo "RAYCON_WEBHOOK_SECRET missing (HMAC auth required by spec)"; exit 1; }
+          # RAYCON_WEBHOOK_SECRET is optional: RayCon's /v1/jobs is public
+          # under the current /v1/* rollout. When set, we sign the body
+          # with HMAC-SHA256 so we're ready the day RayCon flips on
+          # signature verification.
           echo "All required secrets are present"
 
       - name: Create .env file from secrets

--- a/.github/workflows/publish-to-mcp-hive.yml
+++ b/.github/workflows/publish-to-mcp-hive.yml
@@ -53,7 +53,10 @@ jobs:
           [ -n "${{ secrets.EMAIL_APP_PASSWORD }}" ] || { echo "EMAIL_APP_PASSWORD missing"; exit 1; }
           [ -n "${{ secrets.DD_REPORT_EMAIL_RECIPIENTS }}" ] || { echo "DD_REPORT_EMAIL_RECIPIENTS missing"; exit 1; }
           [ -n "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" ] || { echo "GOOGLE_CHAT_WEBHOOK_URL missing"; exit 1; }
-          [ -n "${{ secrets.RAYCON_WEBHOOK_SECRET }}" ] || { echo "RAYCON_WEBHOOK_SECRET missing (HMAC auth required by spec)"; exit 1; }
+          # RAYCON_WEBHOOK_SECRET is optional: RayCon's /v1/jobs is public
+          # under the current /v1/* rollout. When set, we sign the body
+          # with HMAC-SHA256 so we're ready the day RayCon flips on
+          # signature verification.
           echo "All required secrets are present"
 
       - name: Get version from pyproject.toml

--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -99,19 +99,19 @@ class Settings(BaseSettings):
     raycon_api_key: str = Field(
         "",
         description=(
-            "Optional fallback API key for the X-RayCon-API-Key header. "
-            "The /v1/jobs spec is HMAC-SHA256 signed with raycon_webhook_secret "
-            "(see X-RayCon-Signature). The API key is sent only when set, for "
-            "compatibility with environments that haven't rolled to HMAC yet."
+            "Optional API key sent in X-RayCon-API-Key for RayCon's Firebase "
+            "auth path. Gated by RAYCON_REQUIRE_FIREBASE_AUTH=true on RayCon's "
+            "side (currently disabled), so leaving this blank is fine."
         ),
     )
     raycon_webhook_secret: str = Field(
         "",
         description=(
-            "Shared secret used to HMAC-SHA256 sign the raw /v1/jobs request "
-            "body. RayCon validates the signature in the X-RayCon-Signature "
-            "header. Required by the integration spec; without it, "
-            "post_raycon_job refuses to dispatch."
+            "Optional shared secret. When set, post_raycon_job HMAC-SHA256-signs "
+            "the raw /v1/jobs request body with it and sends X-RayCon-Signature. "
+            "RayCon's /v1/jobs is currently public under the /v1/* rollout and "
+            "does not validate the header, but signing keeps the canonical path "
+            "exercised so we're ready the day verification is turned on."
         ),
     )
 

--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -126,22 +126,22 @@ def post_raycon_job(
     ``block_plan_file_id`` (idempotency key), ``m1_folder_id`` (where
     RayCon writes ``raycon_scenario.json``), and ``total_building_sf``.
 
-    Auth is HMAC-SHA256 of the raw body, signed with
-    ``RAYCON_WEBHOOK_SECRET`` and sent in ``X-RayCon-Signature`` per
-    spec §1.1. If ``RAYCON_API_KEY`` is also set, it's sent in
-    ``X-RayCon-API-Key`` for backward compatibility while environments
-    roll to HMAC; the HMAC signature is the canonical auth.
+    Auth is currently a no-op: RayCon's ``/v1/jobs`` endpoint is public
+    under the ``/v1/*`` rollout (per RayCon team, 2026-04-30) and does
+    not validate webhook signatures. We still compute an HMAC-SHA256 of
+    the raw body and send it in ``X-RayCon-Signature`` *when*
+    ``RAYCON_WEBHOOK_SECRET`` is configured, so the canonical signing
+    path is exercised and ready the day RayCon enables verification —
+    but the call works fine without a secret. ``RAYCON_API_KEY``, if
+    set, is sent in ``X-RayCon-API-Key`` for the optional Firebase auth
+    path (gated by ``RAYCON_REQUIRE_FIREBASE_AUTH=true`` on RayCon's
+    side, currently disabled).
 
     The standard ``retry_config`` retries on connection errors and
     retryable HTTP status codes (429/5xx). Re-pinging with the same
     ``block_plan_file_id`` is a spec-defined no-op on RayCon's side.
     """
     settings = get_settings()
-    if not settings.raycon_webhook_secret:
-        raise RuntimeError(
-            "RAYCON_WEBHOOK_SECRET is not configured; cannot HMAC-sign the "
-            "Block Plan job request to RayCon (spec §1.1)."
-        )
     missing_required: list[str] = []
     for arg_name, arg_value in (
         ("site_id", site_id),
@@ -177,19 +177,21 @@ def post_raycon_job(
         "requested_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
-    # Serialize once, sign those exact bytes, and POST those exact bytes.
-    # Using `requests`' `json=` would re-serialize and risk a signature
-    # mismatch (different separators, key ordering, etc.).
+    # Serialize once and POST those exact bytes. Using `requests`' `json=`
+    # would re-serialize and break the signature when HMAC verification is
+    # eventually enabled on RayCon's side.
     body_bytes = json.dumps(body, separators=(",", ":"), sort_keys=False).encode("utf-8")
-    signature = _compute_hmac_signature(settings.raycon_webhook_secret, body_bytes)
 
-    headers: dict[str, str] = {
-        "Content-Type": "application/json",
-        "X-RayCon-Signature": signature,
-    }
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if settings.raycon_webhook_secret:
+        # Sign and send the signature header now so the canonical path is
+        # ready the day RayCon flips on verification. Until then RayCon
+        # ignores the header.
+        headers["X-RayCon-Signature"] = _compute_hmac_signature(
+            settings.raycon_webhook_secret, body_bytes
+        )
     if settings.raycon_api_key:
-        # Optional, kept for environments still using the legacy API key
-        # while RayCon rolls HMAC enforcement.
+        # Optional, gated by RAYCON_REQUIRE_FIREBASE_AUTH=true on RayCon.
         headers["X-RayCon-API-Key"] = settings.raycon_api_key
 
     logger.info(

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -49,8 +49,12 @@ def _ok_response(status_code: int = 202, body: dict | None = None):
 class TestPostRayConJob:
     """The POST contract is the only place DDR can break RayCon, so guard it.
 
-    Spec: raycon_ddr_integration_spec.md §1 — 11 required body fields,
-    HMAC-SHA256 of the raw body in X-RayCon-Signature.
+    Spec: raycon_ddr_integration_spec.md §1 — 11 required body fields.
+    HMAC-SHA256 of the raw body is sent in X-RayCon-Signature *when*
+    RAYCON_WEBHOOK_SECRET is configured. RayCon's /v1/jobs is currently
+    public (no signature verification) per RayCon team 2026-04-30, so
+    the secret is optional; the signing path is exercised when present
+    so we're ready the day RayCon enables verification.
     """
 
     def _fake_settings(self):
@@ -119,15 +123,29 @@ class TestPostRayConJob:
         assert headers["X-RayCon-API-Key"] == "legacy-key"
         assert headers["X-RayCon-Signature"].startswith("sha256=")
 
-    def test_missing_webhook_secret_raises(self) -> None:
+    def test_missing_webhook_secret_skips_signature_header(self) -> None:
+        """RayCon /v1/jobs is currently public; without a secret we still
+        POST the spec-shaped body but omit the X-RayCon-Signature header."""
         settings = self._fake_settings()
         settings.raycon_webhook_secret = ""
         with patch(
             "due_diligence_reporter.raycon_client.get_settings",
             return_value=settings,
-        ):
-            with pytest.raises(RuntimeError, match="RAYCON_WEBHOOK_SECRET"):
-                post_raycon_job(total_building_sf=8400, **_REQUIRED_KW)
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            result = post_raycon_job(total_building_sf=8400, **_REQUIRED_KW)
+
+        assert result == {"status": "accepted"}
+        kwargs = mock_post.call_args.kwargs
+        # Body still sent as raw bytes with the full 11-field payload.
+        body = json.loads(kwargs["data"].decode("utf-8"))
+        assert body["site_id"] == "S-123"
+        assert body["block_plan_file_id"] == "bp-123"
+        # No signature header when secret is unset.
+        assert "X-RayCon-Signature" not in kwargs["headers"]
+        assert "X-RayCon-API-Key" not in kwargs["headers"]
 
     def test_missing_required_field_raises(self) -> None:
         with patch(


### PR DESCRIPTION
RayCon team confirmed (2026-04-30) that `/v1/jobs` is currently public under the `/v1/*` rollout — no shared secret exists, no HMAC verification on RayCon's side. The strict `RuntimeError` and workflow secret check from PR #44 would break every production hand-off until RayCon ships verification, which is "a while" away.

Making the secret optional while keeping the signing path intact for future cutover.

## Behavior

| `RAYCON_WEBHOOK_SECRET` | Result |
| --- | --- |
| Unset (current prod) | POST goes through, no `X-RayCon-Signature` header, RayCon accepts publicly |
| Set | POST goes through with `X-RayCon-Signature: sha256=<hex>` over the raw body bytes (ready for the day RayCon enables verification) |

Body shape, idempotency key (`block_plan_file_id`), and `data=`-byte-exact serialization are unchanged — only the signature header becomes conditional.

## Changes

- `src/due_diligence_reporter/raycon_client.py`: dropped the `RuntimeError` when secret is unset; `X-RayCon-Signature` only added when configured. Docstring rewrote to document current state.
- `src/due_diligence_reporter/config.py`: field descriptions for `raycon_webhook_secret` and `raycon_api_key` rewrote — both are explicitly optional, with explanation of RayCon's current public state and the Firebase auth flag.
- `.github/workflows/inbox-scan.yml`, `.github/workflows/publish-to-mcp-hive.yml`: removed the `RAYCON_WEBHOOK_SECRET missing → exit 1` check; replaced with a comment explaining it's optional.
- `.env.example`: `RAYCON_WEBHOOK_SECRET` now blank with comment explaining the rollout state.
- `tests/test_raycon_client.py`: replaced `test_missing_webhook_secret_raises` with `test_missing_webhook_secret_skips_signature_header` — verifies the body still POSTs but no signature header is sent.
- `raycon_ddr_integration_spec.md`: status section + §1.1 split into "target" (HMAC required) and "current 2026-04-30" (public, signing best-effort).

## Tests
- 742 passed (full suite, excluding 3 pre-existing unrelated permit_history failures).
- Updated test confirms missing secret → no signature header, body still goes through.

## Deployment
No new GitHub secret required. After this merges, prod resumes full RayCon hand-off without any other action. When RayCon ships HMAC verification, we (1) generate a secret, (2) share with RayCon, (3) add `RAYCON_WEBHOOK_SECRET` to GitHub Actions secrets — done; signing flips on automatically.
