### PR TITLE
Publish partial reports to dashboard when completeness check fails

### DIFF
--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -1283,6 +1283,26 @@ def process_site_pipeline(
                 ),
                 trace_url=trace_url or "",
             )
+        # Publish partial data to the dashboard with dd_status="in_progress"
+        # so the row shows the real report fields instead of leaving the
+        # site stuck on the empty roster-sync stub. Without this branch,
+        # any report that fails the completeness check (raw template
+        # tokens, invalid Can-We-Open answer, unfilled placeholders) never
+        # reaches the dashboard, even when the agent successfully filled
+        # most of the template. Keeps the success-path publish unchanged.
+        if completeness_result.status == "report_incomplete":
+            _publish_to_dashboard_best_effort(
+                site_title=site_title,
+                trace=agent_result.get("trace"),
+                drive_folder_url=drive_folder_url,
+                dd_report_url=doc_url,
+                site_address=site_address,
+                p1_name=p1_name,
+                dd_status="in_progress",
+                school_feasibility=school_feasibility,
+                timeline_confidence=timeline_confidence,
+                wrike_created_at=wrike_created_at,
+            )
         return completeness_result
     assert completeness is not None
 
@@ -1320,7 +1340,11 @@ def _publish_to_dashboard_best_effort(
     site_address: str | None,
     p1_name: str | None = None,
     # Phase 2 DD provenance pass-through. Publisher auto-stamps
-    # dd_status="complete" so it's not threaded through here.
+    # dd_status="complete" when this is None, so callers on the success
+    # path can leave it unset. The ``report_incomplete`` branch passes
+    # ``"in_progress"`` so partial real data still lands on the dashboard
+    # instead of leaving sites stuck on the empty roster-sync stub.
+    dd_status: str | None = None,
     school_feasibility: str | None = None,
     timeline_confidence: str | None = None,
     wrike_created_at: str | None = None,
@@ -1354,6 +1378,7 @@ def _publish_to_dashboard_best_effort(
             drive_folder_url=drive_folder_url,
             dd_report_url=dd_report_url,
             site_owner=p1_name,
+            dd_status=dd_status,
             school_feasibility=school_feasibility,
             timeline_confidence=timeline_confidence,
             wrike_created_at=wrike_created_at,

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -310,6 +310,132 @@ class TestProcessSitePipeline:
         assert result.doc_id == "doc123"
         assert "export broke" in (result.error or "")
 
+    @patch("due_diligence_reporter.report_pipeline.publish_to_dashboard")
+    @patch("due_diligence_reporter.server.check_report_completeness")
+    @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
+    @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
+    def test_report_incomplete_still_publishes_to_dashboard_in_progress(
+        self,
+        mock_readiness,
+        mock_agent,
+        mock_completeness,
+        mock_publish,
+    ):
+        """report_incomplete reports must still publish partial data to the
+        dashboard with ``dd_status="in_progress"`` so sites do not get
+        stuck on the empty roster-sync stub when the completeness check
+        rejects an otherwise-filled report (raw template tokens leaking,
+        invalid Can-We-Open answer, unfilled placeholders)."""
+        mock_readiness.return_value = {
+            "sir_found": True,
+            "isp_found": False,
+            "inspection_found": True,
+            "report_exists": False,
+        }
+        trace = ReportTrace(
+            site_name="Alpha Keller",
+            started_at="2026-04-30T15:53:12+00:00",
+            events=[],
+            final_report_data={"exec.c_answer": "Yes", "q1.school_approval_label": "yes"},
+        )
+        mock_agent.return_value = {
+            "success": True,
+            "doc_id": "doc123",
+            "doc_url": "https://docs.google.com/document/d/doc123",
+            "trace": trace,
+        }
+
+        async def fake_completeness(doc_id):
+            # Same shape the production code returns when the doc has
+            # raw template tokens leaked: ready_to_send=False with zero
+            # unresolved {{...}} tokens. This is the exact failure mode
+            # observed for both Tulsa sites in run 25175297453.
+            return {
+                "ready_to_send": False,
+                "unresolved_token_count": 0,
+                "unresolved_tokens": [],
+                "raw_template_token_count": 1,
+                "raw_template_tokens": ["INSERT_ANSWER"],
+                "pending_section_count": 0,
+                "summary": "Report NOT ready to send. 1 raw template token(s).",
+            }
+
+        mock_completeness.side_effect = fake_completeness
+        mock_publish.return_value = True
+
+        gc = MagicMock()
+        result = process_site_pipeline(
+            gc, "Alpha Keller", "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Keller"], {}, "system prompt", _make_settings(),
+            site_address="123 Main St, Keller TX",
+            p1_name="Robbie Forrest",
+            wrike_created_at="2026-04-01T00:00:00Z",
+        )
+
+        assert result.status == "report_incomplete"
+        assert result.doc_id == "doc123"
+        # The HTTP publish must fire on the incomplete branch.
+        mock_publish.assert_called_once()
+        kwargs = mock_publish.call_args.kwargs
+        assert kwargs["dd_status"] == "in_progress"
+        assert kwargs["address"] == "123 Main St, Keller TX"
+        assert kwargs["site_owner"] == "Robbie Forrest"
+        assert kwargs["wrike_created_at"] == "2026-04-01T00:00:00Z"
+        # The real report data (not an empty stub) is published.
+        positional = mock_publish.call_args.args
+        assert positional[0] == "Alpha Keller"
+        assert positional[1] == trace.final_report_data
+
+    @patch("due_diligence_reporter.report_pipeline.publish_to_dashboard")
+    @patch("due_diligence_reporter.server.check_report_completeness")
+    @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
+    @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
+    def test_report_created_publishes_with_default_dd_status(
+        self,
+        mock_readiness,
+        mock_agent,
+        mock_completeness,
+        mock_publish,
+    ):
+        """Success path must NOT pass dd_status=in_progress; publisher
+        auto-stamps ``complete`` when the kwarg is None."""
+        mock_readiness.return_value = {
+            "sir_found": True,
+            "isp_found": False,
+            "inspection_found": True,
+            "report_exists": False,
+        }
+        trace = ReportTrace(
+            site_name="Alpha Keller",
+            started_at="2026-04-30T15:53:12+00:00",
+            events=[],
+            final_report_data={"exec.c_answer": "Yes"},
+        )
+        mock_agent.return_value = {
+            "success": True,
+            "doc_id": "doc123",
+            "doc_url": "https://docs.google.com/document/d/doc123",
+            "trace": trace,
+        }
+
+        async def fake_completeness(doc_id):
+            return {"ready_to_send": True, "pending_section_count": 0}
+
+        mock_completeness.side_effect = fake_completeness
+        mock_publish.return_value = True
+
+        gc = MagicMock()
+        result = process_site_pipeline(
+            gc, "Alpha Keller", "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Keller"], {}, "system prompt", _make_settings(),
+        )
+
+        assert result.status == "report_created"
+        mock_publish.assert_called_once()
+        # The success path leaves dd_status unset so the publisher's
+        # auto-stamp logic still fires ("complete").
+        assert mock_publish.call_args.kwargs["dd_status"] is None
+
 
 class TestCheckSiteReadinessDirect:
     def test_picks_up_source_docs_from_site_folder_m1(self):


