### PR TITLE
fix(recovery): thread canonical slug through to publisher

### DIFF
--- a/scripts/backfill_dashboard.py
+++ b/scripts/backfill_dashboard.py
@@ -155,7 +155,17 @@ def backfill_one(
     address: str | None,
     school_type: str | None,
     site_owner: str | None = None,
+    force_slug: str | None = None,
 ) -> bool:
+    """Backfill one site from its Drive trace.
+
+    Args:
+        force_slug: Optional canonical dashboard slug to publish under. When
+            provided, suppresses the `publish_to_dashboard` slug-derivation
+            chain (rebl_site_id token -> slugify(title)) that has historically
+            minted phantom legacy-slug records when callers already knew the
+            correct slug. Used by the migration recovery flow.
+    """
     folder_id = extract_folder_id_from_url(drive_folder_url)
     if not folder_id:
         logger.warning("%s: could not extract folder id from %s", site_title, drive_folder_url)
@@ -222,6 +232,7 @@ def backfill_one(
         dd_report_url=doc_url,
         report_date=rd,
         site_owner=site_owner,
+        force_slug=force_slug,
     )
 
 

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -179,6 +179,10 @@ def _recover_one(
 
     logger.info("Recovering %s [slug=%s] …", title, dashboard_slug)
     try:
+        # Pass dashboard_slug as force_slug so the publisher does NOT re-derive
+        # a fresh slug from the trace's rebl_site_id token (empty on legacy
+        # traces) or slugify(title). Without this, recovery has historically
+        # minted phantom legacy-slug records on the dashboard.
         return backfill_one(
             gc,
             title,
@@ -186,6 +190,7 @@ def _recover_one(
             address,
             school_type,
             site_owner=site_owner,
+            force_slug=dashboard_slug,
         )
     except Exception as e:
         logger.exception("%s [%s]: backfill_one raised: %s", title, dashboard_slug, e)

--- a/src/due_diligence_reporter/dashboard_publisher.py
+++ b/src/due_diligence_reporter/dashboard_publisher.py
@@ -345,6 +345,12 @@ def publish_to_dashboard(
     dd_site_score_band: str | None = None,
     # Phase 4 DD analytical pass-through. See build_site_meta() for semantics.
     dd_risk_flags: list[dict[str, Any]] | None = None,
+    # Override the slug derived from rebl_site_id / slugify(title). Used by
+    # recovery flows that already know the canonical dashboard slug and must
+    # not let the publisher mint a fresh one (which has historically created
+    # phantom legacy-slug records on the dashboard). When provided, the URL
+    # slug AND the meta.slug field both use this value.
+    force_slug: str | None = None,
     base_url: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
 ) -> bool:
@@ -486,7 +492,15 @@ def publish_to_dashboard(
         dd_site_score_band=dd_site_score_band,
         dd_risk_flags=effective_dd_risk_flags,
     )
-    slug = meta["slug"]
+    # Slug override path: callers in recovery / migration flows know the
+    # canonical dashboard slug and must not let `build_site_meta` re-derive
+    # one from the report's rebl_site_id token (which is empty on legacy
+    # traces). The dashboard's publish handler forces meta.slug from the URL
+    # slug regardless, so updating both keeps the in-memory meta consistent
+    # with what gets persisted.
+    slug = (force_slug or "").strip() or meta["slug"]
+    if force_slug and slug != meta["slug"]:
+        meta["slug"] = slug
 
     endpoint = f"{url_base}/api/sites/{slug}/publish"
     payload = {"site_meta": meta, "report_data": report_data}

--- a/tests/test_backfill_dashboard.py
+++ b/tests/test_backfill_dashboard.py
@@ -166,3 +166,86 @@ def test_backfill_one_skips_unparseable_trace_and_uses_next(monkeypatch):
     )
 
     assert ok is True
+
+def test_backfill_one_threads_force_slug_to_publish(monkeypatch):
+    """backfill_one(force_slug=...) must forward the kwarg to publish_to_dashboard.
+
+    This is the recovery-path safety: callers that already know the canonical
+    dashboard slug (the migration-recovery script) pass it as force_slug so
+    the publisher does not re-derive one from the trace's rebl_site_id token
+    or slugify(title). Without this threading, recovery silently mints
+    phantom legacy-slug records.
+    """
+    gc = MagicMock()
+    gc.list_files_in_folder.return_value = [
+        _trace_file("ok", "Site Report Trace - 04-30-2026.json", "2026-04-30T10:00:00Z"),
+    ]
+    gc.download_file_bytes.return_value = _trace_payload(
+        {"address.full": {"value": "421 E 11th St, Tulsa, OK"}}
+    )
+
+    publish_calls: list[dict] = []
+
+    def fake_publish(site_title, report_data, **kwargs):
+        publish_calls.append({"site_title": site_title, "kwargs": kwargs})
+        return True
+
+    monkeypatch.setattr(backfill_dashboard, "publish_to_dashboard", fake_publish)
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "extract_folder_id_from_url",
+        lambda url: "folder123",
+    )
+
+    canonical = "421-e-11th-st-tulsa-ok"
+    ok = backfill_dashboard.backfill_one(
+        gc,
+        "Alpha School Tulsa 421",
+        "https://drive.google.com/drive/folders/folder123",
+        address="421 E 11th St, Tulsa, OK",
+        school_type="K-8",
+        site_owner="Greg",
+        force_slug=canonical,
+    )
+
+    assert ok is True
+    assert len(publish_calls) == 1
+    assert publish_calls[0]["kwargs"].get("force_slug") == canonical
+
+
+def test_backfill_one_omits_force_slug_when_caller_omits_it(monkeypatch):
+    """When force_slug is not passed, the kwarg defaults to None.
+
+    Pre-existing callers (the daily backfill loop) must keep working
+    unchanged: they don't know the canonical slug and rely on the
+    rebl_site_id token / slugify(title) chain inside publish_to_dashboard.
+    """
+    gc = MagicMock()
+    gc.list_files_in_folder.return_value = [
+        _trace_file("ok", "Site Report Trace - 04-30-2026.json", "2026-04-30T10:00:00Z"),
+    ]
+    gc.download_file_bytes.return_value = _trace_payload(
+        {"address.full": {"value": "X"}}
+    )
+
+    publish_calls: list[dict] = []
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "publish_to_dashboard",
+        lambda *a, **kw: publish_calls.append({"args": a, "kwargs": kw}) or True,
+    )
+    monkeypatch.setattr(
+        backfill_dashboard,
+        "extract_folder_id_from_url",
+        lambda url: "folder123",
+    )
+
+    backfill_dashboard.backfill_one(
+        gc,
+        "Site",
+        "https://drive.google.com/drive/folders/folder123",
+        address=None,
+        school_type=None,
+    )
+
+    assert publish_calls[0]["kwargs"].get("force_slug") is None

