### PR TITLE
Backfill: prefer trace with non-empty token_report over newest-but-empty

### DIFF
--- a/scripts/backfill_dashboard.py
+++ b/scripts/backfill_dashboard.py
@@ -73,13 +73,30 @@ _TRACE_DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
 def _latest_trace_file(
     gc: GoogleClient, folder_id: str
 ) -> dict[str, Any] | None:
-    """Return the most recently modified DD Report Trace JSON in a folder."""
+    """Return the most recently modified DD Report Trace JSON in a folder.
+
+    Kept for backwards compatibility; prefer ``_candidate_trace_files``.
+    """
+    candidates = _candidate_trace_files(gc, folder_id)
+    return candidates[0] if candidates else None
+
+
+def _candidate_trace_files(
+    gc: GoogleClient, folder_id: str
+) -> list[dict[str, Any]]:
+    """Return all Report Trace JSONs in a folder, newest first.
+
+    The pipeline can write two trace files in the same day (older
+    ``... Report Trace - YYYY-MM-DD.json`` from the legacy server.py path and
+    newer ``... DD Report Trace - YYYY-MM-DD.json`` from report_pipeline.py).
+    The newer one is sometimes written before the token_report is populated,
+    leaving the trace empty. Callers should iterate this list and fall back to
+    the next candidate when the chosen trace has no usable token_report.
+    """
     files = gc.list_files_in_folder(folder_id)
     traces = [f for f in files if _TRACE_NAME_RE.search(f.get("name", ""))]
-    if not traces:
-        return None
     traces.sort(key=lambda f: f.get("modifiedTime", ""), reverse=True)
-    return traces[0]
+    return traces
 
 
 def _report_date_from_trace(trace_data: dict[str, Any], fallback: str) -> date:
