### PR TITLE
Validate Rebl slugs: cross-reference dashboard with /api/resolve, optional --apply migrates stale slugs

### DIFF
--- a/.github/workflows/validate-rebl-slugs.yml
+++ b/.github/workflows/validate-rebl-slugs.yml
@@ -1,0 +1,98 @@
+name: Validate Rebl Slugs
+
+# Cross-references the DD Dashboard's slugs with Rebl's canonical
+# /api/resolve output. Default is dry-run (report only). Set apply=true on
+# manual dispatch to actually migrate stale slugs (POST under the new slug,
+# DELETE the old). The weekly cron is dry-run by design — only operators
+# trigger an apply, and the consolidated Google Chat alert tells us when.
+#
+# Triggers:
+#   - manual workflow_dispatch (apply input)
+#   - weekly cron (Tuesdays 13:30 UTC) — always dry-run
+#
+# Required secrets:
+#   WRIKE_ACCESS_TOKEN, DASHBOARD_PUBLISH_SECRET, GOOGLE_CHAT_WEBHOOK_URL
+# Optional:
+#   DASHBOARD_PUBLISH_URL (defaults to https://dd-dashboard-three.vercel.app)
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Set true to actually MIGRATE slugs (POST new + DELETE old). Leave false for dry-run.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      site:
+        description: 'Optional: filter to sites whose Wrike title or address contains this substring.'
+        required: false
+        default: ''
+        type: string
+  schedule:
+    # Tuesdays 13:30 UTC = 08:30 CDT, 30 min after the reconcile-dashboard cron.
+    - cron: '30 13 * * 2'
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.WRIKE_ACCESS_TOKEN }}" ]       || { echo "[ERROR] WRIKE_ACCESS_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ] || { echo "[ERROR] DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
+          echo "[OK] Required secrets present"
+
+      - name: Create .env file from secrets
+        env:
+          WRIKE_ACCESS_TOKEN: ${{ secrets.WRIKE_ACCESS_TOKEN }}
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
+          DASHBOARD_PUBLISH_URL: ${{ secrets.DASHBOARD_PUBLISH_URL }}
+          GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+        run: |
+          touch .env
+          echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
+          if [ -n "${DASHBOARD_PUBLISH_URL}" ]; then
+            echo "DASHBOARD_PUBLISH_URL=${DASHBOARD_PUBLISH_URL}" >> .env
+          fi
+          if [ -n "${GOOGLE_CHAT_WEBHOOK_URL}" ]; then
+            echo "GOOGLE_CHAT_WEBHOOK_URL=${GOOGLE_CHAT_WEBHOOK_URL}" >> .env
+          fi
+          echo "[OK] Created .env file"
+
+      - name: Run Rebl slug validator
+        env:
+          APPLY_FLAG: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') && '--apply' || '' }}
+          SITE_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.site || '' }}
+        run: |
+          ARGS=""
+          if [ -n "${APPLY_FLAG}" ]; then
+            ARGS="${ARGS} ${APPLY_FLAG}"
+          fi
+          if [ -n "${SITE_FILTER}" ]; then
+            ARGS="${ARGS} --site ${SITE_FILTER}"
+          fi
+          echo "[INFO] Running with args: ${ARGS:-(dry-run, all sites)}"
+          uv run python scripts/validate_rebl_slugs.py ${ARGS}
+
+      - name: Done
+        run: echo "Rebl slug validation completed"

