### PR TITLE
Reconcile DD Dashboard against Wrike Active status group

### DIFF
--- a/.github/workflows/reconcile-dashboard.yml
+++ b/.github/workflows/reconcile-dashboard.yml
@@ -1,0 +1,80 @@
+name: Reconcile Dashboard
+
+# Prunes the DD Dashboard to match Wrike's Active status group. The live
+# publish path only ever ADDS or UPDATES sites, so cancelled / on-hold /
+# deferred sites accumulate forever without this. Default mode is dry-run.
+#
+# Triggers:
+#   - manual workflow_dispatch (with apply=true to actually delete)
+#   - weekly cron (Mondays 13:00 UTC) — always dry-run, surfaces orphans in logs
+#
+# Required secrets:
+#   WRIKE_ACCESS_TOKEN, DASHBOARD_PUBLISH_SECRET
+# Optional:
+#   DASHBOARD_PUBLISH_URL (defaults to https://dd-dashboard-three.vercel.app)
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Set true to actually DELETE orphan sites. Leave false for dry-run.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  schedule:
+    # Mondays 13:00 UTC = 08:00 CDT, before the daily-dd-check cron at 14:00 UTC
+    - cron: '0 13 * * 1'
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.WRIKE_ACCESS_TOKEN }}" ]       || { echo "[ERROR] WRIKE_ACCESS_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ] || { echo "[ERROR] DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
+          echo "[OK] Required secrets present"
+
+      - name: Create .env file from secrets
+        env:
+          WRIKE_ACCESS_TOKEN: ${{ secrets.WRIKE_ACCESS_TOKEN }}
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
+          DASHBOARD_PUBLISH_URL: ${{ secrets.DASHBOARD_PUBLISH_URL }}
+        run: |
+          touch .env
+          echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
+          if [ -n "${DASHBOARD_PUBLISH_URL}" ]; then
+            echo "DASHBOARD_PUBLISH_URL=${DASHBOARD_PUBLISH_URL}" >> .env
+          fi
+          echo "[OK] Created .env file"
+
+      - name: Run dashboard reconciler
+        env:
+          # Cron always runs dry. workflow_dispatch honours the apply input.
+          RECONCILE_DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') && '0' || '1' }}
+        run: |
+          echo "[INFO] RECONCILE_DRY_RUN=${RECONCILE_DRY_RUN}"
+          uv run python scripts/reconcile_dashboard.py
+
+      - name: Done
+        run: echo "Dashboard reconcile completed"

--- a/scripts/reconcile_dashboard.py
+++ b/scripts/reconcile_dashboard.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+reconcile_dashboard.py — Prune the DD Dashboard to match Wrike's Active set.
+
+Workflow flow (live publish path) only ever ADDS or UPDATES sites in the
+dashboard's sites.json. When Wrike moves a site out of the Active status
+group (cancelled / on-hold / deferred), the row stays on the dashboard
+forever. This script reconciles by:
+
+  1. Fetching the live sites.json from the dashboard.
+  2. Listing every Wrike Site Record and computing the set of *expected* slugs
+     (active records only, slug derived via dashboard_publisher.slugify).
+  3. Diffing: any slug present on the dashboard but NOT in the active set is
+     an orphan candidate.
+  4. Default RECONCILE_DRY_RUN=1: log the orphan list and exit. No changes.
+  5. Set RECONCILE_DRY_RUN=0 to actually issue
+     DELETE /api/sites/<slug>/publish for each orphan, with a reason header
+     so the GitHub commit message captures why it was removed.
+
+Env (from .env):
+    DASHBOARD_PUBLISH_URL, DASHBOARD_PUBLISH_SECRET
+    plus the usual pipeline env (Wrike)
+    RECONCILE_DRY_RUN  (default "1"; set "0" to actually delete)
+
+Run:
+    uv run python scripts/reconcile_dashboard.py            # dry-run, all
+    RECONCILE_DRY_RUN=0 uv run python scripts/reconcile_dashboard.py  # apply
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+from due_diligence_reporter.dashboard_publisher import slugify  # noqa: E402
+from due_diligence_reporter.wrike import (  # noqa: E402
+    _get_active_status_ids,
+    _get_all_site_records,
+    is_record_active,
+    load_wrike_config,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s \u2014 %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("reconcile_dashboard")
+
+_DEFAULT_BASE_URL = "https://dd-dashboard-three.vercel.app"
+
+
+def _is_dry_run() -> bool:
+    raw = os.environ.get("RECONCILE_DRY_RUN", "1").strip().lower()
+    # Default-on: anything other than an explicit "0"/"false"/"no" stays dry.
+    return raw not in {"0", "false", "no"}
+
+
+def _dashboard_base_url() -> str:
+    return (os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_BASE_URL).rstrip("/")
+
+
+def _fetch_dashboard_slugs(base_url: str, *, timeout: int = 20) -> list[dict[str, Any]]:
+    """Return the sites array from the live sites.json (slug + minimal meta)."""
+    url = f"{base_url}/sites.json"
+    r = requests.get(url, timeout=timeout)
+    r.raise_for_status()
+    payload = r.json()
+    sites = payload.get("sites") or []
+    if not isinstance(sites, list):
+        return []
+    return [s for s in sites if isinstance(s, dict) and s.get("slug")]
+
+
+def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str]]:
+    """Build the set of slugs that *should* exist on the dashboard.
+
+    Returns (slug_set, slug_to_status_label) — the status label is used purely
+    for log/audit messages on inactive records that we are NOT pruning (e.g.
+    they were never published in the first place).
+    """
+    cfg = load_wrike_config()
+    records = _get_all_site_records(cfg=cfg)
+    active_ids = _get_active_status_ids(access_token=cfg.access_token)
+
+    expected: set[str] = set()
+    inactive_slugs: dict[str, str] = {}
+    for rec in records:
+        title = (rec.get("title") or "").strip()
+        if not title:
+            continue
+        slug = slugify(title)
+        if not slug:
+            continue
+        if is_record_active(rec, active_ids):
+            expected.add(slug)
+        else:
+            # Track status id for the audit log, raw value is informative
+            # enough even if we don't resolve it to a human name here.
+            inactive_slugs[slug] = str(rec.get("customStatusId") or "inactive")
+    return expected, inactive_slugs
+
+
+def _delete_site(
+    base_url: str,
+    slug: str,
+    secret: str,
+    *,
+    reason: str,
+    timeout: int = 20,
+) -> bool:
+    endpoint = f"{base_url}/api/sites/{slug}/publish"
+    try:
+        r = requests.delete(
+            endpoint,
+            headers={
+                "Authorization": f"Bearer {secret}",
+                "X-Reconcile-Reason": reason,
+            },
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        logger.warning("DELETE %s failed (network): %s", slug, e)
+        return False
+
+    if r.status_code == 200:
+        logger.info("Removed %s from dashboard (%s)", slug, reason)
+        return True
+    if r.status_code == 404:
+        logger.info("%s already absent on dashboard (404), treating as success", slug)
+        return True
+    logger.warning(
+        "DELETE %s returned HTTP %d: %s", slug, r.status_code, r.text[:200]
+    )
+    return False
+
+
+def main() -> int:
+    dry_run = _is_dry_run()
+    base_url = _dashboard_base_url()
+    secret = os.environ.get("DASHBOARD_PUBLISH_SECRET", "")
+
+    if not dry_run and not secret:
+        logger.error(
+            "RECONCILE_DRY_RUN=0 but DASHBOARD_PUBLISH_SECRET is unset; refusing to delete"
+        )
+        return 2
+
+    logger.info(
+        "Reconcile mode=%s base_url=%s",
+        "DRY_RUN" if dry_run else "APPLY",
+        base_url,
+    )
+
+    try:
+        dashboard_sites = _fetch_dashboard_slugs(base_url)
+    except requests.RequestException as e:
+        logger.error("Failed to fetch %s/sites.json: %s", base_url, e)
+        return 3
+
+    dashboard_slugs = {str(s["slug"]) for s in dashboard_sites}
+    logger.info("Dashboard currently has %d sites", len(dashboard_slugs))
+
+    try:
+        expected, inactive_slugs = _expected_slugs_from_wrike()
+    except Exception as e:
+        logger.error("Failed to load Wrike active set: %s", e)
+        return 4
+
+    logger.info(
+        "Wrike Active set: %d slugs (plus %d known inactive)",
+        len(expected),
+        len(inactive_slugs),
+    )
+
+    orphans = sorted(dashboard_slugs - expected)
+    if not orphans:
+        logger.info("No orphan slugs on dashboard — nothing to reconcile")
+        return 0
+
+    logger.info("Found %d orphan slug(s) on dashboard:", len(orphans))
+    for slug in orphans:
+        if slug in inactive_slugs:
+            logger.info("  - %s (Wrike status_id=%s)", slug, inactive_slugs[slug])
+        else:
+            logger.info("  - %s (no matching Wrike record)", slug)
+
+    if dry_run:
+        logger.info(
+            "RECONCILE_DRY_RUN=1 — no DELETE calls issued. "
+            "Re-run with RECONCILE_DRY_RUN=0 to apply."
+        )
+        return 0
+
+    deleted, failed = 0, 0
+    for slug in orphans:
+        reason = (
+            f"wrike-status:{inactive_slugs[slug]}"
+            if slug in inactive_slugs
+            else "wrike-record-missing"
+        )
+        if _delete_site(base_url, slug, secret, reason=reason):
+            deleted += 1
+        else:
+            failed += 1
+
+    logger.info(
+        "Reconcile complete: %d deleted, %d failed (of %d orphans)",
+        deleted,
+        failed,
+        len(orphans),
+    )
+    return 0 if failed == 0 else 5
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_reconcile_dashboard.py
+++ b/tests/test_reconcile_dashboard.py
@@ -1,0 +1,273 @@
+"""Tests for scripts/reconcile_dashboard.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "reconcile_dashboard.py"
+
+_spec = importlib.util.spec_from_file_location("reconcile_dashboard", _SCRIPT_PATH)
+reconcile_dashboard = importlib.util.module_from_spec(_spec)
+sys.modules["reconcile_dashboard"] = reconcile_dashboard
+_spec.loader.exec_module(reconcile_dashboard)  # type: ignore[union-attr]
+
+
+# ---------- helpers ----------
+
+def _wrike_record(title: str, status_id: str | None) -> dict:
+    rec: dict = {"title": title}
+    if status_id is not None:
+        rec["customStatusId"] = status_id
+    return rec
+
+
+# ---------- _is_dry_run ----------
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, True),  # default ON
+        ("1", True),
+        ("0", False),
+        ("false", False),
+        ("FALSE", False),
+        ("no", False),
+        ("yes", True),
+        ("", True),
+        ("anything-else", True),
+    ],
+)
+def test_is_dry_run(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("RECONCILE_DRY_RUN", raising=False)
+    else:
+        monkeypatch.setenv("RECONCILE_DRY_RUN", value)
+    assert reconcile_dashboard._is_dry_run() is expected
+
+
+# ---------- _expected_slugs_from_wrike ----------
+
+def test_expected_slugs_from_wrike_partitions_active_and_inactive(monkeypatch):
+    records = [
+        _wrike_record("Alpha School Tulsa 421 E 11th St", "ACTIVE_ID"),
+        _wrike_record("Alpha School Minneapolis 1128", "CANCELLED_ID"),
+        _wrike_record("Alpha School Dallas 4152", "ACTIVE_ID"),
+        _wrike_record("", "ACTIVE_ID"),  # blank title — skipped
+    ]
+
+    monkeypatch.setattr(reconcile_dashboard, "load_wrike_config", lambda: MagicMock(access_token="t"))
+    monkeypatch.setattr(reconcile_dashboard, "_get_all_site_records", lambda cfg: records)
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_get_active_status_ids",
+        lambda access_token: {"ACTIVE_ID"},
+    )
+
+    expected, inactive = reconcile_dashboard._expected_slugs_from_wrike()
+
+    assert expected == {
+        "alpha-school-tulsa-421-e-11th-st",
+        "alpha-school-dallas-4152",
+    }
+    assert inactive == {"alpha-school-minneapolis-1128": "CANCELLED_ID"}
+
+
+# ---------- main(): dry-run finds orphans without deleting ----------
+
+def test_main_dry_run_logs_orphans_and_does_not_delete(monkeypatch, caplog):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "1")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_URL", "https://dash.example")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "shh")
+
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [
+            {"slug": "alpha-school-tulsa-421-e-11th-st"},
+            {"slug": "alpha-school-minneapolis-1128"},  # inactive in Wrike
+            {"slug": "ghost-site-no-wrike-record"},     # not in Wrike at all
+        ],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (
+            {"alpha-school-tulsa-421-e-11th-st"},
+            {"alpha-school-minneapolis-1128": "CANCELLED_ID"},
+        ),
+    )
+    delete_calls: list[tuple] = []
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_delete_site",
+        lambda *a, **kw: delete_calls.append((a, kw)) or True,
+    )
+
+    caplog.set_level("INFO", logger="reconcile_dashboard")
+    rc = reconcile_dashboard.main()
+
+    assert rc == 0
+    assert delete_calls == []  # dry-run never deletes
+    text = caplog.text
+    assert "DRY_RUN" in text
+    assert "alpha-school-minneapolis-1128" in text
+    assert "ghost-site-no-wrike-record" in text
+    assert "no DELETE calls issued" in text
+
+
+# ---------- main(): apply mode deletes only orphans ----------
+
+def test_main_apply_mode_deletes_each_orphan_with_reason(monkeypatch):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "0")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_URL", "https://dash.example")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "shh")
+
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [
+            {"slug": "active-site"},
+            {"slug": "alpha-school-minneapolis-1128"},
+            {"slug": "ghost-site"},
+        ],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (
+            {"active-site"},
+            {"alpha-school-minneapolis-1128": "CANCELLED_ID"},
+        ),
+    )
+
+    delete_calls: list[dict] = []
+
+    def fake_delete(base_url, slug, secret, *, reason, timeout=20):
+        delete_calls.append(
+            {"base_url": base_url, "slug": slug, "secret": secret, "reason": reason}
+        )
+        return True
+
+    monkeypatch.setattr(reconcile_dashboard, "_delete_site", fake_delete)
+
+    rc = reconcile_dashboard.main()
+
+    assert rc == 0
+    by_slug = {c["slug"]: c for c in delete_calls}
+    # Active site is NOT touched
+    assert "active-site" not in by_slug
+    # Orphans get correct reasons
+    assert by_slug["alpha-school-minneapolis-1128"]["reason"] == "wrike-status:CANCELLED_ID"
+    assert by_slug["ghost-site"]["reason"] == "wrike-record-missing"
+    assert by_slug["alpha-school-minneapolis-1128"]["base_url"] == "https://dash.example"
+    assert by_slug["alpha-school-minneapolis-1128"]["secret"] == "shh"
+
+
+# ---------- main(): apply mode without secret refuses to run ----------
+
+def test_main_apply_mode_without_secret_refuses(monkeypatch):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "0")
+    monkeypatch.delenv("DASHBOARD_PUBLISH_SECRET", raising=False)
+
+    rc = reconcile_dashboard.main()
+    assert rc == 2
+
+
+# ---------- main(): no orphans → exits cleanly ----------
+
+def test_main_no_orphans_returns_zero(monkeypatch):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "1")
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [{"slug": "active-site"}],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: ({"active-site"}, {}),
+    )
+    delete_calls: list = []
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_delete_site",
+        lambda *a, **kw: delete_calls.append(1) or True,
+    )
+
+    rc = reconcile_dashboard.main()
+    assert rc == 0
+    assert delete_calls == []
+
+
+# ---------- main(): apply mode counts failures and surfaces non-zero rc ----------
+
+def test_main_apply_mode_returns_nonzero_when_delete_fails(monkeypatch):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "0")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "shh")
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [{"slug": "ghost-1"}, {"slug": "ghost-2"}],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (set(), {}),
+    )
+
+    def flaky_delete(base_url, slug, secret, *, reason, timeout=20):
+        return slug == "ghost-1"
+
+    monkeypatch.setattr(reconcile_dashboard, "_delete_site", flaky_delete)
+
+    rc = reconcile_dashboard.main()
+    assert rc == 5  # one failure
+
+
+# ---------- _delete_site: 200/404 = success, others = fail ----------
+
+def test_delete_site_treats_200_and_404_as_success(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_delete(url, headers=None, timeout=20):
+        calls.append({"url": url, "headers": headers})
+        resp = MagicMock()
+        resp.status_code = 200 if "ok-slug" in url else 404
+        resp.text = ""
+        return resp
+
+    monkeypatch.setattr(reconcile_dashboard.requests, "delete", fake_delete)
+
+    assert reconcile_dashboard._delete_site(
+        "https://dash.example", "ok-slug", "shh", reason="wrike-status:X"
+    )
+    assert reconcile_dashboard._delete_site(
+        "https://dash.example", "missing-slug", "shh", reason="wrike-record-missing"
+    )
+
+    assert calls[0]["url"] == "https://dash.example/api/sites/ok-slug/publish"
+    assert calls[0]["headers"]["Authorization"] == "Bearer shh"
+    assert calls[0]["headers"]["X-Reconcile-Reason"] == "wrike-status:X"
+
+
+def test_delete_site_returns_false_on_http_error(monkeypatch):
+    def fake_delete(url, headers=None, timeout=20):
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = "boom"
+        return resp
+
+    monkeypatch.setattr(reconcile_dashboard.requests, "delete", fake_delete)
+
+    assert (
+        reconcile_dashboard._delete_site(
+            "https://dash.example", "slug", "shh", reason="r"
+        )
+        is False
+    )


### PR DESCRIPTION
## Why

The live publish path (`report_pipeline` \u2192 `dashboard_publisher`) only
ever ADDs or UPDATEs sites in `sites.json`. When Wrike moves a site out of
the Active status group (cancelled / on-hold / deferred), nothing removes
it. Cancelled sites then linger on the dashboard forever \u2014 e.g.
'Alpha School Minneapolis 1128'.

## What

- `scripts/reconcile_dashboard.py`: fetches the live `sites.json`,
  computes the expected slug set from Wrike active records via
  `is_record_active()`, diffs, and (optionally) issues
  `DELETE /api/sites/<slug>/publish` for each orphan with an
  `X-Reconcile-Reason` header so the GitHub commit message captures why.
- Default `RECONCILE_DRY_RUN=1`: log only, never delete. `RECONCILE_DRY_RUN=0`
  is required to actually prune. Apply-mode also requires
  `DASHBOARD_PUBLISH_SECRET`; refuses to run without it.
- `.github/workflows/reconcile-dashboard.yml`:
    - weekly Monday cron at 13:00 UTC always dry-runs \u2014 orphans surface in workflow logs
    - manual `workflow_dispatch` with `apply=true` lets us prune on demand

## Tests

`tests/test_reconcile_dashboard.py` (new):

- `_is_dry_run` env-parsing parametrized cases (default ON; only `0`/`false`/`no` flips it OFF)
- `_expected_slugs_from_wrike` partitions active vs inactive correctly, skips blank-title records
- `main()` dry-run: logs orphans without calling `_delete_site`
- `main()` apply-mode: deletes only orphans, attaches correct `reason` per orphan
- `main()` apply-mode without secret: refuses (rc=2)
- `main()` no orphans: returns 0 cleanly
- `main()` apply-mode with delete failure: rc=5
- `_delete_site` HTTP 200 \u2192 success, 404 \u2192 success (idempotent), 500 \u2192 fail
- `_delete_site` sends `Authorization: Bearer` and `X-Reconcile-Reason` headers

`uv run pytest tests/test_reconcile_dashboard.py` \u2192 17 passed.
Full dashboard suite (`test_dashboard_*` + `test_backfill_dashboard` + `test_reconcile_dashboard`) \u2192 136 passed.

## Companion PR

Requires dd-dashboard#22 to be merged first \u2014 that adds the `DELETE` handler on
the `/api/sites/[slug]/publish` route. Until then, dry-run cron is harmless.