### PR DESCRIPTION
## Problem

Run 25175297453 (2026-04-30 daily-dd-check) processed both Tulsa sites successfully — the agent filled the template with 0 unfilled tokens — but neither site got real data on https://dd-dashboard-three.vercel.app. They show as empty stubs only because `sync_site_roster.py` posts `report_data={}` for new Wrike entries.

## Root cause

`process_site_pipeline` calls `_check_generated_report` after the agent finishes. When `ready_to_send=False` (raw template tokens leaked, invalid Can-We-Open answer, or unfilled `{{...}}` placeholders), the function early-returns `report_incomplete` at `report_pipeline.py:1287` — **before** `_publish_to_dashboard_best_effort` runs at line 1291. Result: the HTTP path to `/api/sites/:slug/publish` never fires for any report that fails completeness, even when most of the template was filled correctly.

The Tulsa runs hit this with `raw_template_token_count > 0` despite `unresolved_token_count == 0` (`[!!] report incomplete (0 unfilled tokens)` in run logs).

## Fix

Publish on the `report_incomplete` branch with `dd_status="in_progress"` before returning, so the live dashboard sees real partial data instead of the empty stub. Threads `dd_status` through `_publish_to_dashboard_best_effort` to `publish_to_dashboard`.

Success path is unchanged — leaving `dd_status=None` preserves the publisher's auto-stamp to `complete`.

## Tests

- New: `test_report_incomplete_still_publishes_to_dashboard_in_progress` — asserts publish fires with `dd_status="in_progress"` and the real `final_report_data` (not an empty stub) when completeness fails on raw template tokens.
- New: `test_report_created_publishes_with_default_dd_status` — asserts the success path still leaves `dd_status=None` so the publisher auto-stamps `complete`.
- All 26 `test_report_pipeline.py` tests pass. Full suite: 793 passed, 3 pre-existing failures in `test_permit_history.py` unrelated to this PR.

## Risk

Low. The `report_incomplete` branch's only new behavior is a fire-and-forget HTTP call wrapped in the existing best-effort guard. `publish_to_dashboard` already handles disabled/missing-secret/network-error cases without raising. Vendor-gate escalation Chat alert still fires unchanged.