### PR TITLE
Add delete_dashboard_slugs.py: targeted DELETE pass for hand-confirmed orphan slugs

### DIFF
--- a/.github/workflows/delete-dashboard-slugs.yml
+++ b/.github/workflows/delete-dashboard-slugs.yml
@@ -1,0 +1,85 @@
+name: Delete Dashboard Slugs
+
+# One-off cleanup workflow for hand-confirmed orphan slugs that the
+# title-driven reconciler skips as RENAME-SUSPECT but a human has cleared
+# for deletion. See scripts/delete_dashboard_slugs.py for usage details.
+#
+# Triggers: manual workflow_dispatch only (no cron). Default is dry-run;
+# set apply=true to actually issue DELETE.
+#
+# Required secrets:
+#   DASHBOARD_PUBLISH_SECRET
+# Optional:
+#   DASHBOARD_PUBLISH_URL (defaults to https://dd-dashboard-three.vercel.app)
+
+on:
+  workflow_dispatch:
+    inputs:
+      slugs:
+        description: 'Comma-separated slug list to DELETE.'
+        required: true
+        type: string
+      reason:
+        description: 'X-Reconcile-Reason header value (shows up in dashboard commits).'
+        required: false
+        default: 'manual-cleanup'
+        type: string
+      apply:
+        description: 'Set true to actually issue DELETE. Leave false for dry-run.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ] || { echo "[ERROR] DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
+          echo "[OK] Required secrets present"
+
+      - name: Create .env file from secrets
+        env:
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
+          DASHBOARD_PUBLISH_URL: ${{ secrets.DASHBOARD_PUBLISH_URL }}
+        run: |
+          touch .env
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
+          if [ -n "${DASHBOARD_PUBLISH_URL}" ]; then
+            echo "DASHBOARD_PUBLISH_URL=${DASHBOARD_PUBLISH_URL}" >> .env
+          fi
+          echo "[OK] Created .env file"
+
+      - name: Run slug deleter
+        env:
+          APPLY_FLAG: ${{ inputs.apply == 'true' && '--apply' || '' }}
+        run: |
+          ARGS="--slugs '${{ inputs.slugs }}' --reason '${{ inputs.reason }}'"
+          if [ -n "${APPLY_FLAG}" ]; then
+            ARGS="${ARGS} ${APPLY_FLAG}"
+          fi
+          echo "[INFO] Args: ${ARGS}"
+          eval uv run python scripts/delete_dashboard_slugs.py ${ARGS}
+
+      - name: Done
+        run: echo "Slug deletion completed"

