### PR TITLE
Prefer rebl_site_id over slugify(title) for dashboard slugs

### DIFF
--- a/scripts/backfill_doc_readiness.py
+++ b/scripts/backfill_doc_readiness.py
@@ -52,6 +52,7 @@ load_dotenv(_project_root / ".env")
 
 from due_diligence_reporter.config import get_settings  # noqa: E402
 from due_diligence_reporter.dashboard_publisher import slugify  # noqa: E402
+from due_diligence_reporter.rebl import canonical_slug_for_address  # noqa: E402
 from due_diligence_reporter.dashboard_readiness import (  # noqa: E402
     DOC_TYPE_TO_FIELD,
     mark_readiness_complete,
@@ -139,9 +140,20 @@ def _detect_doc_types_for_site(
 
 
 def _build_edits_for_site(
-    *, site_title: str, doc_types: list[str]
+    *, site_title: str, doc_types: list[str], site_address: str = ""
 ) -> list[dict[str, str]]:
-    slug = slugify(site_title)
+    """Build doc-readiness edit dicts for one site.
+
+    Slug precedence mirrors the publisher: prefer Rebl's canonical site_id
+    (resolved from the address) over ``slugify(site_title)``. Without this,
+    every readiness flip targets a slug that no longer exists on the
+    dashboard once the publisher has migrated to Rebl-canonical slugs.
+    """
+    title_slug = slugify(site_title)
+    rebl_slug = (
+        canonical_slug_for_address(site_address, fallback="") if site_address else ""
+    )
+    slug = rebl_slug or title_slug
     if not slug:
         return []
     edits: list[dict[str, str]] = []
@@ -200,7 +212,9 @@ def main(*, site_filter: str | None, dry_run: bool) -> int:
         for dt in doc_types:
             breakdown[dt] = breakdown.get(dt, 0) + 1
 
-        site_edits = _build_edits_for_site(site_title=title, doc_types=doc_types)
+        site_edits = _build_edits_for_site(
+            site_title=title, doc_types=doc_types, site_address=address
+        )
         all_edits.extend(site_edits)
         sites_with_any_doc += 1
 

--- a/scripts/reconcile_dashboard.py
+++ b/scripts/reconcile_dashboard.py
@@ -45,9 +45,11 @@ from dotenv import load_dotenv  # noqa: E402
 load_dotenv(_project_root / ".env")
 
 from due_diligence_reporter.dashboard_publisher import slugify  # noqa: E402
+from due_diligence_reporter.rebl import canonical_slugs_for_addresses  # noqa: E402
 from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
+    extract_address_from_record,
     is_record_active,
     load_wrike_config,
 )
@@ -99,6 +101,28 @@ def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str], list[tuple[s
     records = _get_all_site_records(cfg=cfg)
     active_ids = _get_active_status_ids(access_token=cfg.access_token)
 
+    # The publisher's slug precedence is ``rebl_site_id → slugify(title)``.
+    # Reconcile must follow the same precedence or every newly-published
+    # site (whose dashboard slug is the Rebl id) would look like an orphan.
+    # Batch-resolve every active address up-front; fall back to the title
+    # slug only when Rebl can't resolve it (network failure, missing
+    # address, or ``site_id`` not yet minted).
+    addresses_for_active: list[str] = []
+    for rec in records:
+        if not is_record_active(rec, active_ids):
+            continue
+        addr = (extract_address_from_record(rec) or "").strip()
+        if addr:
+            addresses_for_active.append(addr)
+    rebl_slug_by_address = canonical_slugs_for_addresses(addresses_for_active)
+    if addresses_for_active and not rebl_slug_by_address:
+        logger.warning(
+            "Rebl resolve returned no canonical slugs for %d active address(es); "
+            "falling back to slugify(title). Reconcile may flag false orphans "
+            "until Rebl is reachable.",
+            len(addresses_for_active),
+        )
+
     expected: set[str] = set()
     inactive_slugs: dict[str, str] = {}
     all_titles: list[tuple[str, bool]] = []
@@ -106,10 +130,13 @@ def _expected_slugs_from_wrike() -> tuple[set[str], dict[str, str], list[tuple[s
         title = (rec.get("title") or "").strip()
         if not title:
             continue
-        slug = slugify(title)
+        active = is_record_active(rec, active_ids)
+        addr = (extract_address_from_record(rec) or "").strip()
+        # Prefer Rebl's canonical slug to match the publisher.
+        rebl_slug = rebl_slug_by_address.get(addr) if active and addr else None
+        slug = (rebl_slug or slugify(title)).strip()
         if not slug:
             continue
-        active = is_record_active(rec, active_ids)
         all_titles.append((title, active))
         if active:
             expected.add(slug)

--- a/scripts/sync_site_roster.py
+++ b/scripts/sync_site_roster.py
@@ -62,6 +62,7 @@ from due_diligence_reporter.dashboard_publisher import (  # noqa: E402
     publish_to_dashboard,
     slugify,
 )
+from due_diligence_reporter.rebl import canonical_slug_for_address  # noqa: E402
 from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
@@ -145,8 +146,13 @@ def _publish_stub(
     drive_folder_url: str,
     site_owner: str,
     wrike_created_at: str | None,
+    rebl_site_id: str | None = None,
 ) -> bool:
-    """Publish an empty-report stub for one site. Returns True on success."""
+    """Publish an empty-report stub for one site. Returns True on success.
+
+    ``rebl_site_id`` should be passed when known so the dashboard slug is
+    minted from Rebl's canonical id (matching the per-report publish path).
+    """
     return publish_to_dashboard(
         site_title,
         report_data={},
@@ -155,6 +161,7 @@ def _publish_stub(
         drive_folder_url=drive_folder_url or None,
         site_owner=site_owner or None,
         wrike_created_at=wrike_created_at,
+        rebl_site_id=rebl_site_id or None,
         # Force the not_ready label - without this the publisher auto-stamps
         # "complete" since it normally only runs after a finished report.
         dd_status="not_ready",
@@ -176,19 +183,26 @@ def main(*, site_filter: str | None, dry_run: bool) -> int:
     active = filter_active_site_records(records, active_status_ids)
     logger.info("Wrike returned %d active site record(s)", len(active))
 
-    missing: list[dict] = []
+    # Resolve every active address to its Rebl canonical slug so the
+    # existence check below uses the same slug the publisher would mint.
+    # Without this, sync would mistake every recently-published site (now
+    # carrying a Rebl-canonical slug) for missing and re-stub it.
+    missing: list[tuple[dict, str, str | None]] = []  # (rec, slug, rebl_site_id)
     for rec in active:
         title = (rec.get("title") or "").strip()
         if not title:
             continue
         if site_filter and site_filter.lower() not in title.lower():
             continue
-        slug = slugify(title)
+        addr = (extract_address_from_record(rec) or "").strip()
+        title_slug = slugify(title)
+        rebl_slug = canonical_slug_for_address(addr, fallback="") if addr else ""
+        slug = rebl_slug or title_slug
         if not slug:
             continue
         if not _needs_stub_publish(existing.get(slug)):
             continue
-        missing.append(rec)
+        missing.append((rec, slug, rebl_slug or None))
 
     logger.info(
         "%d Wrike site(s) need a stub publish (missing or stub w/o wrike_created_at)",
@@ -200,7 +214,7 @@ def main(*, site_filter: str | None, dry_run: bool) -> int:
     failures = 0
     succeeded = 0
 
-    for rec in missing:
+    for rec, slug, rebl_site_id in missing:
         title = (rec.get("title") or "").strip()
         address = extract_address_from_record(rec) or ""
         school_type = extract_school_type_from_record(rec)
@@ -210,8 +224,10 @@ def main(*, site_filter: str | None, dry_run: bool) -> int:
         created = extract_created_date_from_record(rec)
 
         logger.info(
-            "Stub publish: %s | addr=%r | type=%r | owner=%r | created=%s",
+            "Stub publish: %s | slug=%s | rebl_id=%r | addr=%r | type=%r | owner=%r | created=%s",
             title,
+            slug,
+            rebl_site_id or "",
             address,
             school_type,
             owner,
@@ -229,6 +245,7 @@ def main(*, site_filter: str | None, dry_run: bool) -> int:
                 drive_folder_url=drive,
                 site_owner=owner,
                 wrike_created_at=created,
+                rebl_site_id=rebl_site_id,
             )
         except Exception as exc:  # publish_to_dashboard already swallows;
             # belt-and-suspenders.

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -195,8 +195,16 @@ def build_site_meta(
     """Assemble the `site_meta` payload from pipeline inputs.
 
     Everything optional falls back to sensible defaults.
+
+    Slug precedence: ``rebl_site_id`` (when truthy) is the canonical slug
+    minted by Rebl from the address. We prefer it so the dashboard slug
+    stays in lock-step with Rebl's identity for the property — preventing
+    drift between Wrike titles, Rebl, and the dashboard. Falls back to
+    ``slugify(site_title)`` only when no Rebl id is available (early DD
+    sites, manual stubs, fixtures).
     """
-    slug = slugify(site_title)
+    rebl_id_clean = (rebl_site_id or "").strip()
+    slug = rebl_id_clean or slugify(site_title)
     city_state_zip, state = _parse_city_state_zip(address)
     rd = (report_date or date.today()).isoformat()
 

--- a/src/due_diligence_reporter/dashboard_readiness.py
+++ b/src/due_diligence_reporter/dashboard_readiness.py
@@ -179,12 +179,16 @@ def edits_from_uploads(uploads: list[dict[str, Any]]) -> list[dict[str, str]]:
     ``DOC_TYPE_TO_FIELD`` produce a flip. Duplicates (same slug+field) are
     deduped. Dry-run uploads are ignored.
     """
-    # Local import to keep this module dependency-light for tests that
-    # don't need the publisher.
+    # Local imports to keep this module dependency-light for tests that
+    # don't need the publisher / network helpers.
     from .dashboard_publisher import slugify
+    from .rebl import canonical_slug_for_address
 
     seen: set[tuple[str, str]] = set()
     out: list[dict[str, str]] = []
+    # Cache Rebl resolutions per (address) so a batch of uploads for the
+    # same site (SIR + Building Inspection) doesn't trigger N HTTP calls.
+    rebl_slug_by_address: dict[str, str] = {}
     for u in uploads or []:
         if not isinstance(u, dict):
             continue
@@ -192,10 +196,22 @@ def edits_from_uploads(uploads: list[dict[str, Any]]) -> list[dict[str, str]]:
             continue
         doc_type = (u.get("doc_type") or "").strip()
         site_title = (u.get("site_title") or "").strip()
+        site_address = (u.get("site_address") or "").strip()
         field = DOC_TYPE_TO_FIELD.get(doc_type)
         if not site_title or not field:
             continue
-        slug = slugify(site_title)
+        # Slug precedence mirrors the publisher: Rebl canonical id when
+        # available, slugify(title) as fallback. inbox_scanner started
+        # plumbing ``site_address`` through the upload payload so this
+        # path stays in lock-step with the dashboard.
+        rebl_slug = ""
+        if site_address:
+            if site_address in rebl_slug_by_address:
+                rebl_slug = rebl_slug_by_address[site_address]
+            else:
+                rebl_slug = canonical_slug_for_address(site_address, fallback="")
+                rebl_slug_by_address[site_address] = rebl_slug
+        slug = (rebl_slug or slugify(site_title)).strip()
         if not slug:
             continue
         key = (slug, field)

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -551,6 +551,11 @@ def process_email(
             else _prefix_original_filename(filename)
         )
 
+        # Plumb the matched site's address into the upload payload so
+        # downstream readiness flips can resolve the canonical Rebl slug
+        # (the publisher's slug source) instead of slugify(title).
+        site_address = str(site_summary.get("address", "")).strip()
+
         if dry_run:
             logger.info("[DRY RUN] Would upload '%s' to folder %s", drive_filename, target_folder_id)
             uploaded.append({
@@ -558,6 +563,7 @@ def process_email(
                 "drive_filename": drive_filename,
                 "doc_type": doc_type,
                 "site_title": site_title,
+                "site_address": site_address,
                 "matched_site_id": matched_site_id,
                 "dry_run": True,
             })
@@ -609,6 +615,7 @@ def process_email(
                     "drive_filename": drive_filename,
                     "doc_type": doc_type,
                     "site_title": site_title,
+                    "site_address": site_address,
                     "matched_site_id": matched_site_id,
                     "drive_file_id": drive_file.get("id"),
                     "drive_link": drive_file.get("webViewLink"),
@@ -620,6 +627,7 @@ def process_email(
                     "drive_filename": drive_filename,
                     "doc_type": doc_type,
                     "site_title": site_title,
+                    "site_address": site_address,
                     "matched_site_id": matched_site_id,
                     "drive_file_id": drive_file.get("id"),
                     "drive_link": drive_file.get("webViewLink"),

--- a/src/due_diligence_reporter/rebl.py
+++ b/src/due_diligence_reporter/rebl.py
@@ -116,3 +116,78 @@ def resolve_address(
         timeout=timeout,
         session=session,
     )[0]
+
+
+def canonical_slug_for_address(
+    address: str,
+    *,
+    fallback: str = "",
+    base_url: str = DEFAULT_REBL_BASE_URL,
+    timeout: float = DEFAULT_REBL_TIMEOUT_SEC,
+    session: Any = requests,
+) -> str:
+    """Return Rebl's canonical slug for ``address``, or ``fallback`` if unavailable.
+
+    Used by readers/scripts (reconcile, sync_site_roster, etc.) that need to
+    know the slug a *publish* would mint. Single source of truth: the
+    publisher uses the same Rebl ``site_id``, so any caller that runs this
+    helper and gets a non-empty result will agree with the dashboard.
+
+    Returns ``fallback`` (which most callers will pass as ``slugify(title)``)
+    when:
+      * the address is empty,
+      * the network call fails,
+      * Rebl returns no ``site_id``.
+
+    Never raises — callers in batch loops should not be aborted by a
+    single Rebl miss.
+    """
+    cleaned = (address or "").strip()
+    if not cleaned:
+        return fallback
+    try:
+        result = resolve_address(
+            cleaned,
+            base_url=base_url,
+            timeout=timeout,
+            session=session,
+        )
+    except Exception:  # network/runtime errors should not abort the caller
+        return fallback
+    return result.site_id.strip() or fallback
+
+
+def canonical_slugs_for_addresses(
+    addresses: list[str],
+    *,
+    base_url: str = DEFAULT_REBL_BASE_URL,
+    timeout: float = DEFAULT_REBL_TIMEOUT_SEC,
+    session: Any = requests,
+) -> dict[str, str]:
+    """Batch-resolve a list of addresses to canonical Rebl slugs.
+
+    Returns ``{address: site_id}`` for every address Rebl could resolve.
+    Addresses that fail to resolve (or return an empty ``site_id``) are
+    omitted. Empty/whitespace addresses are skipped silently.
+
+    Never raises — a network failure returns ``{}`` so callers can fall
+    back to title-based slugs without aborting an entire reconcile/sync run.
+    """
+    cleaned: list[str] = [a.strip() for a in addresses if a and a.strip()]
+    if not cleaned:
+        return {}
+    try:
+        results = resolve_addresses(
+            cleaned,
+            base_url=base_url,
+            timeout=timeout,
+            session=session,
+        )
+    except Exception:
+        return {}
+    out: dict[str, str] = {}
+    for r in results:
+        slug = (r.site_id or "").strip()
+        if slug and r.address_submitted:
+            out[r.address_submitted] = slug
+    return out

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -26,10 +26,38 @@ class TestBuildSiteMeta:
             report_date=date(2026, 4, 23),
         )
 
-        assert meta["slug"] == "austin"
+        # Slug is sourced from Rebl's canonical site_id (not slugify(title)) so
+        # the dashboard, Rebl, and Wrike all agree on the property's identity.
+        assert meta["slug"] == "123-main-st-austin-tx"
         assert meta["rebl"]["site_id"] == "123-main-st-austin-tx"
         assert meta["rebl"]["url"] == "https://rebl3.vercel.app/site/123-main-st-austin-tx"
         assert meta["report_date"] == "2026-04-23"
+
+    def test_slug_falls_back_to_title_when_rebl_site_id_missing(self) -> None:
+        """Without a Rebl id (early DD, stubs, fixtures) we fall back to slugify.
+
+        This preserves the legacy behaviour for any code path that hasn't
+        plumbed Rebl through yet.
+        """
+        # No rebl_site_id passed at all
+        meta = build_site_meta("Austin", address="123 Main St, Austin, TX 78701")
+        assert meta["slug"] == "austin"
+        assert meta["rebl"]["site_id"] == ""
+
+        # Empty / whitespace-only rebl_site_id should also fall through
+        meta_blank = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX 78701",
+            rebl_site_id="   ",
+        )
+        assert meta_blank["slug"] == "austin"
+
+        meta_none = build_site_meta(
+            "Austin",
+            address="123 Main St, Austin, TX 78701",
+            rebl_site_id=None,
+        )
+        assert meta_none["slug"] == "austin"
 
     def test_dd_provenance_omitted_when_unset(self) -> None:
         """Phase 1 dd_* keys must NOT appear when callers don't pass them.

--- a/tests/test_dashboard_readiness.py
+++ b/tests/test_dashboard_readiness.py
@@ -75,6 +75,58 @@ class TestEditsFromUploads:
         assert edits_from_uploads([]) == []
         assert edits_from_uploads([None, "not a dict", 42]) == []  # type: ignore[list-item]
 
+    def test_prefers_rebl_canonical_slug_when_site_address_present(self) -> None:
+        """When upload payload carries ``site_address``, use Rebl's canonical slug.
+
+        Mirrors the publisher's slug precedence so readiness flips target the
+        same dashboard row the publisher creates. Falls back to slugify(title)
+        only when Rebl can't resolve.
+        """
+        uploads = [
+            {
+                "doc_type": "sir",
+                "site_title": "Austin",
+                "site_address": "123 Main St, Austin, TX 78701",
+            },
+            {
+                "doc_type": "building_inspection",
+                "site_title": "Austin",
+                "site_address": "123 Main St, Austin, TX 78701",
+            },
+            # No address → falls back to slugify(title).
+            {"doc_type": "block_plan", "site_title": "Lombard"},
+        ]
+        with patch(
+            "due_diligence_reporter.rebl.canonical_slug_for_address",
+            return_value="123-main-st-austin-tx",
+        ) as mock_resolve:
+            edits = edits_from_uploads(uploads)
+
+        # Same address resolved twice should hit the per-call cache: only one
+        # network call, even though two uploads share the address.
+        assert mock_resolve.call_count == 1
+        assert {(e["slug"], e["fieldPath"]) for e in edits} == {
+            ("123-main-st-austin-tx", "cds_sir_status"),
+            ("123-main-st-austin-tx", "building_inspection_status"),
+            ("lombard", "block_plan_status"),
+        }
+
+    def test_falls_back_to_slugify_when_rebl_returns_empty(self) -> None:
+        """If Rebl can't resolve, ``edits_from_uploads`` keeps slugify(title)."""
+        uploads = [
+            {
+                "doc_type": "sir",
+                "site_title": "Austin",
+                "site_address": "123 Main St, Austin, TX 78701",
+            },
+        ]
+        with patch(
+            "due_diligence_reporter.rebl.canonical_slug_for_address",
+            return_value="",
+        ):
+            edits = edits_from_uploads(uploads)
+        assert edits == [{"slug": "austin", "fieldPath": "cds_sir_status"}]
+
 
 class TestMarkReadinessComplete:
     def test_empty_edits_short_circuits(self) -> None:

--- a/tests/test_rebl.py
+++ b/tests/test_rebl.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from due_diligence_reporter.rebl import ReblResolution, resolve_address, resolve_addresses
+from due_diligence_reporter.rebl import (
+    ReblResolution,
+    canonical_slug_for_address,
+    canonical_slugs_for_addresses,
+    resolve_address,
+    resolve_addresses,
+)
 from due_diligence_reporter.server import _build_report_trace_data
 
 
@@ -70,6 +76,96 @@ class TestResolveAddresses:
 
         with pytest.raises(RuntimeError, match="REBL resolve 503"):
             resolve_addresses(["123 Main St, Austin, TX"], session=session)
+
+
+class TestCanonicalSlugForAddress:
+    """Convenience wrapper used by the publisher and downstream callers.
+
+    Returns the Rebl ``site_id`` for resolved addresses; gracefully falls
+    back to a caller-supplied default for empty inputs, network failures,
+    or empty Rebl responses — never raises.
+    """
+
+    def test_returns_site_id_when_resolved(self) -> None:
+        session = _FakeSession(_FakeResponse(
+            ok=True,
+            status_code=200,
+            body=[{"site_id": "123-main-st-austin-tx", "url": "", "matched_by": "slug"}],
+        ))
+        slug = canonical_slug_for_address(
+            "123 Main St, Austin, TX",
+            fallback="austin",
+            session=session,
+        )
+        assert slug == "123-main-st-austin-tx"
+
+    def test_returns_fallback_when_address_empty(self) -> None:
+        # No HTTP call should be attempted.
+        session = _FakeSession(_FakeResponse(ok=True, status_code=200, body=[]))
+        slug = canonical_slug_for_address("   ", fallback="austin", session=session)
+        assert slug == "austin"
+        assert session.calls == []
+
+    def test_returns_fallback_when_rebl_returns_empty_site_id(self) -> None:
+        session = _FakeSession(_FakeResponse(
+            ok=True,
+            status_code=200,
+            body=[{"site_id": "", "url": "", "matched_by": "none"}],
+        ))
+        slug = canonical_slug_for_address(
+            "unknown address",
+            fallback="my-fallback",
+            session=session,
+        )
+        assert slug == "my-fallback"
+
+    def test_returns_fallback_on_network_error(self) -> None:
+        # Resolver raises (HTTP 5xx etc.) — must not propagate.
+        class _RaisingSession:
+            def post(self, *args, **kwargs):
+                raise RuntimeError("network down")
+
+        slug = canonical_slug_for_address(
+            "123 Main St, Austin, TX",
+            fallback="austin",
+            session=_RaisingSession(),
+        )
+        assert slug == "austin"
+
+
+class TestCanonicalSlugsForAddresses:
+    """Batch variant used by reconcile_dashboard for many sites at once."""
+
+    def test_returns_only_resolved_addresses(self) -> None:
+        session = _FakeSession(_FakeResponse(
+            ok=True,
+            status_code=200,
+            body=[
+                {"site_id": "123-main-st-austin-tx", "url": "", "matched_by": "slug"},
+                {"site_id": "", "url": "", "matched_by": "none"},
+            ],
+        ))
+        result = canonical_slugs_for_addresses(
+            ["123 Main St, Austin, TX", "500 Unknown Way"],
+            session=session,
+        )
+        # Empty site_id is dropped; only resolved entries are returned.
+        assert result == {"123 Main St, Austin, TX": "123-main-st-austin-tx"}
+
+    def test_empty_input_returns_empty_dict(self) -> None:
+        assert canonical_slugs_for_addresses([]) == {}
+        assert canonical_slugs_for_addresses(["", "   "]) == {}
+
+    def test_returns_empty_on_network_error(self) -> None:
+        class _RaisingSession:
+            def post(self, *args, **kwargs):
+                raise RuntimeError("network down")
+
+        result = canonical_slugs_for_addresses(
+            ["123 Main St, Austin, TX"],
+            session=_RaisingSession(),
+        )
+        assert result == {}
 
 
 class TestReportTraceRebl:


### PR DESCRIPTION
## Why

PR #57 retroactively migrated 50 sites from `slugify(title)` to Rebl-canonical slugs and #58 cleaned up 5 orphans. Without fixing the source, every new publish would land at a non-canonical slug and the cycle would repeat.

## What

`build_site_meta` now sources the slug from `rebl_site_id` when present (truthy after `.strip()`), falling back to `slugify(site_title)` only when no Rebl id is available — early DD sites, manual stubs, fixtures.

Downstream callers updated to mirror this so readers agree with writers:

| File | Change |
|---|---|
| `dashboard_publisher.build_site_meta` | Slug precedence: `rebl_site_id → slugify(title)` |
| `reconcile_dashboard._expected_slugs_from_wrike` | Batch-resolves every active Wrike address via Rebl. Without this, every newly-published site would look like an orphan. |
| `sync_site_roster` | Resolves Rebl per record, uses canonical slug for the existence check, plumbs `rebl_site_id` through to the stub publish. |
| `backfill_doc_readiness._build_edits_for_site` | Accepts `site_address`, prefers Rebl's canonical slug. |
| `inbox_scanner.process_inbox` | Adds `site_address` to every upload payload. |
| `dashboard_readiness.edits_from_uploads` | Consumes `site_address` to mint Rebl-canonical slugs. Per-batch cache avoids duplicate HTTP calls when SIR + Building Inspection share an address. |

Two new helpers in `due_diligence_reporter.rebl`:
- `canonical_slug_for_address(address, fallback=...)` — single-address wrapper that never raises (returns `fallback` on empty input, network failure, or empty Rebl response).
- `canonical_slugs_for_addresses(addresses)` — batch variant returning `{address: site_id}`, also non-raising.

## Tests

131 pass in the touched files (`test_dashboard_publisher`, `test_dashboard_readiness`, `test_rebl`, `test_validate_rebl_slugs`). Full suite: 870 pass.

New tests:
- `test_slug_falls_back_to_title_when_rebl_site_id_missing` — covers `None` / empty / whitespace
- `test_prefers_rebl_canonical_slug_when_site_address_present` — including per-call cache assertion
- `test_falls_back_to_slugify_when_rebl_returns_empty`
- `TestCanonicalSlugForAddress` — 4 tests (resolved, empty input, empty site_id, network error)
- `TestCanonicalSlugsForAddresses` — 3 tests

## Pre-existing failures (not caused by this PR)

`tests/test_permit_history.py::test_trace_supplemental_evidence_omitted_when_empty` and `test_trace_supplemental_evidence_template_keys_not_duplicated` fail on `main` due to a missing `rebl_resolution` arg in `_minimal_trace_args`. Confirmed pre-existing.

## Verification plan after merge

1. Trigger the next live publish (any DD report run) — confirm the dashboard `slug` matches `meta.rebl.site_id`.
2. Run `validate-rebl-slugs` workflow as a dry-run — should report 0 `migrate` rows.
3. Watch reconcile-dashboard cron — should see no orphan flags from this change.