--- a/tests/test_dashboard_publisher.py
+++ b/tests/test_dashboard_publisher.py
@@ -811,3 +811,88 @@ class TestDashboardPublishOwnerCutover:
             )
         assert returned is False
         post_mock.assert_not_called()
+
+
+class TestPublishToDashboardForceSlug:
+    """force_slug overrides BOTH the URL slug and meta.slug.
+
+    Recovery / migration callers know the canonical dashboard slug from the
+    live ``sites.json`` and must not let the publisher re-derive a fresh slug
+    from the trace (rebl_site_id token -> slugify(title)). Without this
+    override, recovery has historically minted phantom legacy-slug records
+    on the dashboard when traces predate the rebl_site_id token.
+    """
+
+    @staticmethod
+    def _run(force_slug: str | None, report_data: dict | None = None) -> tuple[str, dict]:
+        """Run publish_to_dashboard and return (post_url, posted_site_meta)."""
+        post_mock = MagicMock()
+        post_mock.return_value.status_code = 200
+        env = {
+            "DASHBOARD_PUBLISH_SECRET": "test-secret",
+            "DASHBOARD_PUBLISH_ENABLED": "1",
+            "DASHBOARD_PUBLISH_URL": "https://dd.example.com",
+            "DASHBOARD_PUBLISH_OWNER": "reporter",
+        }
+        with patch.dict("os.environ", env, clear=True), patch(
+            "due_diligence_reporter.dashboard_publisher.requests.post",
+            new=post_mock,
+        ):
+            kwargs = {}
+            if force_slug is not None:
+                kwargs["force_slug"] = force_slug
+            ok = publish_to_dashboard(
+                "Alpha School Tulsa 421",
+                report_data or {"exec.c_answer": "Yes"},
+                address="421 E 11th St, Tulsa, OK 74120",
+                **kwargs,
+            )
+        assert ok is True
+        post_mock.assert_called_once()
+        call = post_mock.call_args
+        url = call.args[0] if call.args else call.kwargs["url"]
+        body = call.kwargs.get("json") or {}
+        return url, body.get("site_meta") or {}
+
+    def test_force_slug_overrides_url_and_meta(self) -> None:
+        """Both the POST URL and meta.slug use force_slug, not the derived slug."""
+        canonical = "421-e-11th-st-tulsa-ok"
+        url, meta = self._run(force_slug=canonical)
+        assert url == f"https://dd.example.com/api/sites/{canonical}/publish"
+        assert meta["slug"] == canonical
+
+    def test_force_slug_blank_falls_back_to_derived(self) -> None:
+        """An empty/whitespace force_slug must NOT override -- normal derivation runs."""
+        url, meta = self._run(force_slug="   ")
+        # Title slugified (no rebl_site_id token in the report_data).
+        assert "alpha-school-tulsa-421" in url
+        assert meta["slug"] == "alpha-school-tulsa-421"
+
+    def test_no_force_slug_uses_rebl_token_when_present(self) -> None:
+        """Default behavior unchanged: meta.rebl.site_id from token wins."""
+        url, meta = self._run(
+            force_slug=None,
+            report_data={
+                "exec.c_answer": "Yes",
+                "meta.rebl_site_id": "rebl-canonical-from-token",
+            },
+        )
+        assert url.endswith("/api/sites/rebl-canonical-from-token/publish")
+        assert meta["slug"] == "rebl-canonical-from-token"
+
+    def test_force_slug_overrides_rebl_token(self) -> None:
+        """Even when the trace has a rebl_site_id token, force_slug wins.
+
+        This is the core safety: a recovery caller shouldn't have to scrub the
+        report_data to suppress an inherited rebl_site_id.
+        """
+        canonical = "operator-known-slug"
+        url, meta = self._run(
+            force_slug=canonical,
+            report_data={
+                "exec.c_answer": "Yes",
+                "meta.rebl_site_id": "stale-rebl-token",
+            },
+        )
+        assert url.endswith(f"/api/sites/{canonical}/publish")
+        assert meta["slug"] == canonical

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -141,3 +141,78 @@ class TestMatchWrikeToBrokenSites:
             pairs = recover._match_wrike_to_broken_sites(records, broken_by_slug={})
 
         assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# _recover_one threads dashboard_slug -> backfill_one(force_slug=...)
