### PR TITLE
RayCon follow-up: use GoogleClient.from_oauth_config + keyword Wrike calls

### DIFF
--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -278,10 +278,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     settings = get_settings()
-    gc = GoogleClient()
+    gc = GoogleClient.from_oauth_config(
+        client_config_path=str(settings.get_client_config_path()),
+        token_file_path=str(settings.get_token_file_path()),
+        oauth_port=settings.oauth_port,
+        scopes=settings.google_scopes,
+    )
     config = load_wrike_config()
-    records = _get_all_site_records(config)
-    active_status_ids = _get_active_status_ids(config)
+    records = _get_all_site_records(cfg=config)
+    active_status_ids = _get_active_status_ids(access_token=config.access_token)
     active_records = filter_active_site_records(records, active_status_ids)
 
     summaries = [build_site_summary(r) for r in active_records]


### PR DESCRIPTION
## Bug
Scheduled `RayCon Follow-up` run [25197702559](https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/25197702559) failed at startup:
```
TypeError: GoogleClient.__init__() missing 1 required positional argument: 'credentials'
```

## Root cause
`GoogleClient` was refactored to require a `Credentials` object. Every other script bootstraps via `GoogleClient.from_oauth_config(...)` — `raycon_followup.py` was still calling `GoogleClient()` with no args, so every scheduled run since the refactor has crashed before doing any work.

## Fix
Switched to the same `from_oauth_config` bootstrap pattern used by `daily_dd_check.py`, `backfill_dashboard.py`, `scan_inbox.py`, etc.

Also corrected two latent positional-arg bugs in the same block (both functions are keyword-only):
- `_get_all_site_records(config)` → `_get_all_site_records(cfg=config)`
- `_get_active_status_ids(config)` → `_get_active_status_ids(access_token=config.access_token)`

The script would have crashed at those lines next without the fix.

## Verified
Local smoke test gets past init now (fails on missing OAuth token in sandbox, which is expected — runner has the token).