### PR TITLE
Add recover_migration_wiped_sites.py: rehydrate the 26 sites blanked by rebl-slug migration

### DIFF
--- a/.github/workflows/recover-migration-wiped-sites.yml
+++ b/.github/workflows/recover-migration-wiped-sites.yml
@@ -1,0 +1,146 @@
+name: Recover Migration-Wiped Sites
+
+# One-shot recovery for the 26 sites whose analytical fields were wiped
+# by the rebl-canonical slug migration on 2026-05-01.
+#
+# Background: scripts/validate_rebl_slugs.py --apply round-tripped each
+# site's transformed dashboard record back through the publish endpoint.
+# The dashboard's transform reads only flat reporter tokens, so every
+# analytical field (can_we_open, scenarios, sources.*) was blanked.
+#
+# This workflow republishes from the original Drive trace JSON for any
+# site whose live record matches the wipe signature
+# (dd_status=complete + can_we_open empty). Idempotent.
+#
+# Default is --dry-run. Flip the apply input to true to actually publish.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually publish (true) or dry-run only (false).'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      site:
+        description: 'Filter to dashboard slugs containing this substring (case-insensitive). Leave blank for all wiped sites.'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.WRIKE_ACCESS_TOKEN }}" ]         || { echo "[ERROR] WRIKE_ACCESS_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}" ] || { echo "[ERROR] GOOGLE_DRIVE_ROOT_FOLDER_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_ID }}" ]            || { echo "[ERROR] OAUTH_CLIENT_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_SECRET }}" ]        || { echo "[ERROR] OAUTH_CLIENT_SECRET missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_REFRESH_TOKEN }}" ]        || { echo "[ERROR] OAUTH_REFRESH_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.DASHBOARD_PUBLISH_SECRET }}" ]   || { echo "[ERROR] DASHBOARD_PUBLISH_SECRET missing"; exit 1; }
+          echo "[OK] All required secrets are present"
+
+      - name: Create .env file from secrets
+        env:
+          WRIKE_ACCESS_TOKEN: ${{ secrets.WRIKE_ACCESS_TOKEN }}
+          GOOGLE_DRIVE_ROOT_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_ROOT_FOLDER_ID }}
+          SIR_FOLDER_ID: ${{ secrets.SIR_FOLDER_ID }}
+          ISP_FOLDER_ID: ${{ secrets.ISP_FOLDER_ID }}
+          BUILDING_INSPECTION_FOLDER_ID: ${{ secrets.BUILDING_INSPECTION_FOLDER_ID }}
+          DASHBOARD_PUBLISH_SECRET: ${{ secrets.DASHBOARD_PUBLISH_SECRET }}
+        run: |
+          touch .env
+          echo "WRIKE_ACCESS_TOKEN=${WRIKE_ACCESS_TOKEN}" >> .env
+          echo "GOOGLE_DRIVE_ROOT_FOLDER_ID=${GOOGLE_DRIVE_ROOT_FOLDER_ID}" >> .env
+          echo "SIR_FOLDER_ID=${SIR_FOLDER_ID}" >> .env
+          echo "ISP_FOLDER_ID=${ISP_FOLDER_ID}" >> .env
+          echo "BUILDING_INSPECTION_FOLDER_ID=${BUILDING_INSPECTION_FOLDER_ID}" >> .env
+          echo "DASHBOARD_PUBLISH_SECRET=${DASHBOARD_PUBLISH_SECRET}" >> .env
+          echo "[OK] Created .env file"
+
+      - name: Write Google OAuth client secrets
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          mkdir -p credentials
+          python -c "
+          import json, os
+          data = {
+              'installed': {
+                  'client_id': os.environ['OAUTH_CLIENT_ID'],
+                  'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+                  'redirect_uris': ['http://localhost'],
+                  'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                  'token_uri': 'https://oauth2.googleapis.com/token',
+              }
+          }
+          with open('credentials/client_secrets.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote credentials/client_secrets.json"
+
+      - name: Write Google OAuth refresh token
+        env:
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          python -c "
+          import json, os
+          data = {
+              'token': None,
+              'refresh_token': os.environ['OAUTH_REFRESH_TOKEN'],
+              'token_uri': 'https://oauth2.googleapis.com/token',
+              'client_id': os.environ['OAUTH_CLIENT_ID'],
+              'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+              'scopes': [
+                  'https://www.googleapis.com/auth/drive',
+                  'https://www.googleapis.com/auth/documents',
+                  'https://www.googleapis.com/auth/gmail.modify',
+              ],
+          }
+          with open('.gcp-saved-tokens.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          echo "[OK] Wrote .gcp-saved-tokens.json"
+
+      - name: Run recovery
+        run: |
+          ARGS=()
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            ARGS+=(--apply)
+          else
+            ARGS+=(--dry-run)
+          fi
+          if [ -n "${{ inputs.site }}" ]; then
+            ARGS+=(--site "${{ inputs.site }}")
+          fi
+          uv run python scripts/recover_migration_wiped_sites.py "${ARGS[@]}"
+
+      - name: Done
+        run: echo "Recovery run completed (apply=${{ inputs.apply }})"

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""recover_migration_wiped_sites.py — rehydrate the 26 sites the rebl-canonical
+slug migration self-wiped on 2026-05-01.
+
+Background
+----------
+``scripts/validate_rebl_slugs.py --apply`` (PR #57) renamed dashboard slugs
+to Rebl-canonical form. Its ``migrate_slug`` helper POSTed each site's
+*transformed* dashboard record back to ``/api/sites/<new-slug>/publish``
+under both ``site_meta`` and ``report_data``. The dashboard's transform
+(see ``dd-dashboard/api/_lib/transform.ts``) reads only flat reporter
+tokens (``exec.c_answer``, ``exec.fastest_open_capacity``,
+``sources.sir_link``, …) — it has no fallback to nested dashboard fields.
+Result: every analytical field on the 26 migrated sites was wiped.
+
+Recovery
+--------
+Re-publish each affected site from its Drive trace JSON, exactly the same
+way ``backfill_dashboard.py`` does. Targets only the broken set (live
+sites where ``dd_status=="complete"`` and ``can_we_open`` is blank). Skips
+the 4 stuck-empty stubs and any healthy site.
+
+Run
+---
+    uv run python scripts/recover_migration_wiped_sites.py --dry-run
+    uv run python scripts/recover_migration_wiped_sites.py --apply
+    uv run python scripts/recover_migration_wiped_sites.py --apply --site austin
+
+Env (from .env):
+    DASHBOARD_PUBLISH_URL, DASHBOARD_PUBLISH_SECRET
+    plus the usual pipeline env (Wrike, Google)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+sys.path.insert(0, str(_project_root / "scripts"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+# Reuse backfill_dashboard's trace-discovery + reconstruction so we stay in
+# lockstep with the proven publish path. Importing as a script-relative
+# module keeps the recovery logic surgical (one helper) rather than
+# duplicating the trace-walking machinery.
+from backfill_dashboard import backfill_one  # noqa: E402
+from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
+from due_diligence_reporter.wrike import (  # noqa: E402
+    _get_active_status_ids,
+    _get_all_site_records,
+    extract_address_from_record,
+    extract_google_folder_from_record,
+    extract_p1_from_record,
+    extract_school_type_from_record,
+    filter_active_site_records,
+    load_wrike_config,
+)
+from due_diligence_reporter.rebl import canonical_slug_for_address  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s \u2014 %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("recover_migration_wiped_sites")
+
+_DEFAULT_DASHBOARD_URL = "https://dd-dashboard-three.vercel.app"
+
+
+def _dashboard_base_url() -> str:
+    return (
+        os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_DASHBOARD_URL
+    ).rstrip("/")
+
+
+def _fetch_live_sites() -> list[dict[str, Any]]:
+    """Pull the live ``sites.json`` snapshot from the dashboard."""
+    url = f"{_dashboard_base_url()}/sites.json"
+    r = requests.get(url, timeout=20)
+    r.raise_for_status()
+    payload = r.json()
+    sites = payload.get("sites") or []
+    if not isinstance(sites, list):
+        return []
+    return [s for s in sites if isinstance(s, dict) and s.get("slug")]
+
+
+def _is_migration_wiped(site: dict[str, Any]) -> bool:
+    """Migration-wiped signature: dd_status=complete + can_we_open blank.
+
+    The rebl-slug migration's ``migrate_slug`` round-tripped a transformed
+    record through the dashboard's flat-token transform, blanking every
+    analytical field. ``dd_status`` and ``dd_recommendation`` survived
+    because they live on ``site_meta``. ``can_we_open`` is the cleanest
+    fingerprint of the wipe — it comes from ``report_data["exec.c_answer"]``
+    and is non-empty on every healthy DD report.
+    """
+    if (site.get("dd_status") or "").strip().lower() != "complete":
+        return False
+    return not (site.get("can_we_open") or "").strip()
+
+
+def _match_wrike_to_broken_sites(
+    active_records: list[dict[str, Any]],
+    broken_by_slug: dict[str, dict[str, Any]],
+) -> list[tuple[dict[str, Any], str]]:
+    """Pair every Wrike active record with its broken dashboard slug, if any.
+
+    Match strategy:
+      1. Resolve the Wrike record's address through Rebl. The dashboard
+         slug after migration *is* the Rebl canonical id, so equal Rebl
+         slugs are a hard match.
+      2. Skip records whose Rebl slug isn't in the broken set.
+
+    Returns a list of (wrike_record, dashboard_slug) pairs to recover.
+    """
+    pairs: list[tuple[dict[str, Any], str]] = []
+    for rec in active_records:
+        addr = (extract_address_from_record(rec) or "").strip()
+        if not addr:
+            continue
+        rebl_slug = canonical_slug_for_address(addr, fallback="")
+        if not rebl_slug:
+            continue
+        if rebl_slug in broken_by_slug:
+            pairs.append((rec, rebl_slug))
+    return pairs
+
+
+def _recover_one(
+    gc: GoogleClient,
+    rec: dict[str, Any],
+    dashboard_slug: str,
+    *,
+    dry_run: bool,
+) -> bool:
+    """Recover a single site by republishing from its Drive trace.
+
+    Returns True on success (or on a clean dry-run preview).
+    """
+    title = (rec.get("title") or "").strip()
+    drive_url = extract_google_folder_from_record(rec) or ""
+    address = extract_address_from_record(rec) or ""
+    school_type = extract_school_type_from_record(rec)
+    p1 = extract_p1_from_record(rec) or {}
+    site_owner = p1.get("name")
+
+    if not drive_url:
+        logger.warning(
+            "%s [%s]: no Drive folder on Wrike record; cannot recover",
+            title,
+            dashboard_slug,
+        )
+        return False
+
+    if dry_run:
+        logger.info(
+            "DRY_RUN: would recover %s [slug=%s | drive=%s | addr=%s | type=%s | owner=%s]",
+            title,
+            dashboard_slug,
+            drive_url,
+            address,
+            school_type,
+            site_owner,
+        )
+        return True
+
+    logger.info("Recovering %s [slug=%s] …", title, dashboard_slug)
+    try:
+        return backfill_one(
+            gc,
+            title,
+            drive_url,
+            address,
+            school_type,
+            site_owner=site_owner,
+        )
+    except Exception as e:
+        logger.exception("%s [%s]: backfill_one raised: %s", title, dashboard_slug, e)
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually issue POSTs to recover sites. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Explicit dry-run (default behaviour). Mutually exclusive with --apply.",
+    )
+    parser.add_argument(
+        "--site",
+        help=(
+            "Filter to dashboard slugs containing this substring "
+            "(case-insensitive). Useful for one-off retries."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply and args.dry_run:
+        logger.error("--apply and --dry-run are mutually exclusive")
+        return 2
+
+    apply = bool(args.apply)
+    if not apply:
+        logger.info(
+            "DRY_RUN mode (default). Pass --apply to actually issue POSTs."
+        )
+
+    if apply and not os.environ.get("DASHBOARD_PUBLISH_SECRET"):
+        logger.error("--apply requires DASHBOARD_PUBLISH_SECRET in env")
+        return 2
+
+    # 1. Pull live sites + identify the migration-wiped set.
+    try:
+        sites = _fetch_live_sites()
+    except requests.RequestException as e:
+        logger.error("Failed to fetch live sites.json: %s", e)
+        return 3
+    broken = {s["slug"]: s for s in sites if _is_migration_wiped(s)}
+    logger.info(
+        "Live dashboard has %d sites; %d match the migration-wiped signature.",
+        len(sites),
+        len(broken),
+    )
+    if args.site:
+        needle = args.site.lower()
+        broken = {k: v for k, v in broken.items() if needle in k.lower()}
+        logger.info("Filtered to %d slug(s) matching --site %r", len(broken), args.site)
+    if not broken:
+        logger.info("Nothing to recover.")
+        return 0
+
+    # 2. Match each broken slug to its Wrike record (by Rebl-resolved address).
+    wrike_cfg = load_wrike_config()
+    records = _get_all_site_records(cfg=wrike_cfg)
+    active_status_ids = _get_active_status_ids(access_token=wrike_cfg.access_token)
+    active = filter_active_site_records(records, active_status_ids)
+    pairs = _match_wrike_to_broken_sites(active, broken)
+    matched_slugs = {slug for _, slug in pairs}
+    unmatched = sorted(set(broken.keys()) - matched_slugs)
+    logger.info(
+        "Matched %d/%d broken slug(s) to Wrike records via Rebl resolve.",
+        len(pairs),
+        len(broken),
+    )
+    if unmatched:
+        logger.warning(
+            "Could not match %d broken slug(s) to a Wrike record: %s",
+            len(unmatched),
+            ", ".join(unmatched),
+        )
+
+    # 3. Recover each matched pair.
+    gc = None
+    if apply:
+        settings = get_settings()
+        gc = GoogleClient.from_oauth_config(
+            client_config_path=str(settings.get_client_config_path()),
+            token_file_path=str(settings.get_token_file_path()),
+            oauth_port=settings.oauth_port,
+            scopes=settings.google_scopes,
+        )
+
+    succeeded = 0
+    failed: list[tuple[str, str]] = []
+    for rec, dashboard_slug in pairs:
+        ok = _recover_one(gc, rec, dashboard_slug, dry_run=not apply)
+        if ok:
+            succeeded += 1
+        else:
+            failed.append((rec.get("title", "?"), dashboard_slug))
+
+    logger.info(
+        "Recovery %s: %d/%d succeeded; %d failed; %d unmatched.",
+        "APPLY" if apply else "DRY_RUN",
+        succeeded,
+        len(pairs),
+        len(failed),
+        len(unmatched),
+    )
+    if failed:
+        for title, slug in failed:
+            logger.warning("  FAILED: %s [%s]", title, slug)
+        return 5
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -1,0 +1,143 @@
+"""Tests for the rebl-migration recovery script's pure-logic helpers.
+
+The HTTP / OAuth / Wrike paths are exercised end-to-end by manual workflow
+runs; here we cover only the slug-matching and wipe-detection helpers so
+the regression boundary is well-defined without hitting the network.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
+
+import recover_migration_wiped_sites as recover  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _is_migration_wiped
+
+
+class TestIsMigrationWiped:
+    """Wipe signature: dd_status='complete' AND can_we_open blank.
+
+    These two conditions together uniquely identify the rebl-slug-migration
+    casualties — site_meta survived the round-trip but every report_data-
+    derived field (can_we_open, scenarios, sources.*) blanked out. Healthy
+    complete sites always carry a non-empty c_answer-derived can_we_open.
+    """
+
+    def test_complete_with_blank_can_we_open_is_wiped(self) -> None:
+        site = {"dd_status": "complete", "can_we_open": ""}
+        assert recover._is_migration_wiped(site) is True
+
+    def test_complete_with_whitespace_only_can_we_open_is_wiped(self) -> None:
+        site = {"dd_status": "complete", "can_we_open": "   "}
+        assert recover._is_migration_wiped(site) is True
+
+    def test_complete_with_populated_can_we_open_is_healthy(self) -> None:
+        site = {"dd_status": "complete", "can_we_open": "Yes"}
+        assert recover._is_migration_wiped(site) is False
+
+    def test_not_ready_stub_is_not_wiped(self) -> None:
+        # not_ready stubs from sync_site_roster always have blank
+        # can_we_open — they never got a DD report. They aren't wipe
+        # casualties; recovery should leave them alone.
+        site = {"dd_status": "not_ready", "can_we_open": ""}
+        assert recover._is_migration_wiped(site) is False
+
+    def test_in_progress_is_not_wiped(self) -> None:
+        site = {"dd_status": "in_progress", "can_we_open": ""}
+        assert recover._is_migration_wiped(site) is False
+
+    def test_missing_dd_status_is_not_wiped(self) -> None:
+        # The 4 stuck-empty rows have no dd_status at all. Recovery must
+        # not mistake them for migration casualties.
+        site = {"can_we_open": ""}
+        assert recover._is_migration_wiped(site) is False
+
+    def test_dd_status_case_insensitive(self) -> None:
+        site = {"dd_status": "COMPLETE", "can_we_open": ""}
+        assert recover._is_migration_wiped(site) is True
+
+
+# ---------------------------------------------------------------------------
+# _match_wrike_to_broken_sites
+
+
+class TestMatchWrikeToBrokenSites:
+    """Match Wrike active records to broken dashboard slugs via Rebl.
+
+    The dashboard slug after migration is the Rebl canonical id, so an
+    address resolved through Rebl produces the same slug as the live
+    record. Mismatch on Rebl resolution = no recovery candidate.
+    """
+
+    def _make_record(self, address: str, title: str = "Site") -> dict:
+        # Minimal Wrike-record shape that extract_address_from_record can
+        # parse. Real records carry Wrike's customFields blob; the helper
+        # walks it to find the address. We stub the helper instead.
+        return {"title": title, "_test_address": address}
+
+    def test_matches_records_whose_rebl_slug_is_broken(self) -> None:
+        broken = {
+            "421-e-11th-st-tulsa-ok": {"slug": "421-e-11th-st-tulsa-ok"},
+            "1726-whitley-ave-los-angeles-ca": {"slug": "1726-whitley-ave-los-angeles-ca"},
+        }
+        records = [
+            self._make_record("421 E 11th St, Tulsa, OK"),
+            self._make_record("1726 Whitley Ave, Los Angeles, CA"),
+            self._make_record("999 Healthy Way, Austin, TX"),  # not broken
+        ]
+
+        def fake_extract_address(rec: dict) -> str:
+            return rec["_test_address"]
+
+        def fake_rebl(addr: str, fallback: str = "") -> str:
+            return {
+                "421 E 11th St, Tulsa, OK": "421-e-11th-st-tulsa-ok",
+                "1726 Whitley Ave, Los Angeles, CA": "1726-whitley-ave-los-angeles-ca",
+                "999 Healthy Way, Austin, TX": "999-healthy-way-austin-tx",
+            }.get(addr, fallback)
+
+        with patch.object(recover, "extract_address_from_record", side_effect=fake_extract_address), \
+             patch.object(recover, "canonical_slug_for_address", side_effect=fake_rebl):
+            pairs = recover._match_wrike_to_broken_sites(records, broken)
+
+        assert len(pairs) == 2
+        slugs = {slug for _, slug in pairs}
+        assert slugs == {"421-e-11th-st-tulsa-ok", "1726-whitley-ave-los-angeles-ca"}
+
+    def test_skips_records_with_blank_address(self) -> None:
+        broken = {"any-slug": {"slug": "any-slug"}}
+        records = [self._make_record("")]
+
+        with patch.object(recover, "extract_address_from_record", return_value=""), \
+             patch.object(recover, "canonical_slug_for_address", return_value="any-slug"):
+            pairs = recover._match_wrike_to_broken_sites(records, broken)
+
+        assert pairs == []
+
+    def test_skips_records_rebl_cannot_resolve(self) -> None:
+        # Rebl returns "" (the fallback) when it can't find the address.
+        # Such a record can't be matched to any broken slug.
+        broken = {"any-slug": {"slug": "any-slug"}}
+        records = [self._make_record("Unknown Address")]
+
+        with patch.object(recover, "extract_address_from_record", return_value="Unknown Address"), \
+             patch.object(recover, "canonical_slug_for_address", return_value=""):
+            pairs = recover._match_wrike_to_broken_sites(records, broken)
+
+        assert pairs == []
+
+    def test_returns_empty_when_no_broken_sites(self) -> None:
+        records = [self._make_record("123 Main St, Austin, TX")]
+
+        with patch.object(recover, "extract_address_from_record", return_value="123 Main St, Austin, TX"), \
+             patch.object(recover, "canonical_slug_for_address", return_value="123-main-st-austin-tx"):
+            pairs = recover._match_wrike_to_broken_sites(records, broken_by_slug={})
+
+        assert pairs == []


### PR DESCRIPTION
## Summary

The 2026-05-01 rebl-canonical slug migration (`validate_rebl_slugs.py --apply`) self-wiped every analytical field on 26 dashboard sites. Its `migrate_slug` helper round-tripped each site's *transformed* dashboard record back through `/api/sites/<new>/publish` under both `site_meta` and `report_data`. The dashboard's `transformPipelineToSite` reads only flat reporter tokens (`exec.c_answer`, `exec.fastest_open_capacity`, `sources.sir_link`, …) — none of which exist on a transformed record. The comment in `migrate_slug` claiming the transform "falls back to site_meta on every field" is wrong. Result: `can_we_open` / `scenarios` / `sources.*` / `classification.signals` / `acquisition_conditions` all blank on the 26 sites the migration touched.

This PR adds the recovery, not a fix to the broken migration helper itself — that is part of step (c) (rename endpoint) in the broader plan and lives in a separate PR.

## What this PR does

- **`scripts/recover_migration_wiped_sites.py`** — republishes from each affected site's Drive trace JSON, exactly the same way `backfill_dashboard.py` does. Targets only the wipe signature (`dd_status='complete'` + `can_we_open` blank) so the 4 stuck-empty stubs and any healthy site are left alone. Defaults to `--dry-run`; `--apply` flips the POST. Wrike matching uses Rebl-resolved address (the dashboard slug after migration *is* the Rebl canonical id) so every broken slug pairs with its canonical Wrike record without guessing.
- **`.github/workflows/recover-migration-wiped-sites.yml`** — same OAuth/Wrike bootstrap as `backfill-dashboard.yml`. Single manual `workflow_dispatch` with explicit `apply=true|false` and optional site filter.
- **Tests** — cover the wipe-detection signature (must-be-complete + must-have-blank-`can_we_open` + reject `not_ready`/`in_progress`/missing-status) and the Rebl-based Wrike matcher (skips blank addresses, skips records Rebl can't resolve, returns empty for empty broken set). End-to-end Drive + HTTP paths are exercised by the manual workflow run, not the unit tests.

## Affected sites (26)

`421-e-11th-st-tulsa-ok`, `1726-whitley-ave-los-angeles-ca`, `4152-cole-ave-dallas-tx`, `156-william-st-new-york-ny`, `121-west-6th-st-austin-tx`, `2409-s-macdill-ave-tampa-fl`, `10350-riverside-dr-palm-beach-gardens-fl`, `7514-wisconsin-ave-bethesda-md`, `345-peachtree-hills-ave-ne-atlanta-ga`, `205-park-rd-burlingame-ca`, `350-e-s-water-st-chicago-il`, `300-71st-miami-beach-fl`, `3770-ut-224-park-city-ut`, `22600-crenshaw-blvd-torrance-ca`, `17070-collins-ave-sunny-isles-beach-fl`, `212-elm-st-somerville-ma`, `400-s-coltrane-rd-edmond-ok`, `775-columbus-ave-new-york-ny`, `995-oak-creek-dr-lombard-il`, `307-southgate-ct-brentwood-tn`, `838-sw-1st-ave-portland-or`, `3100-monticello-ave-dallas-tx`, `5601-stone-rd-centreville-va`, `4333-4335-w-147th-st-lawndale-ca`, `460-e-new-england-ave-winter-park-fl`, `7550-park-meadows-dr-lone-tree-co`.

## Suggested rollout

1. Merge this PR.
2. Run the workflow with `apply=false` (dry-run). Inspect logs to confirm 26 matches and no surprise unmatched slugs.
3. Re-run with `apply=true`. The dashboard will receive 26 POSTs, each producing one `Update <slug> from DD pipeline (report …)` commit on `client/public/sites.json`.
4. Verify on the live dashboard that `can_we_open`, scenarios, and sources are populated for each.

## Test plan

- `uv run python -m pytest tests/test_recover_migration_wiped_sites.py` — 11 passed.
- Full suite (`--ignore=tests/test_permit_history.py` for the pre-existing 2 failures): 860 passed, no regressions.
- The HTTP / OAuth / Drive paths are reused verbatim from `backfill_dashboard.py`; no changes there.

## Follow-ups (separate PRs)

- **(b) Dashboard PR**: persist `meta.rebl` so the `rebl: null` field on 52/52 sites populates.
- **(c) Dashboard PR**: add a dedicated rename endpoint and rewrite `migrate_slug` to use it, so future Rebl migrations stop wiping data.