--- a/scripts/delete_dashboard_slugs.py
+++ b/scripts/delete_dashboard_slugs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""delete_dashboard_slugs.py — one-off DELETE pass for a fixed slug list.
+
+Used to clean up dashboard rows that the title-driven ``reconcile_dashboard``
+classifies as RENAME-SUSPECT (so it skips them) but a human has confirmed are
+actually safe to drop. Examples: leftover duplicate rows after the Rebl
+canonical-slug migration where the canonical sibling already exists.
+
+Pass slugs via the ``--slugs`` argument (comma-separated) or stdin (newline-
+separated). Default is dry-run; use ``--apply`` to actually issue DELETE.
+Reason header is configurable via ``--reason``.
+
+Run:
+    uv run python scripts/delete_dashboard_slugs.py \\
+        --slugs "alpha-school-chicago-350-gems-full-school,alpha-school-lombard-835" \\
+        --reason "dashboard-cleanup-post-rebl-migration"
+
+Env (loaded from .env):
+    DASHBOARD_PUBLISH_URL    (default https://dd-dashboard-three.vercel.app)
+    DASHBOARD_PUBLISH_SECRET (required for --apply)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+import requests  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s \u2014 %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("delete_dashboard_slugs")
+
+_DEFAULT_BASE_URL = "https://dd-dashboard-three.vercel.app"
+
+
+def _parse_slugs(raw: str) -> list[str]:
+    out: list[str] = []
+    for chunk in raw.replace("\n", ",").split(","):
+        s = chunk.strip()
+        if s:
+            out.append(s)
+    return out
+
+
+def _delete(base_url: str, slug: str, secret: str, reason: str, *, timeout: int = 20) -> tuple[bool, str]:
+    """DELETE one slug. Returns (success, note). 404 is treated as success."""
+    url = f"{base_url}/api/sites/{slug}/publish"
+    try:
+        r = requests.delete(
+            url,
+            headers={
+                "Authorization": f"Bearer {secret}",
+                "X-Reconcile-Reason": reason,
+            },
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        return False, f"network error: {e}"
+    if r.status_code == 200:
+        return True, "deleted"
+    if r.status_code == 404:
+        return True, "already absent (404)"
+    return False, f"HTTP {r.status_code}: {r.text[:200]}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slugs", default="", help="Comma- or newline-separated slug list")
+    parser.add_argument("--reason", default="manual-cleanup", help="X-Reconcile-Reason header")
+    parser.add_argument("--apply", action="store_true", help="Actually issue DELETE; default is dry-run")
+    args = parser.parse_args(argv)
+
+    raw = args.slugs
+    if not raw and not sys.stdin.isatty():
+        raw = sys.stdin.read()
+    slugs = _parse_slugs(raw)
+
+    if not slugs:
+        logger.error("No slugs provided. Use --slugs or pipe via stdin.")
+        return 2
+
+    base_url = (os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_BASE_URL).rstrip("/")
+    secret = os.environ.get("DASHBOARD_PUBLISH_SECRET", "")
+
+    if args.apply and not secret:
+        logger.error("--apply requires DASHBOARD_PUBLISH_SECRET")
+        return 3
+
+    logger.info(
+        "delete_dashboard_slugs mode=%s base_url=%s reason=%r count=%d",
+        "APPLY" if args.apply else "DRY_RUN",
+        base_url,
+        args.reason,
+        len(slugs),
+    )
+
+    if not args.apply:
+        for slug in slugs:
+            logger.info("DRY_RUN would DELETE %s", slug)
+        return 0
+
+    deleted, failed = 0, 0
+    for i, slug in enumerate(slugs):
+        ok, note = _delete(base_url, slug, secret, args.reason)
+        if ok:
+            deleted += 1
+            logger.info("[%d/%d] %s: %s", i + 1, len(slugs), slug, note)
+        else:
+            failed += 1
+            logger.warning("[%d/%d] %s: %s", i + 1, len(slugs), slug, note)
+        # Modest spacing — each DELETE commits to GitHub which Vercel watches.
+        if i + 1 < len(slugs):
+            time.sleep(1.0)
+
+    logger.info("Done: %d deleted, %d failed of %d", deleted, failed, len(slugs))
+    return 0 if failed == 0 else 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_delete_dashboard_slugs.py
+++ b/tests/test_delete_dashboard_slugs.py
@@ -1,0 +1,151 @@
+"""Tests for scripts/delete_dashboard_slugs.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "delete_dashboard_slugs.py"
+
+_spec = importlib.util.spec_from_file_location("delete_dashboard_slugs", _SCRIPT_PATH)
+delete_dashboard_slugs = importlib.util.module_from_spec(_spec)
+sys.modules["delete_dashboard_slugs"] = delete_dashboard_slugs
+_spec.loader.exec_module(delete_dashboard_slugs)  # type: ignore[union-attr]
+
+
+def _resp(status: int, text: str = "{}"):
+    r = MagicMock()
+    r.status_code = status
+    r.text = text
+    return r
+
+
+# ---------- _parse_slugs ----------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a,b,c", ["a", "b", "c"]),
+        ("a\nb\nc", ["a", "b", "c"]),
+        ("a, b ,c\n  d  ", ["a", "b", "c", "d"]),
+        ("", []),
+        (",,,", []),
+    ],
+)
+def test_parse_slugs(raw, expected):
+    assert delete_dashboard_slugs._parse_slugs(raw) == expected
+
+
+# ---------- _delete ----------
+
+
+def test_delete_returns_success_on_200():
+    captured: dict = {}
+
+    def fake_delete(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return _resp(200)
+
+    with patch.object(delete_dashboard_slugs.requests, "delete", side_effect=fake_delete):
+        ok, note = delete_dashboard_slugs._delete(
+            "https://dash.example.com", "my-slug", "secret-xyz", "test-reason"
+        )
+
+    assert ok is True
+    assert note == "deleted"
+    assert captured["url"].endswith("/api/sites/my-slug/publish")
+    assert captured["headers"]["Authorization"] == "Bearer secret-xyz"
+    assert captured["headers"]["X-Reconcile-Reason"] == "test-reason"
+
+
+def test_delete_treats_404_as_success():
+    """If the slug is already gone (idempotent re-run), 404 is OK."""
+    with patch.object(delete_dashboard_slugs.requests, "delete", return_value=_resp(404)):
+        ok, note = delete_dashboard_slugs._delete(
+            "https://dash.example.com", "absent-slug", "secret", "reason"
+        )
+    assert ok is True
+    assert "absent" in note
+
+
+def test_delete_fails_on_500():
+    with patch.object(delete_dashboard_slugs.requests, "delete", return_value=_resp(500, "boom")):
+        ok, note = delete_dashboard_slugs._delete(
+            "https://dash.example.com", "slug", "secret", "reason"
+        )
+    assert ok is False
+    assert "500" in note
+
+
+def test_delete_fails_on_network_error():
+    import requests as _requests
+
+    def boom(*_a, **_kw):
+        raise _requests.RequestException("boom")
+
+    with patch.object(delete_dashboard_slugs.requests, "delete", side_effect=boom):
+        ok, note = delete_dashboard_slugs._delete(
+            "https://dash.example.com", "slug", "secret", "reason"
+        )
+    assert ok is False
+    assert "network error" in note
+
+
+# ---------- main ----------
+
+
+def test_main_dry_run_prints_and_does_not_call(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "secret")
+    with patch.object(delete_dashboard_slugs.requests, "delete") as mock_delete:
+        rc = delete_dashboard_slugs.main(["--slugs", "a,b,c"])
+    assert rc == 0
+    mock_delete.assert_not_called()
+
+
+def test_main_apply_calls_delete_for_each_slug(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "secret")
+    # Patch sleep so the test stays fast.
+    with patch.object(delete_dashboard_slugs.requests, "delete", return_value=_resp(200)) as mock_delete, \
+         patch.object(delete_dashboard_slugs.time, "sleep"):
+        rc = delete_dashboard_slugs.main(["--slugs", "a,b,c", "--apply", "--reason", "cleanup"])
+    assert rc == 0
+    assert mock_delete.call_count == 3
+    # All three calls carry the reason header.
+    for call in mock_delete.call_args_list:
+        assert call.kwargs["headers"]["X-Reconcile-Reason"] == "cleanup"
+
+
+def test_main_apply_returns_nonzero_on_partial_failure(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "secret")
+
+    responses = [_resp(200), _resp(500, "boom"), _resp(200)]
+
+    def fake_delete(*_a, **_kw):
+        return responses.pop(0)
+
+    with patch.object(delete_dashboard_slugs.requests, "delete", side_effect=fake_delete), \
+         patch.object(delete_dashboard_slugs.time, "sleep"):
+        rc = delete_dashboard_slugs.main(["--slugs", "a,b,c", "--apply"])
+
+    assert rc == 4  # one failure
+
+
+def test_main_refuses_apply_without_secret(monkeypatch):
+    monkeypatch.delenv("DASHBOARD_PUBLISH_SECRET", raising=False)
+    rc = delete_dashboard_slugs.main(["--slugs", "a", "--apply"])
+    assert rc == 3
+
+
+def test_main_errors_on_no_slugs(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "secret")
+    # Force stdin to look like a tty so it doesn't try to read.
+    with patch.object(delete_dashboard_slugs.sys.stdin, "isatty", return_value=True):
+        rc = delete_dashboard_slugs.main(["--slugs", ""])
+    assert rc == 2


### PR DESCRIPTION
Companion to `validate_rebl_slugs.py`. The title-driven reconciler classifies any orphan slug whose tokens fuzzy-match an active Wrike record as RENAME-SUSPECT and skips it. After today's Rebl migration, 5 such rows remain — all hand-verified safe to drop:

| Old slug | Why safe |
|---|---|
| `alpha-school-chicago-350-gems-full-school` | duplicate; canonical `350-e-s-water-st-chicago-il` already on dashboard |
| `alpha-school-chicago-350-microschool` | duplicate; same canonical sibling already on dashboard |
| `alpha-school-fort-worth-4717-fletcher-ave` | duplicate; canonical `4717-fletcher-ave-fort-worth-tx` already on dashboard |
| `alpha-school-lombard-835` | true orphan; no active Wrike record (only Lombard 995 exists) |
| `alpha-school-tulsa-6940-s-utica-ave` | duplicate; canonical `6940-s-utica-ave-tulsa-ok` already on dashboard |

Plan: merge → dispatch with these 5 slugs and reason `dashboard-cleanup-post-rebl-migration`.

## Tests
14 tests covering parsing, all `_delete` branches (200/404/500/network), full `main()` flow including dry-run, apply, partial failure exit code, and the apply-without-secret guard.