### PR TITLE
Reconcile: add numeric-anchor tier so qualifier-drop renames stay safe

### DIFF
--- a/scripts/reconcile_dashboard.py
+++ b/scripts/reconcile_dashboard.py
@@ -155,22 +155,27 @@ def _find_near_matches(
 ) -> list[tuple[str, bool]]:
     """Return Wrike ``(title, is_active)`` entries that look like the same site.
 
-    Matching strategy, in order:
+    Matching strategy, in order. Stops at the first tier that yields any hits:
 
     1. **Strict**: every meaningful slug token (after stripping brand words,
-       street types, USPS state codes) appears in the candidate title. This
-       handles the common case of slug-to-title drift like state suffixes
-       (e.g. dashboard slug ``...-tulsa-ok`` vs Wrike title ``... Tulsa ...``).
-    2. **Non-numeric fallback**: if no candidate matches strictly, retry
-       requiring only the *non-numeric* meaningful tokens to be present. This
-       catches the address-number rename case — e.g. dashboard slug
-       ``alpha-school-lombard-835`` (the original Wrike title) vs current
-       Wrike title ``Alpha School Lombard 995`` (renamed to a new street
-       number). Without this fallback, a rename like 835 → 995 looks like a
-       genuine orphan and the reconciler would prune real data.
+       street types, USPS state codes) appears in the candidate title. Handles
+       slug↔title drift like state suffixes (dashboard ``...-tulsa-ok`` vs
+       Wrike ``... Tulsa ...``).
+    2. **Non-numeric fallback**: only the non-numeric meaningful tokens must
+       appear. Catches address-number renames like ``alpha-school-lombard-835``
+       vs current Wrike title ``Alpha School Lombard 995``.
+    3. **Numeric-anchor fallback**: every *numeric* token in the slug appears
+       in the candidate title AND at least one non-numeric token also appears.
+       Catches slugs that carry an extra qualifier the active Wrike title
+       dropped — e.g. ``alpha-school-chicago-350-gems-full-school`` vs current
+       ``Alpha School Chicago 350 (GEMS)``: shared address # ``350`` plus city
+       token ``chicago`` is a strong rename signal. Requires at least one
+       numeric and one non-numeric token in the slug, so this tier never fires
+       for slugs that are pure city/word lists (avoids false positives across
+       same-city sites with different addresses).
 
-    The fallback only fires when at least one non-numeric token survives, so
-    purely numeric slugs (rare) still require the strict path.
+    Each fallback only fires when its precondition is met, so purely numeric
+    or purely text slugs still require the strict path.
     """
     tokens = _slug_tokens(slug)
     if not tokens:
@@ -187,16 +192,31 @@ def _find_near_matches(
         return matches
 
     non_numeric = [t for t in tokens if not t.isdigit()]
-    if not non_numeric or non_numeric == tokens:
-        # No fallback available (either all numeric, or fallback equals strict)
-        return matches
+    numeric = [t for t in tokens if t.isdigit()]
 
-    for title, active in all_titles:
-        lt = title.lower()
-        if all(tok in lt for tok in non_numeric):
-            matches.append((title, active))
-            if len(matches) >= limit:
-                break
+    # Tier 2: non-numeric fallback (skip if it would equal strict).
+    if non_numeric and non_numeric != tokens:
+        for title, active in all_titles:
+            lt = title.lower()
+            if all(tok in lt for tok in non_numeric):
+                matches.append((title, active))
+                if len(matches) >= limit:
+                    return matches
+        if matches:
+            return matches
+
+    # Tier 3: numeric-anchor fallback. Requires at least one numeric AND one
+    # non-numeric token in the slug; numeric tokens must all appear in the
+    # candidate title, plus at least one non-numeric token.
+    if numeric and non_numeric:
+        for title, active in all_titles:
+            lt = title.lower()
+            if all(num in lt for num in numeric) and any(
+                tok in lt for tok in non_numeric
+            ):
+                matches.append((title, active))
+                if len(matches) >= limit:
+                    break
     return matches
 
 

--- a/tests/test_reconcile_dashboard.py
+++ b/tests/test_reconcile_dashboard.py
@@ -288,6 +288,65 @@ def test_find_near_matches_returns_empty_when_no_overlap():
     )
 
 
