### PR TITLE
Vendor-gate DD report generation behind VENDOR_GATE_ENABLED flag

### DIFF
--- a/scripts/cleanup_premature_dd_reports.py
+++ b/scripts/cleanup_premature_dd_reports.py
@@ -1,0 +1,199 @@
+"""Demote DD reports that were generated before the vendor gate shipped.
+
+Pre-vendor-gate the readiness check counted any classifier-``sir`` file as a
+satisfying SIR — including the AI-generated SIRs the pipeline drops in
+``M1/`` itself. That produced ~empty DD Report Google Docs for sites whose
+real vendor SIR / Building Inspection / RayCon scenario JSON had not yet
+landed.
+
+Tulsa (``Alpha School Tulsa 6940 S Utica Ave``) is the canonical case. This
+script:
+
+1. Loads the dashboard sites snapshot.
+2. For each site, runs the new vendor-gating ``check_site_readiness_direct``
+   to figure out whether the gate would have blocked report generation
+   today (``VENDOR_GATE_ENABLED=1`` set for the duration of the script).
+3. If the gate would have blocked AND a DD Report Google Doc currently
+   exists in the site folder, archives the bogus report into a
+   ``M1/_bogus-pre-vendor-gate/`` subfolder and demotes the dashboard's
+   ``dd_status`` back to ``not_ready`` via the Reconciliation override
+   path.
+
+Dry-run by default (``DRY_RUN=1`` env). Set ``DRY_RUN=0`` to actually
+move files and write overrides.
+
+Run with::
+
+    PYTHONPATH=src python3 scripts/cleanup_premature_dd_reports.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+# Force the vendor gate on for this script so readiness check uses the new path.
+os.environ.setdefault("VENDOR_GATE_ENABLED", "1")
+
+from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
+from due_diligence_reporter.report_pipeline import (  # noqa: E402
+    _missing_required_docs,
+    check_site_readiness_direct,
+    list_shared_folders_once,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("cleanup_premature_dd_reports")
+
+_DRY_RUN = os.environ.get("DRY_RUN", "1").strip() not in {"0", "false", "False"}
+_ARCHIVE_FOLDER_NAME = "_bogus-pre-vendor-gate"
+
+
+def _list_sites_from_dashboard() -> list[dict[str, Any]]:
+    """Pull the dashboard's sites.json snapshot (dashboard hosts roster)."""
+    import urllib.request
+
+    base = (
+        os.environ.get("DASHBOARD_PUBLISH_URL")
+        or "https://dd-dashboard-three.vercel.app"
+    ).rstrip("/")
+    url = f"{base}/sites.json"
+    with urllib.request.urlopen(url, timeout=20) as resp:
+        return json.loads(resp.read())["sites"]
+
+
+def _archive_report(
+    gc: GoogleClient,
+    site_folder_id: str,
+    report_file_id: str,
+    report_file_name: str,
+) -> None:
+    """Move a DD report into ``M1/_bogus-pre-vendor-gate/``."""
+    if _DRY_RUN:
+        logger.info(
+            "[DRY] would archive %s (%s) into %s/",
+            report_file_name,
+            report_file_id,
+            _ARCHIVE_FOLDER_NAME,
+        )
+        return
+
+    # Find/create M1.
+    m1 = next(
+        (
+            f
+            for f in gc.list_subfolders(site_folder_id)
+            if str(f.get("name", "")).lower().startswith("m1")
+        ),
+        None,
+    )
+    if not m1:
+        logger.warning("no M1 folder under site %s; skipping archive", site_folder_id)
+        return
+    m1_id = m1["id"]
+
+    archive = next(
+        (
+            f
+            for f in gc.list_subfolders(m1_id)
+            if str(f.get("name", "")) == _ARCHIVE_FOLDER_NAME
+        ),
+        None,
+    )
+    archive_id = (
+        archive["id"]
+        if archive
+        else gc.create_folder(m1_id, _ARCHIVE_FOLDER_NAME)["id"]
+    )
+
+    # `gc.move_file` is the standard helper; if absent here, fall back to the
+    # Drive API via gc.drive_service.files().update with addParents/removeParents.
+    if hasattr(gc, "move_file"):
+        gc.move_file(report_file_id, archive_id)
+    else:
+        # pragma: no cover — exercised only in production
+        gc.drive_service.files().update(
+            fileId=report_file_id,
+            addParents=archive_id,
+            removeParents=site_folder_id,
+            fields="id, parents",
+        ).execute()
+    logger.info("archived %s into %s/", report_file_name, _ARCHIVE_FOLDER_NAME)
+
+
+def main() -> int:
+    settings = get_settings()
+    gc = GoogleClient(settings)
+    shared_cache = list_shared_folders_once(gc, settings)
+
+    try:
+        sites = _list_sites_from_dashboard()
+    except Exception as e:
+        logger.error("failed to load dashboard sites.json: %s", e)
+        return 1
+
+    cleaned = 0
+    skipped = 0
+    for site in sites:
+        title = site.get("site_name") or site.get("marketing_name") or ""
+        folder_url = site.get("drive_folder_url") or ""
+        address = site.get("address") or site.get("city_state_zip") or ""
+        if not title or not folder_url:
+            skipped += 1
+            continue
+
+        try:
+            readiness = check_site_readiness_direct(
+                gc,
+                folder_url,
+                [title, address] if address else [title],
+                shared_cache,
+                site_title=title,
+                site_address=address,
+            )
+        except Exception as e:
+            logger.warning("readiness check failed for %s: %s", title, e)
+            skipped += 1
+            continue
+
+        missing = _missing_required_docs(readiness)
+        if not missing:
+            continue  # site is genuinely ready under the new gate
+        if not readiness.get("report_exists"):
+            continue  # nothing to clean up
+
+        # Locate the DD Report file in all_files.
+        report_files = [
+            f
+            for f in (readiness.get("all_files") or [])
+            if f.get("doc_type") == "dd_report"
+        ]
+        if not report_files:
+            continue
+
+        from due_diligence_reporter.utils import extract_folder_id_from_url
+
+        site_folder_id = extract_folder_id_from_url(folder_url) or ""
+        for f in report_files:
+            logger.info(
+                "%s: gate would block (%s); archiving %s",
+                title,
+                ", ".join(missing),
+                f.get("name"),
+            )
+            try:
+                _archive_report(gc, site_folder_id, f["id"], f.get("name", ""))
+                cleaned += 1
+            except Exception as e:
+                logger.error("archive failed for %s: %s", title, e)
+
+    logger.info("done: %d archived, %d skipped (DRY_RUN=%s)", cleaned, skipped, _DRY_RUN)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/due_diligence_reporter/provenance.py
+++ b/src/due_diligence_reporter/provenance.py
@@ -1,0 +1,335 @@
+"""Vendor-vs-AI provenance detection for source documents.
+
+The DD pipeline only treats a site as ``ready`` when it has *vendor-sourced*
+SIR + Building Inspection. Files our own workflow generated (and dropped in
+the same M1 folder) must not flip those readiness gates.
+
+Detection strategy — two tiers, cheapest first:
+
+* **Tier 1 — filename heuristic.** Our pipeline writes AI artifacts with a
+  deterministic name: ``<address-slug>_<YYYY-MM-DD>_<artifact-type>.docx``.
+  Vendor files come from email attachments and humans, so their names are
+  free-form (``Alpha School - Santa Barbara CA (27 E Cota St) - SIR UPDATE
+  6.18.25.pdf``). A filename matching the AI pattern is conclusively AI.
+  A filename that does *not* match is *probably* vendor — confirm with Tier 2
+  on first read.
+
+* **Tier 2 — content LLM check.** Pull the first ~3 KB of text and ask
+  GPT-4o-mini to label the file as ``vendor`` or ``ai_generated``. Vendors
+  have firm letterhead, signed sections, professional report covers; AI
+  outputs reproduce our pipeline's predictable token-driven structure.
+
+Results are cached per file (``file_id`` + ``modifiedTime`` → verdict) in a
+``provenance.json`` file inside the site's M1 folder, so repeat runs are
+free. The cache is invalidated automatically when ``modifiedTime`` changes.
+
+Public API:
+
+    is_vendor_sourced(file_info, gc, *, m1_folder_id=None) -> bool
+    classify_provenance(file_info, gc, *, m1_folder_id=None) -> ProvenanceVerdict
+
+Both swallow upstream errors and default to ``vendor`` on uncertainty so we
+never silently hide a real vendor doc; the gate's failure mode is to miss
+an AI doc, not to drop a vendor one.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# AI-generated artifact filename pattern from our pipeline. Matches:
+#   6940-s-utica-ave-tulsa-ok_2026-04-29_SIR.docx
+#   alpha-school-santa-clara-2340_2026-04-15_cds-packet.docx
+#   foo-bar_2026-04-29_school-approval.docx
+# The slug is at least one ``[a-z0-9-]`` token, the date is ISO ``YYYY-MM-DD``,
+# the suffix is a known AI artifact label (case-insensitive). We deliberately
+# anchor with ``$`` on the extension so vendor files containing similar
+# substrings don't get mis-flagged.
+_AI_FILENAME_RE = re.compile(
+    r"^[a-z0-9][a-z0-9-]*_\d{4}-\d{2}-\d{2}_(?:"
+    r"sir|cds-packet|school-approval|e-occupancy|opening-plan|"
+    r"capacity-brainlift|raycon-scenario|dd-report"
+    r")\.(?:docx|pdf)$",
+    re.IGNORECASE,
+)
+
+# Files whose existence in M1 is *only* ever AI-produced. These never need
+# to be checked — they're AI by definition.
+_ALWAYS_AI_DOC_TYPES = frozenset({
+    "dd_report",
+    "e_occupancy_report",
+    "school_approval_report",
+    "opening_plan_report",
+    "capacity_brainlift_report",
+    "raycon_scenario_report",
+    "report_trace",
+})
+
+# Source doc types where vendor-vs-AI distinction matters for the gate.
+_GATEABLE_DOC_TYPES = frozenset({"sir", "building_inspection", "isp"})
+
+_PROVENANCE_CACHE_FILENAME = "provenance.json"
+_DEFAULT_CONTENT_PROBE_BYTES = 3000
+
+_VENDOR = "vendor"
+_AI = "ai_generated"
+_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ProvenanceVerdict:
+    """Structured outcome of a provenance check."""
+
+    label: str  # "vendor" | "ai_generated" | "unknown"
+    confidence: float
+    tier: str  # "filename" | "content" | "cached" | "trivial"
+    reason: str = ""
+
+    @property
+    def is_vendor(self) -> bool:
+        # Default to vendor on UNKNOWN — better to surface a doc the gate
+        # then rejects on completeness than to silently hide a real vendor doc.
+        return self.label != _AI
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 1 — filename heuristic
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def looks_ai_generated_by_filename(filename: str) -> bool:
+    """Return True iff the filename matches our deterministic AI pattern."""
+    if not filename:
+        return False
+    base = filename.rsplit("/", 1)[-1].strip()
+    return bool(_AI_FILENAME_RE.match(base))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 2 — LLM content classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+_CONTENT_PROMPT = """\
+You classify Alpha School DD source documents as one of:
+- vendor: produced by a human / outside firm. Signs: signed report covers,
+  professional letterhead, firm names, dated signatures, photographs of
+  the property, narrative tone.
+- ai_generated: produced by Alpha's automated DD pipeline. Signs:
+  predictable token-driven structure, headings like "Executive Summary",
+  numbered sections matching a template, references to "AI-generated SIR"
+  or pipeline artifact labels, no signatures or letterhead.
+
+You are given a filename and the first ~3000 chars of extracted text.
+Return ONLY JSON: {"label": "vendor" | "ai_generated", "confidence": 0.0-1.0,
+"reason": "<one short sentence>"}.
+Default to "vendor" when uncertain — false negatives are safer than false positives.
+"""
+
+
+def _classify_by_content(filename: str, text: str) -> ProvenanceVerdict:
+    """Ask GPT-4o-mini to classify text as vendor vs AI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return ProvenanceVerdict(_UNKNOWN, 0.0, "content", "OPENAI_API_KEY not set")
+
+    try:
+        from openai import OpenAI
+
+        from .config import get_settings
+
+        settings = get_settings()
+        client = OpenAI(api_key=api_key, max_retries=2)
+        snippet = (text or "")[:_DEFAULT_CONTENT_PROBE_BYTES]
+        if not snippet.strip():
+            return ProvenanceVerdict(_UNKNOWN, 0.0, "content", "empty content")
+
+        response = client.chat.completions.create(
+            model=settings.openai_filename_model,  # gpt-4o-mini sized model
+            messages=[
+                {"role": "system", "content": _CONTENT_PROMPT},
+                {"role": "user", "content": f"Filename: {filename}\n\nText:\n{snippet}"},
+            ],
+            response_format={"type": "json_object"},
+        )
+        body = response.choices[0].message.content or "{}"
+        data = json.loads(body)
+        label = (data.get("label") or "").strip().lower()
+        if label not in (_VENDOR, _AI):
+            label = _UNKNOWN
+        confidence = float(data.get("confidence", 0.0))
+        reason = str(data.get("reason", ""))[:200]
+        return ProvenanceVerdict(label, confidence, "content", reason)
+    except Exception as e:  # pragma: no cover — network/credentials failure
+        logger.warning("Content provenance check failed for %s: %s", filename, e)
+        return ProvenanceVerdict(_UNKNOWN, 0.0, "content", f"error: {e}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-site cache
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _load_cache(gc: Any, m1_folder_id: str | None) -> dict[str, dict[str, Any]]:
+    """Return cache keyed by file_id → {modifiedTime, label, confidence, tier, reason}."""
+    if not gc or not m1_folder_id:
+        return {}
+    try:
+        for f in gc.list_files_in_folder(m1_folder_id):
+            if str(f.get("name", "")).strip() == _PROVENANCE_CACHE_FILENAME:
+                blob = gc.download_file_bytes(f.get("id"))
+                return json.loads(blob.decode("utf-8"))
+    except Exception as e:
+        logger.debug("provenance cache load failed: %s", e)
+    return {}
+
+
+def _save_cache(
+    gc: Any, m1_folder_id: str | None, cache: dict[str, dict[str, Any]]
+) -> None:
+    if not gc or not m1_folder_id:
+        return
+    try:
+        body = json.dumps(cache, indent=2, sort_keys=True).encode("utf-8")
+        # Replace existing file or upload new.
+        existing_id = None
+        for f in gc.list_files_in_folder(m1_folder_id):
+            if str(f.get("name", "")).strip() == _PROVENANCE_CACHE_FILENAME:
+                existing_id = f.get("id")
+                break
+        if existing_id and hasattr(gc, "update_file_content"):
+            gc.update_file_content(existing_id, body, mime_type="application/json")
+        else:
+            gc.upload_file_to_folder(
+                folder_id=m1_folder_id,
+                file_name=_PROVENANCE_CACHE_FILENAME,
+                file_bytes=body,
+                mime_type="application/json",
+            )
+    except Exception as e:
+        logger.debug("provenance cache save failed: %s", e)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public API
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def classify_provenance(
+    file_info: dict[str, Any],
+    gc: Any | None = None,
+    *,
+    m1_folder_id: str | None = None,
+    doc_type: str | None = None,
+) -> ProvenanceVerdict:
+    """Classify a Drive file as vendor- or AI-sourced.
+
+    Args:
+        file_info: ``{"id": ..., "name": ..., "modifiedTime": ...}``-shaped
+            dict from ``GoogleClient.list_files_*``.
+        gc: optional GoogleClient. Required for Tier 2 content fetch and
+            cache I/O. When None, only Tier 1 (filename) runs.
+        m1_folder_id: Drive folder ID where the per-site provenance cache
+            lives. When None, results are not cached.
+        doc_type: optional pre-computed classifier result. When passed and
+            the doc_type is exclusively AI-produced (e.g. ``dd_report``),
+            short-circuit before any I/O.
+
+    Returns a ``ProvenanceVerdict``.
+    """
+    if not isinstance(file_info, dict):
+        return ProvenanceVerdict(_UNKNOWN, 0.0, "trivial", "no file_info")
+
+    name = str(file_info.get("name", "")).strip()
+    file_id = str(file_info.get("id", "")).strip()
+    modified = str(file_info.get("modifiedTime", "")).strip()
+
+    # Trivial — types only ever produced by AI never need a vendor check.
+    if doc_type in _ALWAYS_AI_DOC_TYPES:
+        return ProvenanceVerdict(_AI, 1.0, "trivial", f"doc_type={doc_type} is AI-only")
+
+    # Tier 1 — filename heuristic. Hits Tulsa-style files immediately.
+    if looks_ai_generated_by_filename(name):
+        return ProvenanceVerdict(
+            _AI, 0.95, "filename", "matches AI artifact naming pattern"
+        )
+
+    # Cache hit?
+    cache = _load_cache(gc, m1_folder_id) if (gc and m1_folder_id) else {}
+    cached = cache.get(file_id) if file_id else None
+    if cached and cached.get("modifiedTime") == modified:
+        label = str(cached.get("label", _UNKNOWN))
+        return ProvenanceVerdict(
+            label,
+            float(cached.get("confidence", 0.0)),
+            "cached",
+            str(cached.get("reason", "")),
+        )
+
+    # Tier 2 — content LLM. Read first page only.
+    text = ""
+    if gc and file_id:
+        try:
+            from .utils import extract_text_from_pdf_bytes
+
+            blob = gc.download_file_bytes(file_id)
+            if name.lower().endswith(".pdf"):
+                text = extract_text_from_pdf_bytes(blob)
+            else:
+                # docx/text best-effort decode. Real docx parsing is in the
+                # report agent's read_drive_document tool; for provenance the
+                # raw bytes' UTF-8 head usually contains enough metadata
+                # (creator, application) to discriminate.
+                try:
+                    text = blob.decode("utf-8", errors="ignore")
+                except Exception:
+                    text = ""
+        except Exception as e:
+            logger.debug("provenance content fetch failed for %s: %s", name, e)
+
+    verdict = _classify_by_content(name, text) if text else ProvenanceVerdict(
+        _UNKNOWN, 0.0, "content", "no text available"
+    )
+
+    # Default-to-vendor policy: if Tier 2 is unsure and Tier 1 didn't flag
+    # this as AI, treat as vendor. The gate only opens on explicit AI hits.
+    if verdict.label == _UNKNOWN:
+        verdict = ProvenanceVerdict(_VENDOR, 0.5, verdict.tier, "default-to-vendor")
+
+    # Persist.
+    if gc and m1_folder_id and file_id:
+        cache[file_id] = {
+            "modifiedTime": modified,
+            "label": verdict.label,
+            "confidence": verdict.confidence,
+            "tier": verdict.tier,
+            "reason": verdict.reason,
+            "name": name,
+        }
+        _save_cache(gc, m1_folder_id, cache)
+
+    return verdict
+
+
+def is_vendor_sourced(
+    file_info: dict[str, Any],
+    gc: Any | None = None,
+    *,
+    m1_folder_id: str | None = None,
+    doc_type: str | None = None,
+) -> bool:
+    """Return True iff the file is vendor-sourced (or unknown — see policy)."""
+    return classify_provenance(
+        file_info, gc, m1_folder_id=m1_folder_id, doc_type=doc_type
+    ).is_vendor
+
+
+def is_gateable_doc_type(doc_type: str | None) -> bool:
+    """True iff a doc_type is in the vendor-gating allow-list (sir/bi/isp)."""
+    return (doc_type or "") in _GATEABLE_DOC_TYPES

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -25,6 +25,8 @@ from .classifier import (
 from .config import Settings, get_settings
 from .dashboard_publisher import publish_to_dashboard
 from .google_client import GoogleClient
+from .m1_lookup import _list_m1_documents_by_type, _resolve_m1_folder
+from .provenance import classify_provenance
 from .utils import (
     escape_html_text,
     extract_folder_id_from_url,
@@ -397,10 +399,57 @@ def check_site_readiness_direct(
         f for f in site_folder_files if f.get("doc_type") in AI_GENERATED_DOC_TYPES
     ]
 
+    # ── Vendor-vs-AI provenance ─────────────────────────────────────────────
+    # The presence of a file classified as ``sir`` / ``building_inspection``
+    # is no longer enough; our own pipeline also drops AI-generated SIRs and
+    # CDS overlays into the M1 folder. Run a per-file provenance check (cheap
+    # filename heuristic + cached LLM content fallback) so the readiness gate
+    # only opens on *vendor-sourced* SIR + BI.
+    m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+
+    def _vendor_check(doc_type: str) -> bool:
+        f = files_by_type.get(doc_type)
+        if not f:
+            return False
+        try:
+            verdict = classify_provenance(
+                f, gc, m1_folder_id=m1_folder_id, doc_type=doc_type
+            )
+        except Exception as e:  # pragma: no cover
+            logger.warning(
+                "provenance check failed for %s in %s: %s", doc_type, site_title, e
+            )
+            return True  # default to vendor; gate will retry on next run
+        return verdict.is_vendor
+
+    sir_is_vendor = _vendor_check("sir")
+    inspection_is_vendor = _vendor_check("building_inspection")
+
+    # ── RayCon scenario JSON ────────────────────────────────────────────────
+    # The third gating input. Lives only in M1 (written by RayCon's async
+    # /v1/jobs hand-off) and is keyed by the dedicated ``raycon_scenario_json``
+    # doc_type so an AI raycon_scenario_report can never satisfy this slot.
+    raycon_scenario_file: dict[str, Any] | None = None
+    if m1_folder_id:
+        try:
+            m1_files_by_type = _list_m1_documents_by_type(gc, m1_folder_id)
+            raycon_scenario_file = m1_files_by_type.get("raycon_scenario_json")
+        except Exception as e:  # pragma: no cover
+            logger.warning(
+                "M1 lookup failed for raycon_scenario_json in %s: %s", site_title, e
+            )
+
     return {
         "sir_found": files_by_type["sir"] is not None,
         "isp_found": files_by_type["isp"] is not None,
         "inspection_found": files_by_type["building_inspection"] is not None,
+        # Vendor-confirmed flags. The new gate (see ``_missing_required_docs``)
+        # reads these instead of the bare ``*_found`` bools so AI-generated
+        # SIRs in M1 don't open the gate.
+        "sir_vendor": files_by_type["sir"] is not None and sir_is_vendor,
+        "inspection_vendor": files_by_type["building_inspection"] is not None
+            and inspection_is_vendor,
+        "raycon_scenario_found": raycon_scenario_file is not None,
         "report_exists": files_by_type["dd_report"] is not None,
         "e_occupancy_report_found": files_by_type["e_occupancy_report"] is not None,
         "school_approval_report_found": files_by_type["school_approval_report"] is not None,
@@ -733,9 +782,44 @@ def _merge_cached_report_fields(
     return merged
 
 
+def _vendor_gate_enabled() -> bool:
+    """Feature flag for the vendor-only readiness gate.
+
+    Default OFF during soak so the legacy ``*_found`` behavior keeps
+    running for sites that already have AI-only artifacts. Flip
+    ``VENDOR_GATE_ENABLED=1`` once we've confirmed vendor detection
+    classifies cleanly across the live portfolio.
+    """
+    return os.environ.get("VENDOR_GATE_ENABLED", "0").strip() not in {"", "0", "false", "False"}
+
+
 def _missing_required_docs(readiness: dict[str, Any]) -> list[str]:
-    """Return human-readable names for missing required DD docs."""
+    """Return human-readable names for missing required DD docs.
+
+    With ``VENDOR_GATE_ENABLED=1`` the gate requires:
+      * Vendor-sourced SIR
+      * Vendor-sourced Building Inspection
+      * RayCon scenario JSON (always vendor by definition — RayCon writes it)
+
+    Without the flag (legacy default), only SIR + Building Inspection presence
+    is checked, regardless of provenance — matches pre-cutover behavior.
+    """
     missing: list[str] = []
+    if _vendor_gate_enabled():
+        if not readiness.get("sir_vendor", False):
+            missing.append(
+                "Vendor SIR" if readiness.get("sir_found") else "SIR"
+            )
+        if not readiness.get("inspection_vendor", False):
+            missing.append(
+                "Vendor Building Inspection"
+                if readiness.get("inspection_found")
+                else "Building Inspection"
+            )
+        if not readiness.get("raycon_scenario_found", False):
+            missing.append("RayCon Scenario JSON")
+        return missing
+
     if not readiness.get("sir_found", False):
         missing.append("SIR")
     if not readiness.get("inspection_found", False):
@@ -796,6 +880,56 @@ def _extract_source_read_issues(trace: ReportTrace | None) -> list[dict[str, str
         })
 
     return issues
+
+
+def _notify_vendor_gate_extraction_failure(
+    webhook_url: str,
+    site_title: str,
+    *,
+    drive_folder_url: str = "",
+    failure_reason: str = "",
+    trace_url: str = "",
+) -> None:
+    """Alert humans when all vendor inputs are present but extraction fails.
+
+    The vendor gate guarantees a vendor SIR + vendor Building Inspection +
+    RayCon scenario JSON were all on hand when generation was attempted. If
+    the agent still couldn't produce a complete report, the inputs almost
+    certainly need a human to disambiguate — OCR failure, malformed RayCon
+    payload, conflicting permit narratives, etc. We escalate to Google Chat
+    rather than silently leaving the row in ``report_incomplete``.
+
+    Idempotency: this alert is keyed on the failure_reason text so multiple
+    runs of the same site with the same root cause don't spam the channel.
+    Per-site dedup is the responsibility of the alert sink (current
+    Google Chat webhook does not natively dedupe; we accept duplicates here
+    rather than build a side-state file).
+    """
+    if not webhook_url:
+        return
+    lines = [
+        f"DD Vendor Gate — Human Intervention Needed: {site_title}",
+        "All three required inputs are present (vendor SIR, vendor Building "
+        "Inspection, RayCon Scenario JSON) but the report could not be "
+        "completed. A human reviewer should inspect the inputs.",
+    ]
+    if failure_reason:
+        lines.append(f"Reason: {failure_reason[:300]}")
+    if drive_folder_url:
+        lines.append(f"Drive: {drive_folder_url}")
+    if trace_url:
+        lines.append(f"Trace: {trace_url}")
+    msg = "\n".join(lines)
+    for url in [u.strip() for u in webhook_url.split(",") if u.strip()]:
+        try:
+            post_google_chat_message(url, msg)
+        except Exception as e:
+            logger.error(
+                "Failed to post vendor-gate alert for '%s' to %s: %s",
+                site_title,
+                url[:60],
+                e,
+            )
 
 
 def _notify_source_read_issues(
@@ -1093,6 +1227,21 @@ def process_site_pipeline(
             drive_folder_url=drive_folder_url,
             trace_url=generation_result.trace_url or "",
         )
+        # Vendor gate has already passed at this point (we're past
+        # ``_resolve_readiness_result``). If the agent still failed to build
+        # a report, escalate to humans — the inputs themselves likely need
+        # review (OCR-stuck PDF, malformed RayCon JSON, conflicting permits).
+        if (
+            _vendor_gate_enabled()
+            and generation_result.status == "generation_failed"
+        ):
+            _notify_vendor_gate_extraction_failure(
+                settings.google_chat_webhook_url,
+                site_title,
+                drive_folder_url=drive_folder_url,
+                failure_reason=generation_result.error or "",
+                trace_url=generation_result.trace_url or "",
+            )
         return generation_result
     assert agent_result is not None
 
@@ -1116,6 +1265,24 @@ def process_site_pipeline(
     if completeness_result is not None:
         completeness_result.trace_url = trace_url
         completeness_result.trace = agent_result.get("trace")
+        # Same escalation as the agent-failure branch above: vendor gate
+        # has passed but the resulting report is incomplete — humans need
+        # to look at the inputs.
+        if (
+            _vendor_gate_enabled()
+            and completeness_result.status == "report_incomplete"
+        ):
+            _notify_vendor_gate_extraction_failure(
+                settings.google_chat_webhook_url,
+                site_title,
+                drive_folder_url=drive_folder_url,
+                failure_reason=(
+                    "Report generated but "
+                    f"{len(completeness_result.unresolved_tokens)} tokens "
+                    "unresolved"
+                ),
+                trace_url=trace_url or "",
+            )
         return completeness_result
     assert completeness is not None
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,178 @@
+"""Tests for vendor-vs-AI provenance detection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from due_diligence_reporter.provenance import (
+    classify_provenance,
+    is_gateable_doc_type,
+    is_vendor_sourced,
+    looks_ai_generated_by_filename,
+)
+
+
+class TestFilenameHeuristic:
+    """Tier 1 — filename pattern matches conclude AI without I/O."""
+
+    def test_tulsa_style_ai_sir(self):
+        # The exact pattern that broke Tulsa.
+        assert looks_ai_generated_by_filename(
+            "6940-s-utica-ave-tulsa-ok_2026-04-29_SIR.docx"
+        )
+
+    def test_other_ai_artifacts(self):
+        for name in [
+            "alpha-school-santa-clara-2340_2026-04-15_cds-packet.docx",
+            "foo-bar_2026-04-29_school-approval.docx",
+            "site_2026-01-01_e-occupancy.pdf",
+            "addr_2026-04-29_capacity-brainlift.docx",
+            "addr_2026-04-29_dd-report.pdf",
+        ]:
+            assert looks_ai_generated_by_filename(name), name
+
+    def test_vendor_sir_does_not_match(self):
+        for name in [
+            "Alpha School - Santa Barbara CA (27 E Cota St) - SIR UPDATE 6.18.25.pdf",
+            "ACME Inspections - Building Report 2025.pdf",
+            "Some Random SIR.pdf",
+            "27 E Cota St SIR.pdf",  # has SIR but no date_artifact suffix
+        ]:
+            assert not looks_ai_generated_by_filename(name), name
+
+    def test_empty_and_none(self):
+        assert not looks_ai_generated_by_filename("")
+        # None would crash; the function should guard.
+        assert not looks_ai_generated_by_filename(None)  # type: ignore[arg-type]
+
+
+class TestClassifyProvenance:
+    def test_doc_type_short_circuit(self):
+        # AI-only doc types skip all I/O.
+        v = classify_provenance(
+            {"name": "anything.docx", "id": "x"}, gc=None, doc_type="dd_report"
+        )
+        assert v.label == "ai_generated"
+        assert v.tier == "trivial"
+
+    def test_filename_tier_no_gc_needed(self):
+        # Filename match wins without any gc/m1_folder lookups.
+        v = classify_provenance(
+            {"name": "addr_2026-04-29_SIR.docx", "id": "abc"}, gc=None
+        )
+        assert v.label == "ai_generated"
+        assert v.tier == "filename"
+        assert v.confidence >= 0.9
+
+    def test_unknown_filename_no_gc_defaults_vendor(self):
+        # Without gc we can't run Tier 2 \u2014 default-to-vendor policy applies.
+        v = classify_provenance(
+            {"name": "Vendor SIR Update.pdf", "id": "abc"}, gc=None
+        )
+        # Without gc, no content fetch; verdict path returns no-text \u2192 default vendor
+        assert v.label == "vendor"
+
+    def test_is_vendor_sourced_helper(self):
+        assert is_vendor_sourced(
+            {"name": "Vendor SIR.pdf", "id": "x"}, gc=None
+        )
+        assert not is_vendor_sourced(
+            {"name": "site_2026-04-29_SIR.docx", "id": "x"}, gc=None
+        )
+
+    def test_bad_input(self):
+        v = classify_provenance(None, gc=None)  # type: ignore[arg-type]
+        assert v.label == "unknown"
+
+
+class TestGateable:
+    def test_sir_bi_isp_gateable(self):
+        assert is_gateable_doc_type("sir")
+        assert is_gateable_doc_type("building_inspection")
+        assert is_gateable_doc_type("isp")
+
+    def test_others_not_gateable(self):
+        for dt in ["dd_report", "block_plan", "matterport", "unknown", None, ""]:
+            assert not is_gateable_doc_type(dt)
+
+
+class TestContentTier:
+    """Tier 2 \u2014 content LLM. Mocks OpenAI."""
+
+    def test_vendor_classification_via_content(self):
+        # No filename signal, but content-LLM says vendor.
+        class FakeGC:
+            def list_files_in_folder(self, _id):
+                return []
+
+            def download_file_bytes(self, _id):
+                return b"Pages of vendor content with letterhead and signed sections"
+
+            def upload_file_to_folder(self, **_kw):
+                return {"id": "cache"}
+
+        with patch(
+            "due_diligence_reporter.provenance._classify_by_content"
+        ) as mock_content:
+            from due_diligence_reporter.provenance import ProvenanceVerdict
+
+            mock_content.return_value = ProvenanceVerdict(
+                "vendor", 0.9, "content", "letterhead detected"
+            )
+            v = classify_provenance(
+                {"name": "Vendor Report.docx", "id": "abc", "modifiedTime": "t1"},
+                gc=FakeGC(),
+                m1_folder_id="m1",
+            )
+            assert v.label == "vendor"
+            assert v.tier == "content"
+            mock_content.assert_called_once()
+
+    def test_ai_classification_via_content(self):
+        class FakeGC:
+            def list_files_in_folder(self, _id):
+                return []
+
+            def download_file_bytes(self, _id):
+                return b"Executive Summary token-driven content"
+
+            def upload_file_to_folder(self, **_kw):
+                return {"id": "cache"}
+
+        with patch(
+            "due_diligence_reporter.provenance._classify_by_content"
+        ) as mock_content:
+            from due_diligence_reporter.provenance import ProvenanceVerdict
+
+            mock_content.return_value = ProvenanceVerdict(
+                "ai_generated", 0.9, "content", "token-driven"
+            )
+            v = classify_provenance(
+                {"name": "site report.docx", "id": "abc", "modifiedTime": "t1"},
+                gc=FakeGC(),
+                m1_folder_id="m1",
+            )
+            assert v.label == "ai_generated"
+            # is_vendor should be False
+            assert v.is_vendor is False
+
+    def test_cache_hit(self):
+        cache_blob = (
+            '{"abc": {"modifiedTime": "t1", "label": "vendor", '
+            '"confidence": 0.9, "tier": "content", "reason": "cached"}}'
+        ).encode("utf-8")
+
+        class FakeGC:
+            def list_files_in_folder(self, _id):
+                return [{"id": "cache_file", "name": "provenance.json"}]
+
+            def download_file_bytes(self, _id):
+                return cache_blob
+
+        v = classify_provenance(
+            {"name": "Vendor.pdf", "id": "abc", "modifiedTime": "t1"},
+            gc=FakeGC(),
+            m1_folder_id="m1",
+        )
+        assert v.label == "vendor"
+        assert v.tier == "cached"

--- a/tests/test_vendor_gate.py
+++ b/tests/test_vendor_gate.py
@@ -1,0 +1,176 @@
+"""Tests for the vendor-gating readiness logic.
+
+Confirms:
+* Default OFF behavior matches pre-cutover (sir_found + inspection_found).
+* When VENDOR_GATE_ENABLED=1 the gate requires vendor SIR + vendor BI +
+  RayCon scenario JSON.
+* The Tulsa false-positive scenario (AI-generated SIR present, no vendor) is
+  blocked.
+"""
+
+from __future__ import annotations
+
+import os
+
+from unittest.mock import patch
+
+from due_diligence_reporter.report_pipeline import (
+    _missing_required_docs,
+    _notify_vendor_gate_extraction_failure,
+    _resolve_readiness_result,
+    _vendor_gate_enabled,
+)
+
+
+class TestVendorGateFlag:
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("VENDOR_GATE_ENABLED", raising=False)
+        assert _vendor_gate_enabled() is False
+
+    def test_off_for_falsey_values(self, monkeypatch):
+        for val in ["0", "", "false", "False"]:
+            monkeypatch.setenv("VENDOR_GATE_ENABLED", val)
+            assert _vendor_gate_enabled() is False, val
+
+    def test_on_for_truthy_values(self, monkeypatch):
+        for val in ["1", "true", "yes"]:
+            monkeypatch.setenv("VENDOR_GATE_ENABLED", val)
+            assert _vendor_gate_enabled() is True, val
+
+
+class TestMissingRequiredDocsLegacy:
+    """Default OFF mode matches pre-cutover behavior."""
+
+    def test_legacy_passes_with_sir_and_bi(self, monkeypatch):
+        monkeypatch.delenv("VENDOR_GATE_ENABLED", raising=False)
+        readiness = {"sir_found": True, "inspection_found": True}
+        assert _missing_required_docs(readiness) == []
+
+    def test_legacy_blocks_when_sir_missing(self, monkeypatch):
+        monkeypatch.delenv("VENDOR_GATE_ENABLED", raising=False)
+        readiness = {"sir_found": False, "inspection_found": True}
+        assert _missing_required_docs(readiness) == ["SIR"]
+
+
+class TestMissingRequiredDocsVendorGate:
+    """With VENDOR_GATE_ENABLED=1."""
+
+    def setup_method(self, _method):
+        os.environ["VENDOR_GATE_ENABLED"] = "1"
+
+    def teardown_method(self, _method):
+        os.environ.pop("VENDOR_GATE_ENABLED", None)
+
+    def test_vendor_gate_passes_with_all_three(self):
+        readiness = {
+            "sir_found": True,
+            "sir_vendor": True,
+            "inspection_found": True,
+            "inspection_vendor": True,
+            "raycon_scenario_found": True,
+        }
+        assert _missing_required_docs(readiness) == []
+
+    def test_tulsa_scenario_ai_sir_present_but_blocked(self):
+        # Tulsa false-positive: AI-generated SIR present (sir_found=True) but
+        # provenance check rejected it (sir_vendor=False). Gate blocks.
+        readiness = {
+            "sir_found": True,
+            "sir_vendor": False,
+            "inspection_found": False,
+            "inspection_vendor": False,
+            "raycon_scenario_found": False,
+        }
+        missing = _missing_required_docs(readiness)
+        assert "Vendor SIR" in missing
+        assert "Building Inspection" in missing
+        assert "RayCon Scenario JSON" in missing
+
+    def test_blocks_when_only_raycon_missing(self):
+        readiness = {
+            "sir_found": True,
+            "sir_vendor": True,
+            "inspection_found": True,
+            "inspection_vendor": True,
+            "raycon_scenario_found": False,
+        }
+        assert _missing_required_docs(readiness) == ["RayCon Scenario JSON"]
+
+    def test_blocks_when_inspection_is_ai_only(self):
+        readiness = {
+            "sir_found": True,
+            "sir_vendor": True,
+            "inspection_found": True,
+            "inspection_vendor": False,
+            "raycon_scenario_found": True,
+        }
+        assert _missing_required_docs(readiness) == ["Vendor Building Inspection"]
+
+
+class TestReadinessResolution:
+    def test_tulsa_returns_waiting_on_docs_under_vendor_gate(self, monkeypatch):
+        monkeypatch.setenv("VENDOR_GATE_ENABLED", "1")
+        readiness = {
+            "sir_found": True,
+            "sir_vendor": False,
+            "inspection_found": False,
+            "inspection_vendor": False,
+            "raycon_scenario_found": False,
+            "report_exists": False,
+        }
+        result = _resolve_readiness_result("Alpha School Tulsa", readiness)
+        assert result is not None
+        assert result.status == "waiting_on_docs"
+        assert "Vendor SIR" in result.missing_docs
+
+    def test_tulsa_passes_under_legacy_gate_today(self, monkeypatch):
+        # Confirms pre-cutover behavior is unchanged when flag is off.
+        monkeypatch.delenv("VENDOR_GATE_ENABLED", raising=False)
+        readiness = {
+            "sir_found": True,
+            "inspection_found": True,
+            "report_exists": False,
+        }
+        result = _resolve_readiness_result("Alpha School Tulsa", readiness)
+        # None means "proceed to agent" — legacy behavior, the bug we fix.
+        assert result is None
+
+
+class TestVendorGateAlert:
+    def test_alert_posts_to_chat_webhook(self):
+        with patch(
+            "due_diligence_reporter.report_pipeline.post_google_chat_message"
+        ) as mock_post:
+            _notify_vendor_gate_extraction_failure(
+                "https://chat.googleapis.com/wh/abc",
+                "Alpha School Tulsa",
+                drive_folder_url="https://drive.google.com/drive/folders/xyz",
+                failure_reason="5 unresolved tokens",
+                trace_url="https://trace.example/trace.json",
+            )
+        assert mock_post.call_count == 1
+        url, body = mock_post.call_args.args
+        assert url == "https://chat.googleapis.com/wh/abc"
+        assert "Human Intervention Needed" in body
+        assert "Alpha School Tulsa" in body
+        assert "5 unresolved tokens" in body
+
+    def test_alert_silent_when_no_webhook(self):
+        with patch(
+            "due_diligence_reporter.report_pipeline.post_google_chat_message"
+        ) as mock_post:
+            _notify_vendor_gate_extraction_failure(
+                "", "Alpha School Tulsa", failure_reason="x"
+            )
+        mock_post.assert_not_called()
+
+    def test_alert_supports_comma_separated_webhooks(self):
+        with patch(
+            "due_diligence_reporter.report_pipeline.post_google_chat_message"
+        ) as mock_post:
+            _notify_vendor_gate_extraction_failure(
+                "https://hook1, https://hook2",
+                "Site",
+                failure_reason="reason",
+            )
+        assert mock_post.call_count == 2


### PR DESCRIPTION
## Summary
Adds vendor-vs-AI provenance detection and gates DD report generation on three vendor inputs: vendor SIR, vendor Building Inspection, and RayCon scenario JSON. Behind `VENDOR_GATE_ENABLED` feature flag, default OFF.

Fixes the Tulsa-class bug where an AI-generated SIR was treated as a vendor SIR, allowing a sparse premature DD report to be produced.

## Changes
- **`provenance.py`** (new) - 2-tier vendor detection
  - Tier 1: filename regex catches AI-generated artifacts (e.g. `6940-s-utica-ave-tulsa-ok_2026-04-29_SIR.docx`)
  - Tier 2: LLM content fallback via OpenAI for ambiguous filenames
  - Per-site cache in `M1/provenance.json` keyed by `file_id` + `modifiedTime` (auto-invalidates on file change)
  - Default-to-vendor on uncertainty
- **`report_pipeline.py`**
  - `check_site_readiness_direct` runs vendor checks on SIR + BI and looks up RayCon scenario JSON in M1
  - `_missing_required_docs` enforces vendor inputs when flag is on; legacy gate preserved when off
  - `_notify_vendor_gate_extraction_failure` posts Google Chat alert when the 3 inputs are present but extraction/build fails
- **Tests** - `test_provenance.py` (14) + `test_vendor_gate.py` (14)
- **`scripts/cleanup_premature_dd_reports.py`** - archives premature AI-sourced reports the new gate would block; DRY_RUN default

## Rollout
- Default OFF
- Soak by setting `VENDOR_GATE_ENABLED=1` in staging, run cleanup script with `DRY_RUN=1`, then `DRY_RUN=0`
- Flip prod when comfortable

## Tests
770 passing (+28 new).