+
+
+class TestRecoverOneThreadsForceSlug:
+    """The recovery path's whole reason for existing is to pin the slug.
+
+    ``_recover_one`` already knows ``dashboard_slug`` -- the canonical Rebl
+    slug pulled from the live ``sites.json`` -- and must forward it as
+    ``force_slug`` to ``backfill_one`` so the publisher does not re-derive
+    one from the legacy trace. Without this thread, recovery silently
+    publishes under the reporter's slugify(title) fallback and creates
+    phantom records (the bug fixed by cleanup_phantom_recovery_slugs.py).
+    """
+
+    def _make_record(self) -> dict:
+        return {
+            "title": "Alpha School Tulsa 421",
+            "_test_address": "421 E 11th St, Tulsa, OK",
+            "_test_drive": "https://drive.google.com/drive/folders/abc",
+            "_test_school_type": "K-8",
+            "_test_p1": {"name": "Greg"},
+        }
+
+    def test_recover_one_passes_dashboard_slug_as_force_slug(self) -> None:
+        rec = self._make_record()
+        canonical = "421-e-11th-st-tulsa-ok"
+        captured: dict = {}
+
+        def fake_backfill_one(gc, title, drive, addr, school_type, **kwargs):
+            captured["title"] = title
+            captured["kwargs"] = kwargs
+            return True
+
+        with patch.object(recover, "backfill_one", side_effect=fake_backfill_one), \
+             patch.object(recover, "extract_address_from_record", return_value=rec["_test_address"]), \
+             patch.object(recover, "extract_google_folder_from_record", return_value=rec["_test_drive"]), \
+             patch.object(recover, "extract_school_type_from_record", return_value=rec["_test_school_type"]), \
+             patch.object(recover, "extract_p1_from_record", return_value=rec["_test_p1"]):
+            ok = recover._recover_one(
+                gc=None,  # backfill_one is fully mocked, so gc is unused
+                rec=rec,
+                dashboard_slug=canonical,
+                dry_run=False,
+            )
+
+        assert ok is True
+        assert captured["kwargs"].get("force_slug") == canonical
+        assert captured["kwargs"].get("site_owner") == "Greg"
+
+    def test_recover_one_dry_run_does_not_call_backfill(self) -> None:
+        """dry_run=True must short-circuit before reaching backfill_one.
+
+        Sanity check on the existing dry-run gate -- ensures the new
+        force_slug threading sits below the dry-run early return so that
+        preview output stays cheap.
+        """
+        rec = self._make_record()
+
+        with patch.object(recover, "backfill_one") as mock_backfill, \
+             patch.object(recover, "extract_address_from_record", return_value=rec["_test_address"]), \
+             patch.object(recover, "extract_google_folder_from_record", return_value=rec["_test_drive"]), \
+             patch.object(recover, "extract_school_type_from_record", return_value="K-8"), \
+             patch.object(recover, "extract_p1_from_record", return_value={"name": "Greg"}):
+            ok = recover._recover_one(
+                gc=None,
+                rec=rec,
+                dashboard_slug="any-slug",
+                dry_run=True,
+            )
+
+        assert ok is True
+        mock_backfill.assert_not_called()