+def test_find_near_matches_numeric_anchor_catches_qualifier_drop_rename():
+    """Numeric-anchor fallback: dashboard slug carries an extra qualifier the
+    active Wrike title dropped. Same numeric address + same city must surface
+    the active title as a rename suspect, not a genuine orphan.
+    """
+    all_titles = [
+        ("Alpha School Chicago 350 (GEMS)", True),
+        ("Alpha School Dallas 4152", True),
+    ]
+
+    # 'gems-full-school' qualifier: tier-3 picks up 350 + chicago.
+    matches = reconcile_dashboard._find_near_matches(
+        "alpha-school-chicago-350-gems-full-school", all_titles
+    )
+    assert matches == [("Alpha School Chicago 350 (GEMS)", True)]
+
+    # 'microschool' qualifier dropped from active title: same anchor logic.
+    matches = reconcile_dashboard._find_near_matches(
+        "alpha-school-chicago-350-microschool", all_titles
+    )
+    assert matches == [("Alpha School Chicago 350 (GEMS)", True)]
+
+
+def test_find_near_matches_numeric_anchor_requires_all_numeric_tokens_in_title():
+    """Tier-3 (numeric anchor) must require EVERY numeric token in the slug
+    to be present in the candidate title. A different-# same-city record
+    must not be returned by tier 3 — only by tier 2 (city-only fallback),
+    which is intentionally lax for safety.
+    """
+    all_titles = [
+        ("Alpha School Minneapolis 4500", True),  # different street #
+    ]
+
+    # Slug 'alpha-school-minneapolis-1128' has tokens [minneapolis, 1128].
+    # Tier 1 fails (no '1128' in title). Tier 2 succeeds because
+    # 'minneapolis' is the only non-numeric token — by design, this is the
+    # safe-by-default path: when in doubt, surface a rename suspect rather
+    # than silently delete real data. The reconciler's skip behavior is the
+    # correct outcome here.
+    matches = reconcile_dashboard._find_near_matches(
+        "alpha-school-minneapolis-1128", all_titles
+    )
+    assert matches == [("Alpha School Minneapolis 4500", True)]
+
+    # But tier 3 alone (numeric anchor) must not fire when the slug's
+    # numeric token is absent from the title. Verify by exercising a slug
+    # whose tier-2 path is blocked (multiple non-numeric tokens, only one
+    # of which appears in title) and whose only numeric token is missing.
+    all_titles_2 = [
+        ("Alpha School Chicago 4500 (GEMS)", True),
+    ]
+    matches = reconcile_dashboard._find_near_matches(
+        "alpha-school-detroit-350-microschool", all_titles_2
+    )
+    # detroit not in title (tier 1 fails on 350+detroit+microschool), tier 2
+    # fails on detroit+microschool, tier 3 fails because '350' not in title.
+    assert matches == []
+
+
 def test_main_logs_near_match_hint_for_orphans_with_no_exact_match(monkeypatch, caplog):
     monkeypatch.setenv("RECONCILE_DRY_RUN", "1")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
PR #52's dry-run still flagged both Chicago 350 dashboard slugs (`...gems-full-school` and `...microschool`) as DELETABLE because the active Wrike title `Alpha School Chicago 350 (GEMS)` dropped the qualifier the dashboard slugs carry. Tier 1 (strict) and tier 2 (non-numeric only) both miss this case.

## New tier 3 — numeric-anchor fallback
Every numeric slug token must appear in the title AND at least one non-numeric token must also appear.

## Catches
| Dashboard slug | Active Wrike title | Tier |
|---|---|---|
| `alpha-school-fort-worth-...` | `Alpha School Fort Worth 4717 Fletcher Ave` | 1 |
| `6940-s-utica-ave-tulsa-ok` | `Alpha School Tulsa 6940 S Utica Ave` | 1 |
| `alpha-school-lombard-835` | `Alpha School Lombard 995` | 2 |
| `alpha-school-chicago-350-gems-full-school` | `Alpha School Chicago 350 (GEMS)` | **3 (new)** |
| `alpha-school-chicago-350-microschool` | `Alpha School Chicago 350 (GEMS)` | **3 (new)** |

## Safety
Tier 3 only fires when the slug has at least one numeric AND one non-numeric token, and *every* numeric token must be in the candidate title. A slug like `detroit-350-microschool` won't match `Chicago 4500 (GEMS)`.

## Tests
26 passing. Two new ones cover the qualifier-drop case and the missing-numeric-token guard.