### PR TITLE
Reconcile: log near-match Wrike candidates for orphan slugs

### DIFF
--- a/scripts/reconcile_dashboard.py
+++ b/scripts/reconcile_dashboard.py
@@ -84,12 +84,16 @@ def _fetch_dashboard_slugs(base_url: str, *, timeout: int = 20) -> list[dict[str
     return [s for s in sites if isinstance(s, dict) and s.get("slug")]
 
 
-def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str]]:
+def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str], list[tuple[str, bool]]]:
     """Build the set of slugs that *should* exist on the dashboard.
 
-    Returns (slug_set, slug_to_status_label) — the status label is used purely
-    for log/audit messages on inactive records that we are NOT pruning (e.g.
-    they were never published in the first place).
+    Returns ``(slug_set, slug_to_status_label, all_titles)``.
+
+    The status label is used purely for log/audit messages on inactive
+    records that we are NOT pruning (e.g. they were never published in the
+    first place). ``all_titles`` is a list of every Wrike record
+    ``(title, is_active)`` tuple, used downstream to suggest near-match
+    candidates when an orphan slug doesn't match any Wrike record exactly.
     """
     cfg = load_wrike_config()
     records = _get_all_site_records(cfg=cfg)
@@ -97,6 +101,7 @@ def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str]]:
 
     expected: set[str] = set()
     inactive_slugs: dict[str, str] = {}
+    all_titles: list[tuple[str, bool]] = []
     for rec in records:
         title = (rec.get("title") or "").strip()
         if not title:
@@ -104,13 +109,65 @@ def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str]]:
         slug = slugify(title)
         if not slug:
             continue
-        if is_record_active(rec, active_ids):
+        active = is_record_active(rec, active_ids)
+        all_titles.append((title, active))
+        if active:
             expected.add(slug)
         else:
             # Track status id for the audit log, raw value is informative
             # enough even if we don't resolve it to a human name here.
             inactive_slugs[slug] = str(rec.get("customStatusId") or "inactive")