### PR DESCRIPTION
## Why

The migration-recovery script (`recover_migration_wiped_sites.py`) already knew the canonical dashboard slug from the live `sites.json` but only used it for **logging**. `backfill_one` re-derived a slug via `publish_to_dashboard`, which falls back to `slugify(title)` when `meta.rebl_site_id` is empty (true for legacy traces).

Net effect from workflow run **25226179557**:
- 14 sites correctly hydrated (had rebl_site_id token in trace)
- 11 sites published as **new records under legacy `alpha-school-*` slugs** (the phantoms cleaned up in PR #62)
- 1 site (Miami Beach 300) collided with a typo'd existing slug (cleaned up in PR #64)

This patch closes the recurrence path so the next recovery run can't re-create phantoms.

## What

- `publish_to_dashboard` gains a `force_slug` kwarg that overrides **both** the POST URL slug and `meta.slug`. Blank/whitespace `force_slug` falls through to the existing `rebl_site_id` / `slugify` chain, preserving the daily-loop's behavior.
- `backfill_one` threads `force_slug` straight through to the publisher (kwarg only — pre-existing positional callers untouched).
- `_recover_one` in the recovery script passes `dashboard_slug` as `force_slug`, so the slug it already trusted for matching is the slug the dashboard receives.

## Tests (+8)

- `TestPublishToDashboardForceSlug` — override beats URL + `meta.slug`, beats `rebl_site_id` token, blank `force_slug` falls back to derived, default behavior unchanged when omitted.
- `backfill_one` — `force_slug` forwarded; absent `force_slug` → `None`.
- `_recover_one` — `dashboard_slug` forwarded as `force_slug`; dry-run short-circuits before `backfill_one`.

Full suite: **892 passed**, 3 pre-existing unrelated failures in `tests/test_permit_history.py` (missing `rebl_resolution` arg, predates this branch).

## Out of scope

- Park City 3770 still has empty `can_we_open` — its trace contains no `token_report` data (early/incomplete DD report). Not a slug bug; needs a fresh report run.