--- a/scripts/validate_rebl_slugs.py
+++ b/scripts/validate_rebl_slugs.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""validate_rebl_slugs.py — make Rebl the source of truth for dashboard slugs.
+
+Rebl drives the canonical slug for every site on the DD Dashboard. Historically
+the dashboard publisher derived its own slug from ``slugify(site_title)``,
+which produced locally-invented slugs (e.g. ``alpha-school-tulsa-6940-s-utica-ave``).
+Rebl resolves the same address to a different canonical slug
+(``6940-s-utica-ave-tulsa-ok``). This script reconciles both:
+
+  1. List every active Wrike Site Record. Wrike is the canonical address source.
+  2. Cross-reference with the dashboard's live ``sites.json``.
+  3. Batch-resolve every active address against
+     ``POST https://rebl3.vercel.app/api/resolve``.
+  4. Per site, classify as:
+        - OK            — Rebl ``site_id`` matches dashboard slug exactly.
+        - migrate       — Rebl ``site_id`` differs; dashboard needs renaming.
+        - missing       — Rebl returned an error or ``matched_by:"none"`` w/o
+                          lat/lng; cannot determine canonical slug.
+        - api_error     — network/transport failure.
+        - unknown       — Wrike has the address but it isn't on the dashboard
+                          yet (no slug to migrate).
+  5. Default ``--dry-run``: print a report. ``--apply``: for each migrate row,
+     ``POST`` the existing record under the new slug, then ``DELETE`` the old
+     slug. Both calls carry ``X-Reconcile-Reason`` so the dashboard's commit
+     log captures the migration cause.
+  6. Always: post one consolidated Google Chat alert summarising the run.
+
+Auth / env (loaded from .env):
+    WRIKE_ACCESS_TOKEN
+    DASHBOARD_PUBLISH_URL    (default https://dd-dashboard-three.vercel.app)
+    DASHBOARD_PUBLISH_SECRET (required for --apply)
+    GOOGLE_CHAT_WEBHOOK_URL  (optional; alert sink)
+    REBL_RESOLVE_URL         (default https://rebl3.vercel.app/api/resolve)
+
+Run:
+    uv run python scripts/validate_rebl_slugs.py            # dry-run, all sites
+    uv run python scripts/validate_rebl_slugs.py --apply    # actually migrate
+    uv run python scripts/validate_rebl_slugs.py --site Tulsa --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+import requests  # noqa: E402
+
+from due_diligence_reporter.wrike import (  # noqa: E402
+    _get_active_status_ids,
+    _get_all_site_records,
+    build_site_summary,
+    filter_active_site_records,
+    load_wrike_config,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s \u2014 %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("validate_rebl_slugs")
+
+_DEFAULT_DASHBOARD_URL = "https://dd-dashboard-three.vercel.app"
+_DEFAULT_REBL_URL = "https://rebl3.vercel.app/api/resolve"
+_REBL_BATCH_SIZE = 25
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+
+
+def _dashboard_base_url() -> str:
+    return (os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_DASHBOARD_URL).rstrip("/")
+
+
+def _rebl_resolve_url() -> str:
+    return os.environ.get("REBL_RESOLVE_URL") or _DEFAULT_REBL_URL
+
+
+# ---------------------------------------------------------------------------
+# Classification
+
+
+@dataclass
+class SiteRow:
+    """One row in the validation report.
+
+    Attributes capture everything we need to act on (or report) for a single
+    Wrike site, *and* enough metadata to write the migration commit message.
+    """
+
+    title: str
+    address: str
+    wrike_id: str | None = None
+    dashboard_slug: str | None = None  # current slug on dashboard (may be None)
+    rebl_slug: str | None = None       # canonical slug returned by Rebl
+    rebl_matched_by: str | None = None
+    rebl_scored: bool | None = None
+    rebl_error: str | None = None
+    classification: str = "unknown"    # ok|migrate|missing|api_error|unknown
+    note: str = ""
+
+
+def classify_rebl_response(rebl_obj: dict[str, Any] | None) -> tuple[str | None, str, str]:
+    """Pull the canonical slug + a status from a single Rebl resolve result.
+
+    Returns ``(slug, status, note)`` where status is one of
+    ``"ok" | "missing" | "api_error"``. ``slug`` is the Rebl ``site_id`` when
+    we trust it, else ``None``.
+
+    Rules (per user):
+      * Object has ``error`` key → MISSING.
+      * ``matched_by == "none"`` AND no lat/lng → MISSING.
+      * ``matched_by == "none"`` WITH lat/lng → valid (Rebl knows it
+        geographically; just no row yet).
+      * ``scored: false`` with valid match → valid (just not enriched).
+    """
+    if rebl_obj is None:
+        return None, "api_error", "no Rebl response"
+
+    if "error" in rebl_obj and rebl_obj["error"]:
+        return None, "missing", f"Rebl error: {rebl_obj['error']}"
+
+    matched_by = (rebl_obj.get("matched_by") or "").strip().lower()
+    has_geo = bool(rebl_obj.get("lat")) and bool(rebl_obj.get("lng"))
+    site_id = (rebl_obj.get("site_id") or "").strip() or None
+
+    if matched_by == "none" and not has_geo:
+        return None, "missing", "Rebl matched_by=none and no lat/lng"
+
+    if not site_id:
+        return None, "missing", "Rebl returned empty site_id"
+
+    return site_id, "ok", ""
+
+
+# ---------------------------------------------------------------------------
+# External I/O
+
+
+def fetch_dashboard_sites(base_url: str, *, timeout: int = 20) -> list[dict[str, Any]]:
+    """Return the full ``sites`` array from the live ``sites.json``."""
+    url = f"{base_url}/sites.json"
+    r = requests.get(url, timeout=timeout)
+    r.raise_for_status()
+    payload = r.json()
+    sites = payload.get("sites") or []
+    if not isinstance(sites, list):
+        return []
+    return [s for s in sites if isinstance(s, dict) and s.get("slug")]
+
+
+def resolve_addresses_in_batches(
+    addresses: list[str],
+    *,
+    resolve_url: str | None = None,
+    batch_size: int = _REBL_BATCH_SIZE,
+    timeout: int = 30,
+) -> list[dict[str, Any] | None]:
+    """Call Rebl ``/api/resolve`` in batches; return results in the same order.
+
+    Each item is either the resolve dict (possibly with ``error`` key) or
+    ``None`` if the entire batch HTTP call failed.
+    """
+    url = resolve_url or _rebl_resolve_url()
+    out: list[dict[str, Any] | None] = []
+    for start in range(0, len(addresses), batch_size):
+        chunk = addresses[start : start + batch_size]
+        body = [{"address": a} for a in chunk]
+        try:
+            r = requests.post(url, json=body, timeout=timeout)
+            r.raise_for_status()
+            data = r.json()
+            if not isinstance(data, list) or len(data) != len(chunk):
+                logger.warning(
+                    "Rebl batch %d-%d returned malformed response (len=%s); marking api_error",
+                    start, start + len(chunk), len(data) if isinstance(data, list) else "n/a",
+                )
+                out.extend([None] * len(chunk))
+            else:
+                out.extend(data)
+        except requests.RequestException as e:
+            logger.warning(
+                "Rebl batch %d-%d failed (network): %s",
+                start, start + len(chunk), e,
+            )
+            out.extend([None] * len(chunk))
+    return out
+
+
+def post_chat(webhook_url: str, text: str, *, timeout: int = 10) -> None:
+    if not webhook_url:
+        return
+    try:
+        requests.post(webhook_url, json={"text": text}, timeout=timeout)
+    except requests.RequestException as e:
+        logger.warning("Failed to post Chat alert: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Migration
+
+
+def migrate_slug(
+    base_url: str,
+    secret: str,
+    *,
+    old_slug: str,
+    new_slug: str,
+    full_record: dict[str, Any],
+    timeout: int = 30,
+) -> tuple[bool, str]:
+    """POST the record under ``new_slug``, then DELETE the old. Idempotent.
+
+    The POST endpoint forces ``slug`` from the URL, so we copy the existing
+    site_meta + report_data wholesale; the only change is the URL slug.
+
+    Returns ``(success, note)``.
+    """
+    reason = f"rebl-canonical-slug-migration (was {old_slug})"
+
+    # Reuse the dashboard's existing record as both site_meta and report_data.
+    # The dashboard's transform layer is tolerant of report_data shape and
+    # falls back to site_meta on every field — so passing the live record back
+    # in produces an identical row under the new slug.
+    site_meta = dict(full_record)
+    site_meta["slug"] = new_slug
+    payload = {"site_meta": site_meta, "report_data": full_record}
+
+    post_url = f"{base_url}/api/sites/{new_slug}/publish"
+    try:
+        r = requests.post(
+            post_url,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {secret}",
+                "Content-Type": "application/json",
+                "X-Reconcile-Reason": reason,
+            },
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        return False, f"POST {new_slug} network error: {e}"
+    if r.status_code != 200:
+        return False, f"POST {new_slug} HTTP {r.status_code}: {r.text[:200]}"
+
+    delete_url = f"{base_url}/api/sites/{old_slug}/publish"
+    try:
+        d = requests.delete(
+            delete_url,
+            headers={
+                "Authorization": f"Bearer {secret}",
+                "X-Reconcile-Reason": reason,
+            },
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        return False, f"POST {new_slug} OK, DELETE {old_slug} network error: {e}"
+    if d.status_code not in (200, 404):
+        return False, (
+            f"POST {new_slug} OK, DELETE {old_slug} HTTP {d.status_code}: "
+            f"{d.text[:200]}"
+        )
+
+    return True, f"migrated {old_slug} -> {new_slug}"
+
+
+# ---------------------------------------------------------------------------
+# Wrike
+
+
+def _site_filter(summary: dict[str, Any], needle: str | None) -> bool:
+    if not needle:
+        return True
+    n = needle.lower()
+    return n in (summary.get("title") or "").lower() or n in (summary.get("address") or "").lower()
+
+
+def load_active_site_summaries(needle: str | None = None) -> list[dict[str, Any]]:
+    """Return the canonical Wrike active-site summaries (filtered by ``needle``)."""
+    config = load_wrike_config()
+    records = _get_all_site_records(cfg=config)
+    active_status_ids = _get_active_status_ids(access_token=config.access_token)
+    active_records = filter_active_site_records(records, active_status_ids)
+    summaries = [build_site_summary(r) for r in active_records]
+    return [s for s in summaries if _site_filter(s, needle)]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+
+
+def build_rows(
+    summaries: Iterable[dict[str, Any]],
+    dashboard_by_slug: dict[str, dict[str, Any]],
+    rebl_results: list[dict[str, Any] | None],
+) -> list[SiteRow]:
+    """Join Wrike summaries + dashboard rows + Rebl results into ``SiteRow``s.
+
+    The dashboard is keyed by slug, but a Wrike site's *current* dashboard slug
+    isn't known up front. We match a Wrike row to a dashboard row by Rebl slug
+    first (preferred), then by ``meta.rebl.site_id`` if present, and finally
+    by *any* slug whose stored address normalises to the Wrike address. This
+    keeps the migration honest even when local slugs are wildly off-format.
+    """
+    # Pre-index dashboard rows by stored rebl.site_id for fast secondary match.
+    by_rebl_id: dict[str, dict[str, Any]] = {}
+    by_address: dict[str, list[dict[str, Any]]] = {}
+    for site in dashboard_by_slug.values():
+        rebl = site.get("meta", {}).get("rebl", {}) if isinstance(site.get("meta"), dict) else {}
+        rid = (rebl.get("site_id") if isinstance(rebl, dict) else "") or ""
+        if rid:
+            by_rebl_id[rid] = site
+        addr = (site.get("address") or "").strip().lower()
+        if addr:
+            by_address.setdefault(addr, []).append(site)
+
+    rows: list[SiteRow] = []
+    summaries_list = list(summaries)
+    if len(summaries_list) != len(rebl_results):
+        # Defensive: should never happen because we built rebl_results from the
+        # same list. Fail loud instead of silently misaligning.
+        raise RuntimeError(
+            f"summaries/rebl_results length mismatch: {len(summaries_list)} vs {len(rebl_results)}"
+        )
+
+    for summary, rebl_obj in zip(summaries_list, rebl_results):
+        title = summary.get("title") or ""
+        address = summary.get("address") or ""
+        row = SiteRow(
+            title=title,
+            address=address,
+            wrike_id=str(summary.get("id")) if summary.get("id") else None,
+        )
+
+        rebl_slug, status, note = classify_rebl_response(rebl_obj)
+        if rebl_obj:
+            row.rebl_matched_by = rebl_obj.get("matched_by")
+            row.rebl_scored = rebl_obj.get("scored")
+        row.rebl_slug = rebl_slug
+        row.note = note
+
+        # Find the matching dashboard row (if any) for the *current* slug.
+        match: dict[str, Any] | None = None
+        if rebl_slug and rebl_slug in dashboard_by_slug:
+            match = dashboard_by_slug[rebl_slug]
+        elif rebl_slug and rebl_slug in by_rebl_id:
+            match = by_rebl_id[rebl_slug]
+        elif address and address.strip().lower() in by_address:
+            candidates = by_address[address.strip().lower()]
+            # Prefer the candidate whose stored rebl_site_id is empty (i.e.
+            # the dashboard never persisted a Rebl id) so we don't shadow a
+            # row that's already canonical.
+            match = candidates[0]
+
+        if match:
+            row.dashboard_slug = match.get("slug")
+
+        # Classify
+        if status == "missing":
+            row.classification = "missing"
+        elif status == "api_error":
+            row.classification = "api_error"
+            row.rebl_error = note or "api_error"
+        else:
+            # status == "ok": we have a canonical Rebl slug.
+            if not row.dashboard_slug:
+                row.classification = "unknown"
+                row.note = "Rebl resolved but no dashboard row for this site"
+            elif row.dashboard_slug == rebl_slug:
+                row.classification = "ok"
+            else:
+                row.classification = "migrate"
+
+        rows.append(row)
+
+    return rows
+
+
+def render_report(rows: list[SiteRow]) -> str:
+    """Plain-text grouped report for stdout + Chat."""
+    buckets: dict[str, list[SiteRow]] = {
+        "migrate": [],
+        "missing": [],
+        "api_error": [],
+        "unknown": [],
+        "ok": [],
+    }
+    for r in rows:
+        buckets.setdefault(r.classification, []).append(r)
+
+    lines: list[str] = []
+    lines.append(
+        f"Rebl slug validation: total={len(rows)} "
+        f"ok={len(buckets['ok'])} migrate={len(buckets['migrate'])} "
+        f"missing={len(buckets['missing'])} api_error={len(buckets['api_error'])} "
+        f"unknown={len(buckets['unknown'])}"
+    )
+
+    if buckets["migrate"]:
+        lines.append("")
+        lines.append(f"Migrate ({len(buckets['migrate'])}):")
+        for r in buckets["migrate"]:
+            lines.append(
+                f"  - {r.title}: {r.dashboard_slug} -> {r.rebl_slug} "
+                f"(matched_by={r.rebl_matched_by}, address={r.address})"
+            )
+
+    if buckets["missing"]:
+        lines.append("")
+        lines.append(f"Missing from Rebl ({len(buckets['missing'])}):")
+        for r in buckets["missing"]:
+            lines.append(f"  - {r.title}: {r.note} (address={r.address})")
+
+    if buckets["api_error"]:
+        lines.append("")
+        lines.append(f"Rebl API errors ({len(buckets['api_error'])}):")
+        for r in buckets["api_error"]:
+            lines.append(f"  - {r.title}: {r.rebl_error}")
+
+    if buckets["unknown"]:
+        lines.append("")
+        lines.append(f"Unknown (not on dashboard) ({len(buckets['unknown'])}):")
+        for r in buckets["unknown"]:
+            lines.append(f"  - {r.title}: rebl_slug={r.rebl_slug}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--site",
+        help="Filter to sites whose Wrike title or address contains this substring",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually issue POST/DELETE to migrate slugs. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--no-chat",
+        action="store_true",
+        help="Skip the Google Chat summary post (still writes stdout report).",
+    )
+    args = parser.parse_args(argv)
+
+    base_url = _dashboard_base_url()
+    secret = os.environ.get("DASHBOARD_PUBLISH_SECRET", "")
+    webhook_url = os.environ.get("GOOGLE_CHAT_WEBHOOK_URL", "")
+
+    if args.apply and not secret:
+        logger.error("--apply requires DASHBOARD_PUBLISH_SECRET")
+        return 2
+
+    logger.info(
+        "validate_rebl_slugs mode=%s base_url=%s",
+        "APPLY" if args.apply else "DRY_RUN",
+        base_url,
+    )
+
+    # 1. Wrike active set (canonical addresses)
+    try:
+        summaries = load_active_site_summaries(args.site)
+    except Exception as e:
+        logger.exception("Failed to load Wrike active set: %s", e)
+        return 3
+    logger.info("Loaded %d active Wrike sites", len(summaries))
+
+    # 2. Dashboard live snapshot
+    try:
+        dashboard_sites = fetch_dashboard_sites(base_url)
+    except requests.RequestException as e:
+        logger.error("Failed to fetch %s/sites.json: %s", base_url, e)
+        return 4
+    dashboard_by_slug = {str(s["slug"]): s for s in dashboard_sites}
+    logger.info("Dashboard currently has %d sites", len(dashboard_by_slug))
+
+    # 3. Rebl resolve (only sites with a non-empty address)
+    addresses = [s.get("address") or "" for s in summaries]
+    rebl_results = resolve_addresses_in_batches(addresses)
+
+    # 4. Classify
+    rows = build_rows(summaries, dashboard_by_slug, rebl_results)
+    report = render_report(rows)
+    print(report)
+
+    # Always emit a JSON line per row for easy log parsing.
+    for r in rows:
+        logger.info(
+            "%s",
+            json.dumps(
+                {
+                    "title": r.title,
+                    "classification": r.classification,
+                    "dashboard_slug": r.dashboard_slug,
+                    "rebl_slug": r.rebl_slug,
+                    "matched_by": r.rebl_matched_by,
+                    "note": r.note,
+                },
+                default=str,
+            ),
+        )
+
+    # 5. Apply (or dry-run summary)
+    migrate_rows = [r for r in rows if r.classification == "migrate"]
+    applied = 0
+    failed: list[tuple[SiteRow, str]] = []
+
+    if args.apply and migrate_rows:
+        logger.info("Applying %d migration(s)…", len(migrate_rows))
+        for r in migrate_rows:
+            old_slug = r.dashboard_slug
+            new_slug = r.rebl_slug
+            if not old_slug or not new_slug:
+                failed.append((r, "missing slug fields"))
+                continue
+            full_record = dashboard_by_slug.get(old_slug)
+            if not full_record:
+                failed.append((r, f"no dashboard record for {old_slug}"))
+                continue
+            ok, note = migrate_slug(
+                base_url,
+                secret,
+                old_slug=old_slug,
+                new_slug=new_slug,
+                full_record=full_record,
+            )
+            if ok:
+                applied += 1
+                logger.info("Migrated: %s", note)
+            else:
+                failed.append((r, note))
+                logger.warning("Migration failed for %s: %s", r.title, note)
+    elif migrate_rows:
+        logger.info(
+            "DRY_RUN: would migrate %d slug(s) (use --apply to execute)",
+            len(migrate_rows),
+        )
+
+    # 6. Consolidated Chat alert
+    if webhook_url and not args.no_chat:
+        title_prefix = "Rebl slug migration (APPLY)" if args.apply else "Rebl slug validation (DRY_RUN)"
+        chat_lines = [title_prefix, report]
+        if args.apply:
+            chat_lines.append("")
+            chat_lines.append(f"Applied: {applied} / {len(migrate_rows)}")
+            if failed:
+                chat_lines.append(f"Failed: {len(failed)}")
+                for r, note in failed:
+                    chat_lines.append(f"  - {r.title}: {note}")
+        post_chat(webhook_url, "\n".join(chat_lines))
+    elif not webhook_url:
+        logger.info("GOOGLE_CHAT_WEBHOOK_URL not set; skipping Chat alert")
+
+    if failed:
+        return 5
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_validate_rebl_slugs.py
+++ b/tests/test_validate_rebl_slugs.py
@@ -1,0 +1,410 @@
+"""Tests for scripts/validate_rebl_slugs.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "validate_rebl_slugs.py"
+
+_spec = importlib.util.spec_from_file_location("validate_rebl_slugs", _SCRIPT_PATH)
+validate_rebl_slugs = importlib.util.module_from_spec(_spec)
+sys.modules["validate_rebl_slugs"] = validate_rebl_slugs
+_spec.loader.exec_module(validate_rebl_slugs)  # type: ignore[union-attr]
+
+
+# ---------- classify_rebl_response ----------
+
+
+@pytest.mark.parametrize(
+    "obj,expected_slug,expected_status",
+    [
+        # Direct slug match (the canonical path)
+        (
+            {
+                "site_id": "6940-s-utica-ave-tulsa-ok",
+                "matched_by": "slug",
+                "scored": True,
+                "lat": 36.0,
+                "lng": -96.0,
+            },
+            "6940-s-utica-ave-tulsa-ok",
+            "ok",
+        ),
+        # geocode_slug match -> still trustable
+        (
+            {
+                "site_id": "4717-fletcher-ave-fort-worth-tx",
+                "matched_by": "geocode_slug",
+                "scored": True,
+                "lat": 32.7,
+                "lng": -97.3,
+            },
+            "4717-fletcher-ave-fort-worth-tx",
+            "ok",
+        ),
+        # scored: false but valid match still returns the slug
+        (
+            {
+                "site_id": "995-oak-creek-dr-lombard-il",
+                "matched_by": "geocode_slug",
+                "scored": False,
+                "lat": 41.8,
+                "lng": -88.0,
+            },
+            "995-oak-creek-dr-lombard-il",
+            "ok",
+        ),
+        # matched_by=none with lat/lng -> trust the slug (Rebl knows it geographically)
+        (
+            {
+                "site_id": "some-new-place",
+                "matched_by": "none",
+                "scored": False,
+                "lat": 40.0,
+                "lng": -100.0,
+            },
+            "some-new-place",
+            "ok",
+        ),
+        # matched_by=none AND no lat/lng -> MISSING
+        (
+            {
+                "site_id": "garbage",
+                "matched_by": "none",
+                "scored": False,
+            },
+            None,
+            "missing",
+        ),
+        # Explicit error key -> MISSING
+        (
+            {"index": 3, "error": "Could not build address"},
+            None,
+            "missing",
+        ),
+        # Empty site_id -> MISSING
+        (
+            {"site_id": "", "matched_by": "slug", "lat": 1.0, "lng": 2.0},
+            None,
+            "missing",
+        ),
+        # None response -> api_error
+        (None, None, "api_error"),
+    ],
+)
+def test_classify_rebl_response(obj, expected_slug, expected_status):
+    slug, status, _note = validate_rebl_slugs.classify_rebl_response(obj)
+    assert slug == expected_slug
+    assert status == expected_status
+
+
+# ---------- resolve_addresses_in_batches ----------
+
+
+def test_resolve_addresses_in_batches_chunks_and_preserves_order():
+    addresses = [f"addr-{i}" for i in range(7)]
+
+    captured_payloads: list[list[dict]] = []
+
+    def _fake_post(url, json=None, timeout=None):  # noqa: A002
+        captured_payloads.append(json)
+        # Echo back a site_id derived from the address so we can verify order.
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = lambda: None
+        resp.json = lambda: [
+            {"site_id": item["address"], "matched_by": "slug", "lat": 1, "lng": 2}
+            for item in json
+        ]
+        return resp
+
+    with patch.object(validate_rebl_slugs.requests, "post", side_effect=_fake_post):
+        results = validate_rebl_slugs.resolve_addresses_in_batches(
+            addresses, batch_size=3, resolve_url="http://stub"
+        )
+
+    assert len(results) == 7
+    assert [r["site_id"] for r in results] == addresses
+    # 7 items in batches of 3 -> 3 calls (3+3+1)
+    assert len(captured_payloads) == 3
+    assert [len(p) for p in captured_payloads] == [3, 3, 1]
+
+
+def test_resolve_addresses_in_batches_returns_none_on_network_failure():
+    import requests as _requests
+
+    def _boom(*_a, **_kw):
+        raise _requests.RequestException("boom")
+
+    with patch.object(validate_rebl_slugs.requests, "post", side_effect=_boom):
+        results = validate_rebl_slugs.resolve_addresses_in_batches(
+            ["a", "b"], batch_size=5, resolve_url="http://stub"
+        )
+
+    assert results == [None, None]
+
+
+def test_resolve_addresses_in_batches_handles_malformed_response():
+    def _fake_post(*_a, **_kw):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = lambda: None
+        resp.json = lambda: {"not": "a list"}
+        return resp
+
+    with patch.object(validate_rebl_slugs.requests, "post", side_effect=_fake_post):
+        results = validate_rebl_slugs.resolve_addresses_in_batches(
+            ["a", "b"], batch_size=5, resolve_url="http://stub"
+        )
+
+    assert results == [None, None]
+
+
+# ---------- build_rows ----------
+
+
+def _summary(title: str, address: str, wid: str = "1") -> dict:
+    return {"id": wid, "title": title, "address": address}
+
+
+def _rebl_ok(site_id: str) -> dict:
+    return {"site_id": site_id, "matched_by": "slug", "scored": True, "lat": 1, "lng": 2}
+
+
+def test_build_rows_classifies_ok_when_slugs_match():
+    summaries = [_summary("Tulsa", "6940 S Utica Ave, Tulsa, OK")]
+    dashboard = {
+        "6940-s-utica-ave-tulsa-ok": {
+            "slug": "6940-s-utica-ave-tulsa-ok",
+            "address": "6940 S Utica Ave, Tulsa, OK",
+        }
+    }
+    rebl_results = [_rebl_ok("6940-s-utica-ave-tulsa-ok")]
+
+    rows = validate_rebl_slugs.build_rows(summaries, dashboard, rebl_results)
+    assert len(rows) == 1
+    assert rows[0].classification == "ok"
+    assert rows[0].dashboard_slug == "6940-s-utica-ave-tulsa-ok"
+    assert rows[0].rebl_slug == "6940-s-utica-ave-tulsa-ok"
+
+
+def test_build_rows_classifies_migrate_when_slugs_differ():
+    summaries = [_summary("Tulsa", "6940 S Utica Ave, Tulsa, OK")]
+    dashboard = {
+        "alpha-school-tulsa-6940-s-utica-ave": {
+            "slug": "alpha-school-tulsa-6940-s-utica-ave",
+            "address": "6940 S Utica Ave, Tulsa, OK",
+        }
+    }
+    rebl_results = [_rebl_ok("6940-s-utica-ave-tulsa-ok")]
+
+    rows = validate_rebl_slugs.build_rows(summaries, dashboard, rebl_results)
+    assert rows[0].classification == "migrate"
+    assert rows[0].dashboard_slug == "alpha-school-tulsa-6940-s-utica-ave"
+    assert rows[0].rebl_slug == "6940-s-utica-ave-tulsa-ok"
+
+
+def test_build_rows_finds_match_via_stored_rebl_site_id():
+    summaries = [_summary("Tulsa", "6940 S Utica Ave, Tulsa, OK")]
+    # Address differs (perhaps the dashboard stored the marketing form), but
+    # meta.rebl.site_id matches the canonical slug.
+    dashboard = {
+        "alpha-school-tulsa-6940-s-utica-ave": {
+            "slug": "alpha-school-tulsa-6940-s-utica-ave",
+            "address": "Different formatted address",
+            "meta": {"rebl": {"site_id": "6940-s-utica-ave-tulsa-ok"}},
+        }
+    }
+    rebl_results = [_rebl_ok("6940-s-utica-ave-tulsa-ok")]
+
+    rows = validate_rebl_slugs.build_rows(summaries, dashboard, rebl_results)
+    assert rows[0].classification == "migrate"
+    assert rows[0].dashboard_slug == "alpha-school-tulsa-6940-s-utica-ave"
+
+
+def test_build_rows_classifies_unknown_when_not_on_dashboard():
+    summaries = [_summary("New Site", "999 Nowhere St, Austin, TX")]
+    dashboard: dict = {}
+    rebl_results = [_rebl_ok("999-nowhere-st-austin-tx")]
+
+    rows = validate_rebl_slugs.build_rows(summaries, dashboard, rebl_results)
+    assert rows[0].classification == "unknown"
+    assert rows[0].rebl_slug == "999-nowhere-st-austin-tx"
+    assert rows[0].dashboard_slug is None
+
+
+def test_build_rows_classifies_missing_on_rebl_error():
+    summaries = [_summary("Bad", "")]
+    dashboard: dict = {}
+    rebl_results = [{"index": 0, "error": "Could not build address"}]
+
+    rows = validate_rebl_slugs.build_rows(summaries, dashboard, rebl_results)
+    assert rows[0].classification == "missing"
+    assert "Could not build address" in rows[0].note
+
+
+def test_build_rows_classifies_api_error_on_none():
+    summaries = [_summary("Net Down", "100 Main St")]
+    dashboard: dict = {}
+    rebl_results = [None]
+
+    rows = validate_rebl_slugs.build_rows(summaries, dashboard, rebl_results)
+    assert rows[0].classification == "api_error"
+    assert rows[0].rebl_error
+
+
+def test_build_rows_raises_on_length_mismatch():
+    with pytest.raises(RuntimeError):
+        validate_rebl_slugs.build_rows(
+            [_summary("a", "x"), _summary("b", "y")],
+            {},
+            [_rebl_ok("a")],  # only one result for two summaries
+        )
+
+
+# ---------- migrate_slug ----------
+
+
+def _ok_response(status: int = 200, text: str = "{}"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+def test_migrate_slug_posts_then_deletes():
+    captured: dict = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["post_url"] = url
+        captured["post_headers"] = headers
+        captured["post_payload"] = json
+        return _ok_response(200)
+
+    def fake_delete(url, headers=None, timeout=None):
+        captured["delete_url"] = url
+        captured["delete_headers"] = headers
+        return _ok_response(200)
+
+    full_record = {
+        "slug": "alpha-school-tulsa-6940-s-utica-ave",
+        "site_name": "Tulsa",
+        "address": "6940 S Utica Ave, Tulsa, OK",
+    }
+
+    with patch.object(validate_rebl_slugs.requests, "post", side_effect=fake_post), \
+         patch.object(validate_rebl_slugs.requests, "delete", side_effect=fake_delete):
+        ok, note = validate_rebl_slugs.migrate_slug(
+            "https://dash.example.com",
+            "secret-xyz",
+            old_slug="alpha-school-tulsa-6940-s-utica-ave",
+            new_slug="6940-s-utica-ave-tulsa-ok",
+            full_record=full_record,
+        )
+
+    assert ok is True
+    assert "migrated" in note
+    # POST hits the new slug URL with the record (slug overwritten to new).
+    assert captured["post_url"].endswith("/api/sites/6940-s-utica-ave-tulsa-ok/publish")
+    assert captured["post_payload"]["site_meta"]["slug"] == "6940-s-utica-ave-tulsa-ok"
+    # Both calls carry the reason header pointing back at the old slug.
+    assert "rebl-canonical-slug-migration" in captured["post_headers"]["X-Reconcile-Reason"]
+    assert "alpha-school-tulsa-6940-s-utica-ave" in captured["post_headers"]["X-Reconcile-Reason"]
+    assert captured["delete_url"].endswith("/api/sites/alpha-school-tulsa-6940-s-utica-ave/publish")
+    assert captured["delete_headers"]["Authorization"] == "Bearer secret-xyz"
+
+
+def test_migrate_slug_treats_delete_404_as_success():
+    """If old slug is already gone (perhaps a half-applied prior run),
+    DELETE 404 should not fail the migration."""
+    with patch.object(validate_rebl_slugs.requests, "post", return_value=_ok_response(200)), \
+         patch.object(validate_rebl_slugs.requests, "delete", return_value=_ok_response(404)):
+        ok, note = validate_rebl_slugs.migrate_slug(
+            "https://dash.example.com",
+            "secret",
+            old_slug="old",
+            new_slug="new",
+            full_record={"slug": "old"},
+        )
+    assert ok is True
+    assert "migrated" in note
+
+
+def test_migrate_slug_fails_on_post_error():
+    with patch.object(validate_rebl_slugs.requests, "post", return_value=_ok_response(500, "boom")), \
+         patch.object(validate_rebl_slugs.requests, "delete") as mock_delete:
+        ok, note = validate_rebl_slugs.migrate_slug(
+            "https://dash.example.com",
+            "secret",
+            old_slug="old",
+            new_slug="new",
+            full_record={"slug": "old"},
+        )
+    assert ok is False
+    assert "POST new" in note
+    # If POST fails we never DELETE the old row (defensive: avoid leaving the
+    # dashboard with neither slug present).
+    mock_delete.assert_not_called()
+
+
+def test_migrate_slug_fails_loudly_on_delete_error():
+    with patch.object(validate_rebl_slugs.requests, "post", return_value=_ok_response(200)), \
+         patch.object(validate_rebl_slugs.requests, "delete", return_value=_ok_response(500, "boom")):
+        ok, note = validate_rebl_slugs.migrate_slug(
+            "https://dash.example.com",
+            "secret",
+            old_slug="old",
+            new_slug="new",
+            full_record={"slug": "old"},
+        )
+    assert ok is False
+    assert "DELETE old" in note
+
+
+# ---------- render_report ----------
+
+
+def test_render_report_includes_all_sections():
+    rows = [
+        validate_rebl_slugs.SiteRow(
+            title="Migrate Site",
+            address="addr1",
+            dashboard_slug="old-slug",
+            rebl_slug="new-slug",
+            rebl_matched_by="slug",
+            classification="migrate",
+        ),
+        validate_rebl_slugs.SiteRow(
+            title="Missing Site",
+            address="addr2",
+            classification="missing",
+            note="Rebl matched_by=none and no lat/lng",
+        ),
+        validate_rebl_slugs.SiteRow(
+            title="Net Site",
+            address="addr3",
+            classification="api_error",
+            rebl_error="boom",
+        ),
+        validate_rebl_slugs.SiteRow(
+            title="OK Site",
+            address="addr4",
+            dashboard_slug="canonical",
+            rebl_slug="canonical",
+            classification="ok",
+        ),
+    ]
+    out = validate_rebl_slugs.render_report(rows)
+    assert "ok=1" in out
+    assert "migrate=1" in out
+    assert "missing=1" in out
+    assert "api_error=1" in out
+    assert "Migrate Site" in out
+    assert "Missing Site" in out
+    assert "Net Site" in out


### PR DESCRIPTION
Rebl is the canonical source of truth for site slugs on the DD Dashboard. The dashboard publisher historically derived its own slug from `slugify(site_title)`, producing locally-invented slugs like `alpha-school-tulsa-6940-s-utica-ave` even though Rebl's `/api/resolve` returns `6940-s-utica-ave-tulsa-ok` for the same address. This PR adds a validator + migrator that reconciles both worlds.

## What it does

`scripts/validate_rebl_slugs.py`:
- Loads active Wrike sites (canonical address source; addresses come from Wrike, not sites.json).
- Cross-references with the live dashboard `sites.json`.
- Batch-resolves addresses via `POST https://rebl3.vercel.app/api/resolve`.
- Classifies each row as **ok | migrate | missing | api_error | unknown**.
- 'missing from Rebl' rule (per discussion): `error` key present **OR** `matched_by: none` AND no lat/lng. Note: `matched_by: none` *with* lat/lng is still trustable; `scored: false` with a valid match is also trustable.
- Default `--dry-run`: report only. With `--apply`: `POST` the existing record under the new (Rebl-canonical) slug, then `DELETE` the old one — both calls carry an `X-Reconcile-Reason` header so the dashboard commit log captures the migration cause.
- Posts one consolidated Google Chat alert at the end of every run (dry-run or apply).

## Migration direction

Rebl probe (today) confirmed the *previously-deleted-suspect* slugs are actually canonical. This script does the **inverse** of yesterday's reconciler — it deletes the locally-derived slugs and keeps Rebl's:

| Rebl-canonical (KEEP) | Locally-derived (DELETE) |
|---|---|
| `6940-s-utica-ave-tulsa-ok` | `alpha-school-tulsa-6940-s-utica-ave` |
| `4717-fletcher-ave-fort-worth-tx` | `alpha-school-fort-worth-4717-fletcher-ave` |
| `350-e-s-water-st-chicago-il` | `alpha-school-chicago-350-gems` (3-into-1) |
| `835-oak-creek-dr-lombard-il` | `alpha-school-lombard-835` |
| `995-oak-creek-dr-lombard-il` | `alpha-school-lombard-995` |

## Tests

`tests/test_validate_rebl_slugs.py` — 23 tests passing locally:
- All classification rules (ok / migrate / missing / api_error / unknown)
- Batch chunking + order preservation
- Network-failure → `None` results
- Malformed Rebl response handling
- All `build_rows()` matching paths (slug, stored `meta.rebl.site_id`, address fallback)
- Full migrate POST+DELETE flow with header verification
- Defensive: DELETE 404 treated as success (idempotent re-runs)
- Defensive: POST failure ⇒ no DELETE issued (avoid orphaning row)
- Report renderer

## Workflow

`.github/workflows/validate-rebl-slugs.yml`:
- `workflow_dispatch` with `apply` + `site` filter inputs
- Tuesdays 13:30 UTC cron (always dry-run; runs 30 min after `reconcile-dashboard`)
- Reuses the `dd-pipeline` concurrency group

## Followup (separate PR)

After this lands and the migration completes, refactor `dashboard_publisher.py` so `slug` is sourced from `rebl_site_id` natively when present, instead of always `slugify(site_title)`. This prevents the issue from recurring on every publish.