-    return expected, inactive_slugs
+    return expected, inactive_slugs, all_titles
+
+
+_TOKEN_STOPWORDS = {
+    # Brand / role words always present and never disambiguating
+    "alpha", "school", "the", "and", "of",
+    # Street type abbreviations
+    "st", "ave", "rd", "dr", "ln", "blvd", "hwy", "pkwy", "ct",
+    # USPS two-letter state codes — dashboard slugs sometimes append the
+    # state, Wrike titles usually don't, and these are never the
+    # disambiguating piece of an address.
+    "al", "ak", "az", "ar", "ca", "co", "ct", "de", "fl", "ga",
+    "hi", "id", "il", "in", "ia", "ks", "ky", "la", "me", "md",
+    "ma", "mi", "mn", "ms", "mo", "mt", "ne", "nv", "nh", "nj",
+    "nm", "ny", "nc", "nd", "oh", "ok", "or", "pa", "ri", "sc",
+    "sd", "tn", "tx", "ut", "vt", "va", "wa", "wv", "wi", "wy",
+    "dc",
+}
+
+
+def _slug_tokens(slug: str) -> list[str]:
+    """Tokenize a slug for fuzzy matching: keep meaningful words/numbers.
+
+    Drops alpha/school/etc. plus single-letter pieces, so tokens like
+    'tulsa' / '6940' / 'minneapolis' / '1128' survive for near-match search.
+    """
+    return [
+        t
+        for t in slug.split("-")
+        if t and len(t) > 1 and t not in _TOKEN_STOPWORDS
+    ]
+
+
+def _find_near_matches(
+    slug: str, all_titles: list[tuple[str, bool]], *, limit: int = 3
+) -> list[tuple[str, bool]]:
+    """Return Wrike (title, is_active) entries whose title contains every
+    meaningful token from ``slug``. Helps a human triage 'no matching Wrike
+    record' orphans by showing what the active record was likely renamed to.
+    """
+    tokens = _slug_tokens(slug)
+    if not tokens:
+        return []
+    matches: list[tuple[str, bool]] = []
+    for title, active in all_titles:
+        lt = title.lower()
+        if all(tok in lt for tok in tokens):
+            matches.append((title, active))
+            if len(matches) >= limit:
+                break
+    return matches
 
 
 def _delete_site(
@@ -174,7 +231,7 @@ def main() -> int:
     logger.info("Dashboard currently has %d sites", len(dashboard_slugs))
 
     try:
-        expected, inactive_slugs = _expected_slugs_from_wrike()
+        expected, inactive_slugs, all_titles = _expected_slugs_from_wrike()
     except Exception as e:
         logger.error("Failed to load Wrike active set: %s", e)
         return 4
@@ -195,7 +252,19 @@ def main() -> int:
         if slug in inactive_slugs:
             logger.info("  - %s (Wrike status_id=%s)", slug, inactive_slugs[slug])
         else:
-            logger.info("  - %s (no matching Wrike record)", slug)
+            near = _find_near_matches(slug, all_titles)
+            if near:
+                hints = "; ".join(
+                    f"{title!r} [{'ACTIVE' if active else 'INACTIVE'}]"
+                    for title, active in near
+                )
+                logger.info(
+                    "  - %s (no exact Wrike record; near matches: %s)",
+                    slug,
+                    hints,
+                )
+            else:
+                logger.info("  - %s (no matching Wrike record)", slug)
 
     if dry_run:
         logger.info(

--- a/tests/test_reconcile_dashboard.py
+++ b/tests/test_reconcile_dashboard.py
@@ -69,13 +69,20 @@ def test_expected_slugs_from_wrike_partitions_active_and_inactive(monkeypatch):
         lambda access_token: {"ACTIVE_ID"},
     )
 
-    expected, inactive = reconcile_dashboard._expected_slugs_from_wrike()
+    expected, inactive, all_titles = reconcile_dashboard._expected_slugs_from_wrike()
 
     assert expected == {
         "alpha-school-tulsa-421-e-11th-st",
         "alpha-school-dallas-4152",
     }
     assert inactive == {"alpha-school-minneapolis-1128": "CANCELLED_ID"}
+    # all_titles preserves order from records, including the inactive one,
+    # so downstream near-match search can find renamed/retitled candidates.
+    assert all_titles == [
+        ("Alpha School Tulsa 421 E 11th St", True),
+        ("Alpha School Minneapolis 1128", False),
+        ("Alpha School Dallas 4152", True),
+    ]
 
 
 # ---------- main(): dry-run finds orphans without deleting ----------
@@ -100,6 +107,10 @@ def test_main_dry_run_logs_orphans_and_does_not_delete(monkeypatch, caplog):
         lambda: (
             {"alpha-school-tulsa-421-e-11th-st"},
             {"alpha-school-minneapolis-1128": "CANCELLED_ID"},
+            [
+                ("Alpha School Tulsa 421 E 11th St", True),
+                ("Alpha School Minneapolis 1128", False),
+            ],
         ),
     )
     delete_calls: list[tuple] = []
@@ -143,6 +154,7 @@ def test_main_apply_mode_deletes_each_orphan_with_reason(monkeypatch):
         lambda: (
             {"active-site"},
             {"alpha-school-minneapolis-1128": "CANCELLED_ID"},
+            [("Active Site", True), ("Alpha School Minneapolis 1128", False)],
         ),
     )
 
