### PR TITLE
Reconcile: skip rename-suspect orphans (active near-match) by default

### DIFF
--- a/scripts/reconcile_dashboard.py
+++ b/scripts/reconcile_dashboard.py
@@ -153,17 +153,47 @@ def _slug_tokens(slug: str) -> list[str]:
 def _find_near_matches(
     slug: str, all_titles: list[tuple[str, bool]], *, limit: int = 3
 ) -> list[tuple[str, bool]]:
-    """Return Wrike (title, is_active) entries whose title contains every
-    meaningful token from ``slug``. Helps a human triage 'no matching Wrike
-    record' orphans by showing what the active record was likely renamed to.
+    """Return Wrike ``(title, is_active)`` entries that look like the same site.
+
+    Matching strategy, in order:
+
+    1. **Strict**: every meaningful slug token (after stripping brand words,
+       street types, USPS state codes) appears in the candidate title. This
+       handles the common case of slug-to-title drift like state suffixes
+       (e.g. dashboard slug ``...-tulsa-ok`` vs Wrike title ``... Tulsa ...``).
+    2. **Non-numeric fallback**: if no candidate matches strictly, retry
+       requiring only the *non-numeric* meaningful tokens to be present. This
+       catches the address-number rename case — e.g. dashboard slug
+       ``alpha-school-lombard-835`` (the original Wrike title) vs current
+       Wrike title ``Alpha School Lombard 995`` (renamed to a new street
+       number). Without this fallback, a rename like 835 → 995 looks like a
+       genuine orphan and the reconciler would prune real data.
+
+    The fallback only fires when at least one non-numeric token survives, so
+    purely numeric slugs (rare) still require the strict path.
     """
     tokens = _slug_tokens(slug)
     if not tokens:
         return []
+
     matches: list[tuple[str, bool]] = []
     for title, active in all_titles:
         lt = title.lower()
         if all(tok in lt for tok in tokens):
+            matches.append((title, active))
+            if len(matches) >= limit:
+                return matches
+    if matches:
+        return matches
+
+    non_numeric = [t for t in tokens if not t.isdigit()]
+    if not non_numeric or non_numeric == tokens:
+        # No fallback available (either all numeric, or fallback equals strict)
+        return matches
+
+    for title, active in all_titles:
+        lt = title.lower()
+        if all(tok in lt for tok in non_numeric):
             matches.append((title, active))
             if len(matches) >= limit:
                 break
@@ -247,48 +277,84 @@ def main() -> int:
         logger.info("No orphan slugs on dashboard — nothing to reconcile")
         return 0
 
+    # Partition orphans into deletable vs rename-suspect.
+    #
+    # Rename-suspect: the dashboard slug has no exact Wrike match, but a Wrike
+    # record that is currently *active* shares the same meaningful tokens. This
+    # almost always means the Wrike record was retitled (e.g. 'Alpha School
+    # Lombard 835' → 'Alpha School Lombard 995') and the dashboard row is real
+    # site data on a stale slug, NOT a cancelled site. Deleting it would
+    # clobber real data, so we surface it for human triage and skip.
+    deletable: list[tuple[str, str]] = []  # (slug, reason)
+    rename_suspects: list[tuple[str, list[tuple[str, bool]]]] = []
+
     logger.info("Found %d orphan slug(s) on dashboard:", len(orphans))
     for slug in orphans:
+        near = _find_near_matches(slug, all_titles)
+        active_near = [m for m in near if m[1]]
+
         if slug in inactive_slugs:
-            logger.info("  - %s (Wrike status_id=%s)", slug, inactive_slugs[slug])
+            reason = f"wrike-status:{inactive_slugs[slug]}"
+            logger.info("  - %s [DELETABLE] (Wrike status_id=%s)", slug, inactive_slugs[slug])
+            deletable.append((slug, reason))
+        elif active_near:
+            hints = "; ".join(
+                f"{title!r} [ACTIVE]" for title, _ in active_near
+            )
+            logger.info(
+                "  - %s [RENAME-SUSPECT] (active near matches: %s)",
+                slug,
+                hints,
+            )
+            rename_suspects.append((slug, active_near))
+        elif near:
+            # All near matches are inactive — still safer to skip; the slug
+            # may map to a record that was renamed and then cancelled. Log it.
+            hints = "; ".join(
+                f"{title!r} [INACTIVE]" for title, _ in near
+            )
+            logger.info(
+                "  - %s [DELETABLE] (no exact match; only inactive near matches: %s)",
+                slug,
+                hints,
+            )
+            deletable.append((slug, "wrike-near-match-inactive"))
         else:
-            near = _find_near_matches(slug, all_titles)
-            if near:
-                hints = "; ".join(
-                    f"{title!r} [{'ACTIVE' if active else 'INACTIVE'}]"
-                    for title, active in near
-                )
-                logger.info(
-                    "  - %s (no exact Wrike record; near matches: %s)",
-                    slug,
-                    hints,
-                )
-            else:
-                logger.info("  - %s (no matching Wrike record)", slug)
+            logger.info("  - %s [DELETABLE] (no matching Wrike record)", slug)
+            deletable.append((slug, "wrike-record-missing"))
+
+    if rename_suspects:
+        logger.info(
+            "Skipping %d rename-suspect orphan(s) — these have an active Wrike "
+            "record under a different title and are NOT pruned. Migrate the "
+            "dashboard data manually if needed.",
+            len(rename_suspects),
+        )
 
     if dry_run:
         logger.info(
-            "RECONCILE_DRY_RUN=1 — no DELETE calls issued. "
-            "Re-run with RECONCILE_DRY_RUN=0 to apply."
+            "RECONCILE_DRY_RUN=1 — no DELETE calls issued (would delete %d). "
+            "Re-run with RECONCILE_DRY_RUN=0 to apply.",
+            len(deletable),
         )
         return 0
 
+    if not deletable:
+        logger.info("Apply mode: nothing safe to delete. Exiting cleanly.")
+        return 0
+
     deleted, failed = 0, 0
-    for slug in orphans:
-        reason = (
-            f"wrike-status:{inactive_slugs[slug]}"
-            if slug in inactive_slugs
-            else "wrike-record-missing"
-        )
+    for slug, reason in deletable:
         if _delete_site(base_url, slug, secret, reason=reason):
             deleted += 1
         else:
             failed += 1
 
     logger.info(
-        "Reconcile complete: %d deleted, %d failed (of %d orphans)",
+        "Reconcile complete: %d deleted, %d failed, %d skipped as rename-suspects (of %d orphans)",
         deleted,
         failed,
+        len(rename_suspects),
         len(orphans),
     )
     return 0 if failed == 0 else 5

--- a/tests/test_reconcile_dashboard.py
+++ b/tests/test_reconcile_dashboard.py
@@ -321,6 +321,133 @@ def test_main_logs_near_match_hint_for_orphans_with_no_exact_match(monkeypatch, 
     assert "[ACTIVE]" in text
 
 
+# ---------- rename-suspect skip behavior ----------
+
+def test_apply_mode_skips_rename_suspects_with_active_near_match(monkeypatch, caplog):
+    """Apply mode must NOT delete an orphan whose active Wrike near-match
+    suggests the slug is just stale (record was renamed).
+
+    Scenario mirrors the live findings: \\
+    - 'alpha-school-lombard-835' on the dashboard \\
+    - 'Alpha School Lombard 995' is the current active Wrike title \\
+    - 'alpha-school-minneapolis-1128' has no Wrike record — truly cancelled
+    """
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "0")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "shh")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_URL", "https://dash.example")
+
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [
+            {"slug": "alpha-school-lombard-835"},          # rename suspect
+            {"slug": "alpha-school-minneapolis-1128"},     # truly orphaned
+            {"slug": "alpha-school-lombard-995"},          # the current active slug
+        ],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (
+            {"alpha-school-lombard-995"},
+            {},
+            [("Alpha School Lombard 995", True)],
+        ),
+    )
+
+    delete_calls: list[dict] = []
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_delete_site",
+        lambda base_url, slug, secret, *, reason, timeout=20: delete_calls.append(
+            {"slug": slug, "reason": reason}
+        )
+        or True,
+    )
+
+    caplog.set_level("INFO", logger="reconcile_dashboard")
+    rc = reconcile_dashboard.main()
+
+    assert rc == 0
+    deleted_slugs = {c["slug"] for c in delete_calls}
+    # Truly orphaned slug is deleted…
+    assert "alpha-school-minneapolis-1128" in deleted_slugs
+    # …but rename-suspect is NOT deleted
+    assert "alpha-school-lombard-835" not in deleted_slugs
+    text = caplog.text
+    assert "RENAME-SUSPECT" in text
+    assert "DELETABLE" in text
+    assert "Alpha School Lombard 995" in text  # active near-match surfaced
+
+
+def test_dry_run_partitions_rename_suspects_separately_from_deletable(monkeypatch, caplog):
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "1")
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [
+            {"slug": "alpha-school-lombard-835"},
+            {"slug": "alpha-school-minneapolis-1128"},
+            {"slug": "alpha-school-lombard-995"},
+        ],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (
+            {"alpha-school-lombard-995"},
+            {},
+            [("Alpha School Lombard 995", True)],
+        ),
+    )
+
+    caplog.set_level("INFO", logger="reconcile_dashboard")
+    rc = reconcile_dashboard.main()
+
+    assert rc == 0
+    text = caplog.text
+    # Dry-run "would delete" count must reflect ONLY truly deletable orphans,
+    # not the rename-suspect ones.
+    assert "would delete 1" in text
+    assert "Skipping 1 rename-suspect" in text
+
+
+def test_apply_mode_treats_inactive_near_match_as_deletable(monkeypatch):
+    """If the only near-matches are INACTIVE Wrike records, the slug is
+    deletable — the underlying site has been cancelled, just under a
+    slightly different title than what the dashboard slug encodes.
+    """
+    monkeypatch.setenv("RECONCILE_DRY_RUN", "0")
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "shh")
+
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_fetch_dashboard_slugs",
+        lambda base_url: [{"slug": "old-cancelled-site-tx"}],
+    )
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_expected_slugs_from_wrike",
+        lambda: (set(), {}, [("Old Cancelled Site", False)]),
+    )
+
+    delete_calls: list[dict] = []
+    monkeypatch.setattr(
+        reconcile_dashboard,
+        "_delete_site",
+        lambda base_url, slug, secret, *, reason, timeout=20: delete_calls.append(
+            {"slug": slug, "reason": reason}
+        )
+        or True,
+    )
+
+    rc = reconcile_dashboard.main()
+    assert rc == 0
+    assert delete_calls == [
+        {"slug": "old-cancelled-site-tx", "reason": "wrike-near-match-inactive"}
+    ]
+
+
 # ---------- _delete_site: 200/404 = success, others = fail ----------
 
 def test_delete_site_treats_200_and_404_as_success(monkeypatch):


### PR DESCRIPTION
## Summary
Partition orphans into `deletable` vs `rename_suspects` based on Wrike state. Only deletes orphans that are clearly gone (no active Wrike near-match); treats orphans whose tokens fuzzy-match an active Wrike record as renames in flight (skip + log).

## Why
Last week's dry-run flagged 6 orphans. 5 were active records that had been renamed in Wrike (Fort Worth, Tulsa, Chicago x2, Lombard); only `alpha-school-minneapolis-1128` is genuinely cancelled. Without this filter, an unattended apply-run would have wiped active sites.

## Behavior
| Orphan situation | Verdict | Reason tag |
|---|---|---|
| Slug present in Wrike but not in Active group | DELETABLE | `wrike-status:<id>` |
| Only inactive Wrike records fuzzy-match | DELETABLE | `wrike-near-match-inactive` |
| No Wrike record at all | DELETABLE | `wrike-record-missing` |
| **Active** Wrike record fuzzy-matches | **RENAME-SUSPECT (skip)** | logged only |

## Heuristic upgrade
`_find_near_matches` now does a non-numeric fallback: if strict all-token match fails, retries requiring only non-numeric tokens. This catches address-# renames like Lombard 835 → Lombard 995.

## Tests
24 passing, including 3 new:
- `test_apply_mode_skips_rename_suspects_with_active_near_match`
- `test_dry_run_partitions_rename_suspects_separately_from_deletable`
- `test_apply_mode_treats_inactive_near_match_as_deletable`

## Next
After merge, dispatch `reconcile-dashboard.yml` with `apply=false` to confirm only `alpha-school-minneapolis-1128` shows as DELETABLE, then with `apply=true` to delete it.