@@ -144,21 +161,45 @@ def backfill_one(
         logger.warning("%s: could not extract folder id from %s", site_title, drive_folder_url)
         return False
 
-    trace_file = _latest_trace_file(gc, folder_id)
-    if not trace_file:
+    candidates = _candidate_trace_files(gc, folder_id)
+    if not candidates:
         logger.info("%s: no Report Trace file found, skipping", site_title)
         return False
 
-    try:
-        data = gc.download_file_bytes(trace_file["id"])
-        trace_data = json.loads(data.decode("utf-8"))
-    except Exception as e:
-        logger.warning("%s: could not load trace '%s': %s", site_title, trace_file.get("name"), e)
-        return False
+    trace_file: dict[str, Any] | None = None
+    trace_data: dict[str, Any] = {}
+    report_data: dict[str, Any] = {}
+    for candidate in candidates:
+        try:
+            data = gc.download_file_bytes(candidate["id"])
+            candidate_data = json.loads(data.decode("utf-8"))
+        except Exception as e:
+            logger.warning(
+                "%s: could not load trace '%s': %s",
+                site_title,
+                candidate.get("name"),
+                e,
+            )
+            continue
 
-    report_data = _reconstruct_report_data(trace_data)
-    if not report_data:
-        logger.info("%s: trace had no token_report values, skipping", site_title)
+        candidate_report = _reconstruct_report_data(candidate_data)
+        if candidate_report:
+            trace_file = candidate
+            trace_data = candidate_data
+            report_data = candidate_report
+            break
+        logger.info(
+            "%s: trace '%s' has no token_report values, trying next candidate",
+            site_title,
+            candidate.get("name"),
+        )
+
+    if not trace_file or not report_data:
+        logger.info(
+            "%s: no trace with usable token_report found across %d candidate(s), skipping",
+            site_title,
+            len(candidates),
+        )
         return False
 
     rd = _report_date_from_trace(trace_data, trace_file.get("name", ""))

--- a/tests/test_backfill_dashboard.py
+++ b/tests/test_backfill_dashboard.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/backfill_dashboard.py trace-selection logic."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "backfill_dashboard.py"
+
+# Load the script as a module without executing main().
+_spec = importlib.util.spec_from_file_location("backfill_dashboard", _SCRIPT_PATH)
+backfill_dashboard = importlib.util.module_from_spec(_spec)
+sys.modules["backfill_dashboard"] = backfill_dashboard
+_spec.loader.exec_module(backfill_dashboard)  # type: ignore[union-attr]
+
+
+def _trace_file(file_id: str, name: str, modified: str) -> dict[str, str]:
+    return {"id": file_id, "name": name, "modifiedTime": modified}
+
+
+def _trace_payload(token_report: dict[str, dict] | None) -> bytes:
+    return json.dumps({"token_report": token_report or {}, "date": "04/30/2026"}).encode("utf-8")
+
+
+def test_candidate_trace_files_sorted_newest_first():
+    gc = MagicMock()
+    gc.list_files_in_folder.return_value = [
+        _trace_file("a", "Site Report Trace - 04-30-2026.json", "2026-04-30T10:00:00Z"),
+        _trace_file("b", "Site DD Report Trace - 2026-04-30.json", "2026-04-30T20:00:00Z"),
+        _trace_file("c", "unrelated.json", "2026-04-30T22:00:00Z"),
+    ]
+
+    result = backfill_dashboard._candidate_trace_files(gc, "folder123")
+
+    assert [f["id"] for f in result] == ["b", "a"]
+
+
+def test_backfill_one_falls_back_to_richer_trace_when_newest_is_empty(monkeypatch):
+    """The newer 'DD Report Trace' file is empty; older 'Report Trace' has data.
+
+    backfill_one must skip the empty newest trace and publish from the older
+    candidate instead. This protects against the morning Tulsa case where two
+    traces exist for the same date but only the older one has token_report.
+    """
+    gc = MagicMock()
+    gc.list_files_in_folder.return_value = [
+        _trace_file("empty", "Tulsa DD Report Trace - 2026-04-30.json", "2026-04-30T20:00:00Z"),
+        _trace_file("rich", "Tulsa Report Trace - 04-30-2026.json", "2026-04-30T10:00:00Z"),
+    ]
+    gc.download_file_bytes.side_effect = lambda fid: {
+        "empty": _trace_payload({}),
+        "rich": _trace_payload(
+            {
+                "address.full": {"value": "421 E 11th St, Tulsa, OK"},
+                "report.summary": {"value": "Site is suitable for school use."},
+            }
+        ),
+    }[fid]
+
+    publish_calls: list[dict] = []
+
+    def fake_publish(site_title, report_data, **kwargs):
+        publish_calls.append(
+            {
+                "site_title": site_title,
+                "report_data": report_data,
+                "kwargs": kwargs,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(backfill_dashboard, "publish_to_dashboard", fake_publish)
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "extract_folder_id_from_url",
+        lambda url: "folder123",
+    )
+
+    ok = backfill_dashboard.backfill_one(
+        gc,
+        "Alpha School Tulsa 421",
+        "https://drive.google.com/drive/folders/folder123",
+        address="421 E 11th St, Tulsa, OK",
+        school_type="K-8",
+        site_owner="Greg",
+    )
+
+    assert ok is True
+    assert len(publish_calls) == 1
+    call = publish_calls[0]
+    assert call["site_title"] == "Alpha School Tulsa 421"
+    assert call["report_data"]["address.full"] == "421 E 11th St, Tulsa, OK"
+    assert call["report_data"]["report.summary"] == "Site is suitable for school use."
+    # Both candidates were downloaded -- empty first, then rich fallback.
+    downloaded_ids = [c.args[0] for c in gc.download_file_bytes.call_args_list]
+    assert downloaded_ids == ["empty", "rich"]
+
+
+def test_backfill_one_returns_false_when_no_candidate_has_data(monkeypatch):
+    gc = MagicMock()
+    gc.list_files_in_folder.return_value = [
+        _trace_file("e1", "Site DD Report Trace - 2026-04-30.json", "2026-04-30T20:00:00Z"),
+        _trace_file("e2", "Site Report Trace - 04-30-2026.json", "2026-04-30T10:00:00Z"),
+    ]
+    gc.download_file_bytes.return_value = _trace_payload({})
+
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "extract_folder_id_from_url",
+        lambda url: "folder123",
+    )
+    publish_called = []
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "publish_to_dashboard",
+        lambda *a, **kw: publish_called.append((a, kw)) or True,
+    )
+
+    ok = backfill_dashboard.backfill_one(
+        gc,
+        "Empty Site",
+        "https://drive.google.com/drive/folders/folder123",
+        address=None,
+        school_type=None,
+    )
+
+    assert ok is False
+    assert publish_called == []
+
+
+def test_backfill_one_skips_unparseable_trace_and_uses_next(monkeypatch):
+    gc = MagicMock()
+    gc.list_files_in_folder.return_value = [
+        _trace_file("bad", "Site DD Report Trace - 2026-04-30.json", "2026-04-30T20:00:00Z"),
+        _trace_file("ok", "Site Report Trace - 04-30-2026.json", "2026-04-30T10:00:00Z"),
+    ]
+
+    def _download(fid):
+        if fid == "bad":
+            return b"not-valid-json{"
+        return _trace_payload({"address.full": {"value": "X"}})
+
+    gc.download_file_bytes.side_effect = _download
+
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "extract_folder_id_from_url",
+        lambda url: "folder123",
+    )
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "publish_to_dashboard",
+        lambda *a, **kw: True,
+    )
+
+    ok = backfill_dashboard.backfill_one(
+        gc,
+        "Site",
+        "https://drive.google.com/drive/folders/folder123",
+        address=None,
+        school_type=None,
+    )
+
+    assert ok is True


### PR DESCRIPTION
## Summary

When a site has BOTH a `Report Trace - YYYY-MM-DD.json` (older server.py
naming) and a `DD Report Trace - YYYY-MM-DD.json` (newer report_pipeline.py
naming) in its Drive folder for the same date, the backfill script previously
picked the newest by modifiedTime and gave up if its `token_report` was empty.

Today's Tulsa run is exactly that case: both 421 E 11th St and 6940 S Utica Ave
have empty newer `DD Report Trace` files (~10 KB / ~8 KB) and rich older
`Report Trace` files (~13.7 KB / ~12.9 KB). The backfill skipped both with
'trace had no token_report values, skipping'.

## Fix

Iterate trace candidates newest-first. Download each, attempt token_report
reconstruction, and publish from the first candidate that yields data. If
every candidate is empty/unparseable, skip with a clearer log line.

## Tests

`tests/test_backfill_dashboard.py` (new):
- `test_candidate_trace_files_sorted_newest_first`
- `test_backfill_one_falls_back_to_richer_trace_when_newest_is_empty` (Tulsa scenario)
- `test_backfill_one_returns_false_when_no_candidate_has_data`
- `test_backfill_one_skips_unparseable_trace_and_uses_next`

All 4 pass. 115 existing dashboard tests still pass.

## Verification plan after merge

Re-dispatch `backfill-dashboard.yml` filtered to Tulsa. Both Tulsa sites
should publish from their richer older trace files.