@@ -191,7 +203,7 @@ def test_main_no_orphans_returns_zero(monkeypatch):
     monkeypatch.setattr(
         reconcile_dashboard,
         "_expected_slugs_from_wrike",
-        lambda: ({"active-site"}, {}),
+        lambda: ({"active-site"}, {}, [("Active Site", True)]),
     )
     delete_calls: list = []
     monkeypatch.setattr(
@@ -218,7 +230,7 @@ def test_main_apply_mode_returns_nonzero_when_delete_fails(monkeypatch):
     monkeypatch.setattr(
         reconcile_dashboard,
         "_expected_slugs_from_wrike",
-        lambda: (set(), {}),
+        lambda: (set(), {}, []),
     )
 
     def flaky_delete(base_url, slug, secret, *, reason, timeout=20):
@@ -228,6 +240,85 @@ def test_main_apply_mode_returns_nonzero_when_delete_fails(monkeypatch):
 
     rc = reconcile_dashboard.main()
     assert rc == 5  # one failure
+
+
+# ---------- _slug_tokens / _find_near_matches ----------
+
+def test_slug_tokens_drops_stopwords_and_short_pieces():
+    assert reconcile_dashboard._slug_tokens("alpha-school-minneapolis-1128") == [
+        "minneapolis",
+        "1128",
+    ]
+    assert reconcile_dashboard._slug_tokens("alpha-school-tulsa-6940-s-utica-ave") == [
+        "tulsa",
+        "6940",
+        "utica",
+    ]
+    assert reconcile_dashboard._slug_tokens("") == []
+
+
+def test_find_near_matches_surfaces_renamed_active_record():
+    """An orphan slug like '6940-s-utica-ave-tulsa-ok' should surface its
+    likely renamed active counterpart 'Alpha School Tulsa 6940 S Utica Ave'.
+    """
+    all_titles = [
+        ("Alpha School Tulsa 6940 S Utica Ave", True),
+        ("Alpha School Tulsa 421 E 11th St", True),
+        ("Alpha School Minneapolis 1128", False),
+    ]
+
+    matches = reconcile_dashboard._find_near_matches(
+        "6940-s-utica-ave-tulsa-ok", all_titles
+    )
+    assert matches == [("Alpha School Tulsa 6940 S Utica Ave", True)]
+
+    matches = reconcile_dashboard._find_near_matches(
+        "alpha-school-minneapolis-1128", all_titles
+    )
+    assert matches == [("Alpha School Minneapolis 1128", False)]
+
+
+def test_find_near_matches_returns_empty_when_no_overlap():
+    all_titles = [("Alpha School Dallas 4152", True)]
+    assert (
+        reconcile_dashboard._find_near_matches(
+            "alpha-school-chicago-350-microschool", all_titles
+        )
+        == []
+    )
+
+
+def test_main_logs_near_match_hint_for_orphans_with_no_exact_match(monkeypatch, caplog):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "1")
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [
+            {"slug": "6940-s-utica-ave-tulsa-ok"},
+            {"slug": "alpha-school-tulsa-6940-s-utica-ave"},
+        ],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (
+            {"alpha-school-tulsa-6940-s-utica-ave"},
+            {},
+            [("Alpha School Tulsa 6940 S Utica Ave", True)],
+        ),
+    )
+
+    caplog.set_level("INFO", logger="reconcile_dashboard")
+    rc = reconcile_dashboard.main()
+
+    assert rc == 0
+    text = caplog.text
+    assert "6940-s-utica-ave-tulsa-ok" in text
+    # The orphan log line should call out the near-match active record so a
+    # human can see this is a rename/retitle, not a stale row to delete blindly.
+    assert "near matches" in text
+    assert "Alpha School Tulsa 6940 S Utica Ave" in text
+    assert "[ACTIVE]" in text
 
 
 # ---------- _delete_site: 200/404 = success, others = fail ----------


### PR DESCRIPTION
## Why

Today's first dry-run flagged 6 orphans, all reported as 'no matching Wrike record'. That label hides whether the row is genuinely cancelled (e.g. `alpha-school-minneapolis-1128`) or just a slug from a since-renamed Wrike record that's still active under a new title (e.g. dashboard slug `6940-s-utica-ave-tulsa-ok` vs current Wrike title 'Alpha School Tulsa 6940 S Utica Ave' \u2192 slug `alpha-school-tulsa-6940-s-utica-ave`). Deleting the latter would clobber real data.

## What

Enrich the orphan log line with up to 3 near-match Wrike titles (active flag included) whose titles contain every meaningful slug token after stripping brand words (`alpha`/`school`), street-type abbreviations (`st`/`ave`/...) and USPS state codes (`ok`/`tx`/...). The triage signal is now visible directly in the workflow logs.

Also extends `_expected_slugs_from_wrike()` to return `all_titles` so the near-match search has full inventory (active + inactive).

## Tests

- Updates the 6 existing `main()` / `expected_slugs` tests for the new tuple shape
- Adds 4 new tests: `_slug_tokens`, `_find_near_matches` (rename + no-overlap), `main()` near-match hint formatting

`uv run pytest tests/test_reconcile_dashboard.py` \u2192 21 passed (was 17).

## Behavior

No change in apply-mode deletion logic \u2014 still operates on the same orphan set. This is purely log enrichment for human triage.