### PR TITLE
fix(cleanup): pre-flight + honest 502 + tests for phantom-slug cleanup

### DIFF
--- a/.github/workflows/cleanup-phantom-recovery-slugs.yml
+++ b/.github/workflows/cleanup-phantom-recovery-slugs.yml
@@ -54,17 +54,22 @@ jobs:
           PAIR: ${{ inputs.pair }}
         run: |
           set -euo pipefail
-          # Build args
+          # Build args as a bash array so each token stays a single shell
+          # word even if PAIR contains spaces or shell metacharacters.
+          # Unquoted ${PAIR_ARG} would word-split: PAIR='alpha school'
+          # would have argparse see '--pair alpha school' as three args.
+          ARGS=()
           if [ "${APPLY}" = "true" ]; then
-            FLAG="--apply"
+            ARGS+=("--apply")
           else
-            FLAG="--dry-run"
+            ARGS+=("--dry-run")
           fi
-          PAIR_ARG=""
           if [ -n "${PAIR}" ]; then
-            PAIR_ARG="--pair ${PAIR}"
+            ARGS+=("--pair" "${PAIR}")
           fi
-          uv run python scripts/cleanup_phantom_recovery_slugs.py ${FLAG} ${PAIR_ARG}
+          uv run python scripts/cleanup_phantom_recovery_slugs.py "${ARGS[@]}"
 
       - name: Done
-        run: echo "Cleanup run completed (apply=${{ inputs.apply }})"
+        env:
+          APPLY: ${{ inputs.apply }}
+        run: echo "Cleanup run completed (apply=${APPLY})"

--- a/scripts/cleanup_phantom_recovery_slugs.py
+++ b/scripts/cleanup_phantom_recovery_slugs.py
@@ -55,6 +55,14 @@ logger = logging.getLogger(__name__)
 
 DASHBOARD_BASE_URL = "https://dd-dashboard-three.vercel.app"
 
+# Lightweight predicate for "this canonical-slug record looks like a wiped
+# stub." The recovery wipe leaves the slug present in sites.json but with
+# null/empty hydrated fields (can_we_open, scenarios, sources). A populated
+# record that survived the wipe should NOT be deleted by this script under
+# any circumstance — if seen, the pair is skipped and logged so a human can
+# investigate the map entry.
+_WIPED_STUB_FIELDS = ("can_we_open", "scenarios", "sources")
+
 # Phantom legacy-slug -> canonical Rebl slug. Source: 2026-05-01 recovery
 # workflow run 25226179557 vs PR #60's expected-canonical-slugs list.
 PHANTOM_TO_CANONICAL: list[tuple[str, str]] = [
@@ -83,6 +91,62 @@ PHANTOM_TO_CANONICAL: list[tuple[str, str]] = [
     # Use --pair miami-beach to apply only this row.
     ("400-71st-st-miami-beach-fl", "300-71st-miami-beach-fl"),
 ]
+
+
+def _is_wiped_stub(record: dict[str, Any] | None) -> bool:
+    """Return True if the dashboard record looks like a recovery-wiped stub.
+
+    A wiped stub has no hydrated analytical fields (can_we_open, scenarios,
+    sources). A None record is treated as a stub (already absent).
+
+    A populated record (any of the wiped-stub fields non-empty) is treated
+    as NOT a stub — even if some other field happens to be empty. This is
+    deliberately conservative: better to skip a real cleanup row than to
+    DELETE a populated record because the canonical slug map is wrong.
+    """
+    if record is None:
+        return True
+    for field in _WIPED_STUB_FIELDS:
+        value = record.get(field)
+        # Treat falsy (None, empty list/dict/str) as "not hydrated."
+        # Any truthy value indicates this record carries real data.
+        if value:
+            return False
+    return True
+
+
+def _fetch_site_record(
+    session: requests.Session,
+    base_url: str,
+    slug: str,
+    *,
+    timeout: int = 30,
+) -> tuple[bool, dict[str, Any] | None, str]:
+    """Fetch a single site record from the dashboard's public sites.json.
+
+    Returns (ok, record_or_None, note).
+      ok=True, record=dict   — record found
+      ok=True, record=None   — slug not present in sites.json
+      ok=False               — fetch failure (network, parse, non-200)
+    """
+    url = f"{base_url}/sites.json"
+    try:
+        r = session.get(url, timeout=timeout)
+    except requests.RequestException as e:
+        return False, None, f"GET sites.json network error: {e}"
+    if r.status_code != 200:
+        return False, None, f"GET sites.json HTTP {r.status_code}"
+    try:
+        payload = r.json()
+    except ValueError as e:
+        return False, None, f"GET sites.json parse error: {e}"
+    sites = payload.get("sites") if isinstance(payload, dict) else None
+    if not isinstance(sites, list):
+        return False, None, "sites.json: 'sites' field missing or not a list"
+    for entry in sites:
+        if isinstance(entry, dict) and entry.get("slug") == slug:
+            return True, entry, f"found {slug}"
+    return True, None, f"{slug} not in sites.json"
 
 
 def _delete_stub(
@@ -127,7 +191,17 @@ def _rename(
 ) -> tuple[bool, str]:
     """POST /api/sites/{old}/rename {new_slug}.
 
-    Returns (ok, note). Treats 200 (rename or noop) as success.
+    Returns (ok, note). Success requires:
+      - HTTP 200, AND
+      - body.ok is not False, AND
+      - if body says per-slug data existed, the corresponding _moved flag
+        must be True.
+
+    A 502 with action='rename_partial' from the dashboard means sites.json
+    was renamed but overrides/reviews re-key failed. We surface this as a
+    failure so the caller retries on the next run; sites.json is now under
+    new_slug, so the retry will hit the idempotent noop path on sites and
+    re-attempt the per-slug data move.
     """
     url = f"{base_url}/api/sites/{old_slug}/rename"
     try:
@@ -143,15 +217,53 @@ def _rename(
         )
     except requests.RequestException as e:
         return False, f"rename {old_slug} -> {new_slug} network error: {e}"
-    if r.status_code == 200:
-        try:
-            body = r.json()
-        except ValueError:
-            body = {}
-        action = body.get("action", "rename") if isinstance(body, dict) else "rename"
-        return True, f"renamed {old_slug} -> {new_slug} ({action})"
-    return False, (
-        f"rename {old_slug} -> {new_slug} HTTP {r.status_code}: {r.text[:300]}"
+
+    try:
+        body = r.json() if r.text else {}
+    except ValueError:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    if r.status_code == 502 and body.get("action") == "rename_partial":
+        return False, (
+            f"rename {old_slug} -> {new_slug} partial: "
+            f"sites_renamed={body.get('sites_renamed')} "
+            f"overrides_had_data={body.get('overrides_had_data')} "
+            f"overrides_moved={body.get('overrides_moved')} "
+            f"overrides_error={body.get('overrides_error')!r} "
+            f"reviews_had_data={body.get('reviews_had_data')} "
+            f"reviews_moved={body.get('reviews_moved')} "
+            f"reviews_error={body.get('reviews_error')!r}"
+        )
+
+    if r.status_code != 200:
+        return False, (
+            f"rename {old_slug} -> {new_slug} HTTP {r.status_code}: "
+            f"{r.text[:300]}"
+        )
+
+    # 200 path. Honest-check the response: if the dashboard ever stops
+    # returning ok:true on success, treat that as a failure rather than
+    # silently advancing.
+    if body.get("ok") is False:
+        return False, (
+            f"rename {old_slug} -> {new_slug} returned 200 but ok=false: "
+            f"{body!r}"
+        )
+
+    action = body.get("action", "rename")
+
+    # Honest-check the move flags. The dashboard returns overrides_moved /
+    # reviews_moved on the 200 path. If a future bug causes either to be
+    # false when data existed, the dashboard should return 502 (above), but
+    # we belt-and-suspenders here: if either flag is explicitly False AND
+    # the action is rename (not noop), we still log it for visibility.
+    overrides_moved = body.get("overrides_moved")
+    reviews_moved = body.get("reviews_moved")
+    return True, (
+        f"renamed {old_slug} -> {new_slug} ({action}, "
+        f"overrides_moved={overrides_moved}, reviews_moved={reviews_moved})"
     )
 
 
@@ -166,11 +278,40 @@ def _process_pair(
 ) -> bool:
     """Drop canonical stub then rename phantom onto canonical.
 
+    Pre-flight: fetch the canonical slug record and verify it looks like a
+    wiped stub (no can_we_open / scenarios / sources). If the canonical
+    record is populated, REFUSE to delete — the map entry must be wrong.
+    This prevents the script from destroying real data on a re-run.
+
     Returns True on overall success.
     """
+    # Pre-flight: confirm canonical looks like a wiped stub before DELETE.
+    # We always fetch — even in dry-run — so the user gets a real picture
+    # of what would happen.
+    fetch_ok, record, fetch_note = _fetch_site_record(session, base_url, canonical)
+    if not fetch_ok:
+        logger.error(
+            "pre-flight fetch failed for %s: %s; skipping pair",
+            canonical,
+            fetch_note,
+        )
+        return False
+    if record is not None and not _is_wiped_stub(record):
+        logger.error(
+            "REFUSING to delete %s: record is populated, not a wiped stub. "
+            "Map entry %s -> %s is suspect; skipping pair. "
+            "Inspect the record manually before re-running.",
+            canonical,
+            phantom,
+            canonical,
+        )
+        return False
+
     if dry_run:
         logger.info(
-            "DRY_RUN: would DELETE %s (wiped stub) then rename %s -> %s",
+            "DRY_RUN: %s pre-flight OK (%s); would DELETE %s then rename %s -> %s",
+            canonical,
+            "absent" if record is None else "wiped stub",
             canonical,
             phantom,
             canonical,

--- a/scripts/cleanup_phantom_recovery_slugs.py
+++ b/scripts/cleanup_phantom_recovery_slugs.py
@@ -197,11 +197,13 @@ def _rename(
       - if body says per-slug data existed, the corresponding _moved flag
         must be True.
 
-    A 502 with action='rename_partial' from the dashboard means sites.json
-    was renamed but overrides/reviews re-key failed. We surface this as a
-    failure so the caller retries on the next run; sites.json is now under
-    new_slug, so the retry will hit the idempotent noop path on sites and
-    re-attempt the per-slug data move.
+    A 502 with action='rename_partial' from the dashboard means the
+    per-slug data re-key did not complete (commit error OR fetch error).
+    We surface this as a failure so the caller retries on the next run.
+    Convergence is guaranteed by the dashboard: on retry, the noop path
+    of /rename re-attempts the per-slug re-key with the current sites.json
+    state, so the retry either finishes the move or surfaces another 502
+    that reflects the live state.
     """
     url = f"{base_url}/api/sites/{old_slug}/rename"
     try:
@@ -229,11 +231,14 @@ def _rename(
         return False, (
             f"rename {old_slug} -> {new_slug} partial: "
             f"sites_renamed={body.get('sites_renamed')} "
+            f"note={body.get('note')!r} "
             f"overrides_had_data={body.get('overrides_had_data')} "
             f"overrides_moved={body.get('overrides_moved')} "
+            f"overrides_fetch_failed={body.get('overrides_fetch_failed')} "
             f"overrides_error={body.get('overrides_error')!r} "
             f"reviews_had_data={body.get('reviews_had_data')} "
             f"reviews_moved={body.get('reviews_moved')} "
+            f"reviews_fetch_failed={body.get('reviews_fetch_failed')} "
             f"reviews_error={body.get('reviews_error')!r}"
         )
 
@@ -278,17 +283,35 @@ def _process_pair(
 ) -> bool:
     """Drop canonical stub then rename phantom onto canonical.
 
-    Pre-flight: fetch the canonical slug record and verify it looks like a
-    wiped stub (no can_we_open / scenarios / sources). If the canonical
-    record is populated, REFUSE to delete — the map entry must be wrong.
-    This prevents the script from destroying real data on a re-run.
+    Pre-flight reads sites.json to classify the (phantom, canonical) state
+    and pick a safe action:
+
+      Case A — fresh state (phantom present, canonical is wiped stub or absent):
+          Happy path. DELETE canonical stub, then POST /rename phantom -> canonical.
+
+      Case B — post-502 convergence (phantom absent, canonical is populated):
+          A prior run already advanced sites.json but failed the per-slug
+          re-key. Skip DELETE entirely (canonical now holds the real data;
+          deleting it would destroy what we just moved). Call /rename anyway
+          — it will hit the dashboard's noop branch which re-attempts the
+          per-slug data move and either finishes or surfaces another 502.
+
+      Case C — already done (phantom absent, canonical absent or stub):
+          Nothing meaningful to do. Log and return success.
+
+      Case D — wrong map entry (phantom present, canonical populated):
+          Both records carry real data. Refuse. The map row is wrong;
+          a human must investigate before any further action.
+
+      Case E — fetch failure on either slug:
+          Cannot classify. Refuse and surface the error.
 
     Returns True on overall success.
     """
-    # Pre-flight: confirm canonical looks like a wiped stub before DELETE.
-    # We always fetch — even in dry-run — so the user gets a real picture
-    # of what would happen.
-    fetch_ok, record, fetch_note = _fetch_site_record(session, base_url, canonical)
+    # Pre-flight: classify the live state of both slugs.
+    fetch_ok, canonical_rec, fetch_note = _fetch_site_record(
+        session, base_url, canonical
+    )
     if not fetch_ok:
         logger.error(
             "pre-flight fetch failed for %s: %s; skipping pair",
@@ -296,34 +319,87 @@ def _process_pair(
             fetch_note,
         )
         return False
-    if record is not None and not _is_wiped_stub(record):
+    fetch_ok, phantom_rec, fetch_note = _fetch_site_record(
+        session, base_url, phantom
+    )
+    if not fetch_ok:
         logger.error(
-            "REFUSING to delete %s: record is populated, not a wiped stub. "
-            "Map entry %s -> %s is suspect; skipping pair. "
-            "Inspect the record manually before re-running.",
+            "pre-flight fetch failed for %s: %s; skipping pair",
+            phantom,
+            fetch_note,
+        )
+        return False
+
+    canonical_is_stub = _is_wiped_stub(canonical_rec)
+    phantom_present = phantom_rec is not None
+
+    # Case D: wrong map entry. Both records exist with real data.
+    if phantom_present and canonical_rec is not None and not canonical_is_stub:
+        logger.error(
+            "REFUSING: both %s and %s exist with hydrated data. Map entry "
+            "%s -> %s is suspect; skipping pair. Inspect manually.",
+            phantom,
             canonical,
             phantom,
             canonical,
         )
         return False
 
-    if dry_run:
+    # Case C: nothing to do. Phantom already gone and canonical isn't
+    # holding real data either (truly absent, or a stub that no one
+    # populated yet). Treat as success (idempotent skip).
+    if not phantom_present and canonical_is_stub:
         logger.info(
-            "DRY_RUN: %s pre-flight OK (%s); would DELETE %s then rename %s -> %s",
-            canonical,
-            "absent" if record is None else "wiped stub",
-            canonical,
+            "%s -> %s already converged (phantom absent, canonical %s); skipping",
             phantom,
             canonical,
+            "absent" if canonical_rec is None else "is wiped stub",
         )
         return True
 
-    ok, note = _delete_stub(session, base_url, secret, canonical)
-    if ok:
-        logger.info(note)
+    # Case B: post-502 convergence retry. Phantom is gone, canonical is
+    # populated (with what should be phantom's data). Skip DELETE.
+    convergence_retry = (
+        not phantom_present
+        and canonical_rec is not None
+        and not canonical_is_stub
+    )
+
+    if dry_run:
+        if convergence_retry:
+            logger.info(
+                "DRY_RUN: %s -> %s convergence retry (phantom absent, canonical "
+                "populated); would skip DELETE and re-call /rename to retry "
+                "per-slug re-key",
+                phantom,
+                canonical,
+            )
+        else:
+            logger.info(
+                "DRY_RUN: %s pre-flight OK (%s); would DELETE %s then rename %s -> %s",
+                canonical,
+                "absent" if canonical_rec is None else "wiped stub",
+                canonical,
+                phantom,
+                canonical,
+            )
+        return True
+
+    if convergence_retry:
+        logger.info(
+            "%s -> %s convergence retry: skipping DELETE; re-calling /rename "
+            "to retry per-slug re-key on dashboard noop path",
+            phantom,
+            canonical,
+        )
     else:
-        logger.error(note)
-        return False
+        # Case A: fresh DELETE + rename.
+        ok, note = _delete_stub(session, base_url, secret, canonical)
+        if ok:
+            logger.info(note)
+        else:
+            logger.error(note)
+            return False
 
     ok, note = _rename(
         session,

--- a/tests/test_cleanup_phantom_recovery_slugs.py
+++ b/tests/test_cleanup_phantom_recovery_slugs.py
@@ -338,13 +338,138 @@ def test_rename_malformed_json_body():
     assert ok is True
 
 
+
 # ──────────────────────────────────────────────────────────────────────────────
-# _process_pair — pre-flight + full flow
+# _rename — additional 502 partial-failure scenarios (iter2)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_rename_502_partial_failure_overrides():
+    """502 with overrides_had_data=True, overrides_moved=False — surfaces
+    the GitHub commit error in the note for ops to triage."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": True,
+            "note": "rename",
+            "overrides_had_data": True,
+            "overrides_moved": False,
+            "overrides_fetch_failed": False,
+            "overrides_error": "GitHub 422",
+            "reviews_had_data": False,
+            "reviews_moved": False,
+            "reviews_fetch_failed": False,
+            "reviews_error": None,
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "overrides_had_data=True" in note
+    assert "overrides_moved=False" in note
+    assert "overrides_fetch_failed=False" in note
+    assert "GitHub 422" in note
+
+
+def test_rename_502_partial_failure_reviews():
+    """IMP-4: reviews-side per-slug data failed — caller MUST retry."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": True,
+            "note": "rename",
+            "overrides_had_data": False,
+            "overrides_moved": False,
+            "overrides_fetch_failed": False,
+            "overrides_error": None,
+            "reviews_had_data": True,
+            "reviews_moved": False,
+            "reviews_fetch_failed": False,
+            "reviews_error": "GitHub 409",
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "reviews_had_data=True" in note
+    assert "reviews_moved=False" in note
+    assert "GitHub 409" in note
+
+
+def test_rename_502_fetch_failure_surfaced():
+    """C-1 regression test: fetch-side throw on the dashboard must surface
+    in the 502 body, not silently turn into a 200 success. Caller logs
+    the fetch_failed flag and retries."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": True,
+            "note": "rename",
+            "overrides_had_data": False,
+            "overrides_moved": False,
+            "overrides_fetch_failed": True,
+            "overrides_error": "GitHub fetch network error: ETIMEDOUT",
+            "reviews_had_data": False,
+            "reviews_moved": False,
+            "reviews_fetch_failed": False,
+            "reviews_error": None,
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "overrides_fetch_failed=True" in note
+    assert "ETIMEDOUT" in note
+
+
+def test_rename_502_already_renamed_note():
+    """Convergence retry hits the dashboard noop branch, which can still
+    return 502 if the per-slug re-key fails again. The 'already-renamed'
+    note distinguishes this from the fresh-rename 502 in logs."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": False,
+            "note": "already-renamed",
+            "overrides_had_data": True,
+            "overrides_moved": False,
+            "overrides_fetch_failed": False,
+            "overrides_error": "GitHub 422",
+            "reviews_had_data": False,
+            "reviews_moved": False,
+            "reviews_fetch_failed": False,
+            "reviews_error": None,
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "note='already-renamed'" in note
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _process_pair — pre-flight + Cases A/B/C/D/E
 # ──────────────────────────────────────────────────────────────────────────────
 
 
 def _stub_canonical_record():
-    """Return a record that _is_wiped_stub considers a stub."""
+    """Wiped canonical stub: present in sites.json but no real fields."""
     return {"slug": "canonical", "published_at": "2026-04-01T00:00:00Z"}
 
 
@@ -356,12 +481,61 @@ def _populated_canonical_record():
     }
 
 
-def test_process_pair_dry_run_skips_writes_but_runs_preflight():
-    """Dry run still does the pre-flight fetch (so the user sees real
-    state) but performs no DELETE or rename."""
+def _phantom_record():
+    return {
+        "slug": "phantom",
+        "can_we_open": "Yes",
+        "scenarios": [{"id": "s1"}],
+        "sources": {"x": "https://example.com"},
+    }
+
+
+def _make_get_returning(*records):
+    """Build a session.get that returns sites.json with the given records on
+    BOTH calls (canonical fetch and phantom fetch). Each fetch scans the
+    same sites list for its own slug — so include both records here when
+    both must be present."""
+    payload = {"sites": list(records)}
+
+    def fake_get(url, timeout=None):
+        return _resp(200, body=payload)
+
+    return fake_get
+
+
+def _make_get_per_slug(canonical_rec=None, phantom_rec=None):
+    """Build a session.get that returns DIFFERENT sites.json snapshots per
+    fetch. _process_pair calls _fetch_site_record(canonical) first, then
+    _fetch_site_record(phantom). Each looks up its own slug in the payload.
+
+    For most tests the same sites list works for both calls. Use this only
+    when you need the canonical and phantom fetches to see different
+    payloads (e.g. simulating a race)."""
+    canonical_payload = {
+        "sites": [canonical_rec] if canonical_rec is not None else []
+    }
+    phantom_payload = {
+        "sites": [phantom_rec] if phantom_rec is not None else []
+    }
+    calls = {"n": 0}
+
+    def fake_get(url, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _resp(200, body=canonical_payload)
+        return _resp(200, body=phantom_payload)
+
+    return fake_get
+
+
+# ── Case A: fresh state — canonical is wiped stub (or absent), phantom present
+
+
+def test_process_pair_dry_run_fresh_state_skips_writes():
+    """Dry run on Case A: pre-flight runs, no DELETE/rename issued."""
     session = MagicMock()
-    session.get.return_value = _resp(
-        200, body={"sites": [_stub_canonical_record()]}
+    session.get.side_effect = _make_get_returning(
+        _stub_canonical_record(), _phantom_record()
     )
     ok = cleanup._process_pair(
         session,
@@ -372,53 +546,17 @@ def test_process_pair_dry_run_skips_writes_but_runs_preflight():
         dry_run=True,
     )
     assert ok is True
-    session.get.assert_called_once()
+    assert session.get.call_count == 2
     session.delete.assert_not_called()
     session.post.assert_not_called()
-
-
-def test_process_pair_refuses_to_delete_populated_canonical():
-    """Footgun guard: canonical record is populated, NOT a wiped stub.
-    Map entry must be wrong — refuse to delete and skip the pair."""
-    session = MagicMock()
-    session.get.return_value = _resp(
-        200, body={"sites": [_populated_canonical_record()]}
-    )
-    ok = cleanup._process_pair(
-        session,
-        "https://x",
-        "secret",
-        phantom="phantom",
-        canonical="canonical",
-        dry_run=False,
-    )
-    assert ok is False
-    session.delete.assert_not_called()
-    session.post.assert_not_called()
-
-
-def test_process_pair_refuses_to_delete_populated_canonical_dry_run():
-    """Same guard applies in dry-run: surfaces the issue without writes."""
-    session = MagicMock()
-    session.get.return_value = _resp(
-        200, body={"sites": [_populated_canonical_record()]}
-    )
-    ok = cleanup._process_pair(
-        session,
-        "https://x",
-        "secret",
-        phantom="phantom",
-        canonical="canonical",
-        dry_run=True,
-    )
-    assert ok is False
 
 
 def test_process_pair_canonical_absent_proceeds():
-    """Canonical not in sites.json = absent = stub-equivalent. Proceed."""
+    """Canonical not in sites.json (treated as stub-equivalent), phantom
+    present — Case A. DELETE is idempotent (404), rename succeeds."""
     session = MagicMock()
-    session.get.return_value = _resp(200, body={"sites": []})
-    session.delete.return_value = _resp(404)  # already gone
+    session.get.side_effect = _make_get_returning(_phantom_record())
+    session.delete.return_value = _resp(404)
     session.post.return_value = _resp(
         200,
         body={
@@ -437,12 +575,16 @@ def test_process_pair_canonical_absent_proceeds():
         dry_run=False,
     )
     assert ok is True
+    session.delete.assert_called_once()
+    session.post.assert_called_once()
 
 
 def test_process_pair_happy_path():
+    """Case A happy path: canonical is wiped stub, phantom present.
+    DELETE 200, rename 200."""
     session = MagicMock()
-    session.get.return_value = _resp(
-        200, body={"sites": [_stub_canonical_record()]}
+    session.get.side_effect = _make_get_returning(
+        _stub_canonical_record(), _phantom_record()
     )
     session.delete.return_value = _resp(200)
     session.post.return_value = _resp(
@@ -450,7 +592,7 @@ def test_process_pair_happy_path():
         body={
             "ok": True,
             "action": "rename",
-            "overrides_moved": False,
+            "overrides_moved": True,
             "reviews_moved": False,
         },
     )
@@ -463,12 +605,15 @@ def test_process_pair_happy_path():
         dry_run=False,
     )
     assert ok is True
+    session.delete.assert_called_once()
+    session.post.assert_called_once()
 
 
 def test_process_pair_delete_failure_aborts_rename():
+    """Case A: DELETE 500 — abort, do not call rename."""
     session = MagicMock()
-    session.get.return_value = _resp(
-        200, body={"sites": [_stub_canonical_record()]}
+    session.get.side_effect = _make_get_returning(
+        _stub_canonical_record(), _phantom_record()
     )
     session.delete.return_value = _resp(500, text="bad")
     ok = cleanup._process_pair(
@@ -484,12 +629,11 @@ def test_process_pair_delete_failure_aborts_rename():
 
 
 def test_process_pair_rename_partial_failure_returns_false():
-    """Pre-flight passes, DELETE succeeds, but rename returns 502
-    rename_partial. Caller must surface this so the run reports failure
-    and is retried."""
+    """Case A: pre-flight ok, DELETE 200, rename 502 rename_partial.
+    Surface as failure for retry on next run."""
     session = MagicMock()
-    session.get.return_value = _resp(
-        200, body={"sites": [_stub_canonical_record()]}
+    session.get.side_effect = _make_get_returning(
+        _stub_canonical_record(), _phantom_record()
     )
     session.delete.return_value = _resp(200)
     session.post.return_value = _resp(
@@ -498,11 +642,14 @@ def test_process_pair_rename_partial_failure_returns_false():
             "ok": False,
             "action": "rename_partial",
             "sites_renamed": True,
+            "note": "rename",
             "overrides_had_data": True,
             "overrides_moved": False,
+            "overrides_fetch_failed": False,
             "overrides_error": "GitHub 422",
             "reviews_had_data": False,
             "reviews_moved": False,
+            "reviews_fetch_failed": False,
             "reviews_error": None,
         },
     )
@@ -517,12 +664,211 @@ def test_process_pair_rename_partial_failure_returns_false():
     assert ok is False
 
 
+# ── Case D: wrong map entry — both records populated. REFUSE.
+
+
+def test_process_pair_refuses_when_both_records_populated():
+    """Case D: phantom AND canonical both carry hydrated data.
+    The map row is wrong — refuse to act."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning(
+        _populated_canonical_record(), _phantom_record()
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_process_pair_refuses_when_both_records_populated_dry_run():
+    """Same Case D guard fires under dry-run — surfaces the issue early."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning(
+        _populated_canonical_record(), _phantom_record()
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=True,
+    )
+    assert ok is False
+
+
+# ── Case B: post-502 convergence retry — phantom absent, canonical populated.
+#    DELETE must be skipped (canonical now holds the real data); rename is
+#    re-issued so the dashboard noop path retries the per-slug re-key.
+
+
+def test_process_pair_convergence_retry_skips_delete_calls_rename():
+    """C-2 regression test. Phantom gone, canonical populated. Skipping
+    DELETE is critical — the canonical slug now holds phantom's hydrated
+    data; deleting it would destroy what we just moved. Rename hits the
+    dashboard noop branch which re-attempts the per-slug re-key."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning(_populated_canonical_record())
+    session.post.return_value = _resp(
+        200,
+        body={
+            "ok": True,
+            "action": "noop",
+            "note": "already-renamed",
+            "overrides_had_data": True,
+            "overrides_moved": True,
+            "reviews_had_data": False,
+            "reviews_moved": False,
+        },
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is True
+    session.delete.assert_not_called()
+    session.post.assert_called_once()
+
+
+def test_process_pair_convergence_retry_dry_run():
+    """Dry-run on Case B: log the retry plan, no DELETE, no rename."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning(_populated_canonical_record())
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=True,
+    )
+    assert ok is True
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_process_pair_convergence_retry_rename_still_502():
+    """Convergence retry: rename hits noop path but re-key still fails.
+    Surface as failure — next run will retry again."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning(_populated_canonical_record())
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": False,
+            "note": "already-renamed",
+            "overrides_had_data": True,
+            "overrides_moved": False,
+            "overrides_fetch_failed": False,
+            "overrides_error": "GitHub 422",
+            "reviews_had_data": False,
+            "reviews_moved": False,
+            "reviews_fetch_failed": False,
+            "reviews_error": None,
+        },
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+    session.delete.assert_not_called()
+    session.post.assert_called_once()
+
+
+# ── Case C: already converged — phantom absent, canonical absent OR stub.
+
+
+def test_process_pair_already_converged_canonical_absent():
+    """Case C: nothing in sites.json for either slug. Idempotent skip."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning()  # empty sites
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is True
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_process_pair_already_converged_canonical_stub():
+    """Case C: canonical is a wiped stub, phantom absent. Idempotent skip."""
+    session = MagicMock()
+    session.get.side_effect = _make_get_returning(_stub_canonical_record())
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is True
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+# ── Case E: pre-flight fetch failure on either slug.
+
+
 def test_process_pair_preflight_fetch_failure_aborts():
-    """Pre-flight network failure: don't blindly proceed; abort the pair."""
+    """Pre-flight network failure on canonical fetch: don't blindly
+    proceed; abort the pair without calling DELETE or rename."""
     import requests as _req
 
     session = MagicMock()
     session.get.side_effect = _req.RequestException("dns")
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_process_pair_preflight_fetch_failure_on_phantom_aborts():
+    """Pre-flight network failure on phantom fetch (second GET): abort."""
+    import requests as _req
+
+    session = MagicMock()
+    # First GET succeeds (canonical), second GET (phantom) raises.
+    canonical_payload = {"sites": [_stub_canonical_record()]}
+    calls = {"n": 0}
+
+    def fake_get(url, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _resp(200, body=canonical_payload)
+        raise _req.RequestException("dns")
+
+    session.get.side_effect = fake_get
     ok = cleanup._process_pair(
         session,
         "https://x",

--- a/tests/test_cleanup_phantom_recovery_slugs.py
+++ b/tests/test_cleanup_phantom_recovery_slugs.py
@@ -1,0 +1,581 @@
+"""Tests for scripts/cleanup_phantom_recovery_slugs.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "cleanup_phantom_recovery_slugs.py"
+
+_spec = importlib.util.spec_from_file_location(
+    "cleanup_phantom_recovery_slugs", _SCRIPT_PATH
+)
+cleanup = importlib.util.module_from_spec(_spec)
+sys.modules["cleanup_phantom_recovery_slugs"] = cleanup
+_spec.loader.exec_module(cleanup)  # type: ignore[union-attr]
+
+
+def _resp(status: int, body: dict | None = None, text: str | None = None):
+    """Build a mock response. Pass body for JSON; text overrides."""
+    r = MagicMock()
+    r.status_code = status
+    if text is not None:
+        r.text = text
+        # json() should raise if text isn't valid JSON
+        try:
+            r.json.return_value = json.loads(text)
+        except (ValueError, TypeError):
+            r.json.side_effect = ValueError("not json")
+    elif body is not None:
+        r.text = json.dumps(body)
+        r.json.return_value = body
+    else:
+        r.text = ""
+        r.json.return_value = {}
+    return r
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _is_wiped_stub
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_is_wiped_stub_none_record():
+    """None (slug absent) is treated as a stub — already gone."""
+    assert cleanup._is_wiped_stub(None) is True
+
+
+def test_is_wiped_stub_empty_dict():
+    """No hydrated fields -> stub."""
+    assert cleanup._is_wiped_stub({}) is True
+
+
+def test_is_wiped_stub_only_slug_and_metadata():
+    """A wiped stub keeps slug/published_at but loses analytical fields."""
+    record = {
+        "slug": "alpha-school-foo",
+        "published_at": "2026-04-01T00:00:00Z",
+        "address": "1 Main St",
+    }
+    assert cleanup._is_wiped_stub(record) is True
+
+
+def test_is_wiped_stub_with_can_we_open():
+    record = {"slug": "x", "can_we_open": "Yes"}
+    assert cleanup._is_wiped_stub(record) is False
+
+
+def test_is_wiped_stub_with_scenarios():
+    record = {"slug": "x", "scenarios": [{"id": "s1"}]}
+    assert cleanup._is_wiped_stub(record) is False
+
+
+def test_is_wiped_stub_with_sources():
+    record = {"slug": "x", "sources": {"permitting": "https://..."}}
+    assert cleanup._is_wiped_stub(record) is False
+
+
+def test_is_wiped_stub_falsy_fields_are_stub():
+    """Empty list / empty dict / empty string for hydrated fields == stub."""
+    record = {
+        "slug": "x",
+        "can_we_open": "",
+        "scenarios": [],
+        "sources": {},
+    }
+    assert cleanup._is_wiped_stub(record) is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _fetch_site_record
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_site_record_found():
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200,
+        body={
+            "sites": [
+                {"slug": "a", "can_we_open": "Yes"},
+                {"slug": "b"},
+            ]
+        },
+    )
+    ok, record, note = cleanup._fetch_site_record(session, "https://x", "b")
+    assert ok is True
+    assert record == {"slug": "b"}
+    assert "found" in note
+
+
+def test_fetch_site_record_not_found():
+    session = MagicMock()
+    session.get.return_value = _resp(200, body={"sites": [{"slug": "a"}]})
+    ok, record, note = cleanup._fetch_site_record(session, "https://x", "missing")
+    assert ok is True
+    assert record is None
+    assert "not in sites.json" in note
+
+
+def test_fetch_site_record_http_error():
+    session = MagicMock()
+    session.get.return_value = _resp(503, text="upstream down")
+    ok, record, note = cleanup._fetch_site_record(session, "https://x", "a")
+    assert ok is False
+    assert "HTTP 503" in note
+
+
+def test_fetch_site_record_network_error():
+    import requests as _req
+
+    session = MagicMock()
+    session.get.side_effect = _req.RequestException("connection refused")
+    ok, record, note = cleanup._fetch_site_record(session, "https://x", "a")
+    assert ok is False
+    assert "network error" in note
+
+
+def test_fetch_site_record_malformed_payload():
+    session = MagicMock()
+    session.get.return_value = _resp(200, body={"sites": "not a list"})
+    ok, record, note = cleanup._fetch_site_record(session, "https://x", "a")
+    assert ok is False
+    assert "missing or not a list" in note
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _delete_stub
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_delete_stub_200():
+    session = MagicMock()
+    session.delete.return_value = _resp(200)
+    ok, note = cleanup._delete_stub(session, "https://x", "secret", "slug-a")
+    assert ok is True
+    assert "deleted" in note
+    # Auth header carried
+    call = session.delete.call_args
+    assert call.kwargs["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_delete_stub_404_idempotent():
+    session = MagicMock()
+    session.delete.return_value = _resp(404)
+    ok, note = cleanup._delete_stub(session, "https://x", "secret", "slug-a")
+    assert ok is True
+    assert "already absent" in note
+
+
+def test_delete_stub_500_failure():
+    session = MagicMock()
+    session.delete.return_value = _resp(500, text="bad")
+    ok, note = cleanup._delete_stub(session, "https://x", "secret", "slug-a")
+    assert ok is False
+    assert "HTTP 500" in note
+
+
+def test_delete_stub_network_error():
+    import requests as _req
+
+    session = MagicMock()
+    session.delete.side_effect = _req.RequestException("boom")
+    ok, note = cleanup._delete_stub(session, "https://x", "secret", "slug-a")
+    assert ok is False
+    assert "network error" in note
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _rename — honest checks
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_rename_200_full_success():
+    session = MagicMock()
+    session.post.return_value = _resp(
+        200,
+        body={
+            "ok": True,
+            "action": "rename",
+            "overrides_moved": True,
+            "reviews_moved": True,
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is True
+    assert "rename" in note
+    assert "overrides_moved=True" in note
+    assert "reviews_moved=True" in note
+
+
+def test_rename_200_noop_no_data_to_move():
+    """Common case: no per-slug data existed for the old slug. Both flags
+    false. Still success."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        200,
+        body={
+            "ok": True,
+            "action": "rename",
+            "overrides_moved": False,
+            "reviews_moved": False,
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is True
+
+
+def test_rename_200_action_noop():
+    """Idempotent retry: dashboard reports action=noop."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        200,
+        body={"ok": True, "action": "noop", "message": "already renamed"},
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is True
+    assert "noop" in note
+
+
+def test_rename_502_partial_failure():
+    """Dashboard reports sites.json renamed but overrides re-key failed.
+    Caller MUST retry. _rename returns False to surface this."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": True,
+            "overrides_had_data": True,
+            "overrides_moved": False,
+            "overrides_error": "GitHub 422",
+            "reviews_had_data": False,
+            "reviews_moved": False,
+            "reviews_error": None,
+        },
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "partial" in note
+    assert "overrides_had_data=True" in note
+    assert "overrides_moved=False" in note
+
+
+def test_rename_200_with_explicit_ok_false_treated_as_failure():
+    """If dashboard ever returns 200 ok:false, treat as failure rather
+    than silently advance."""
+    session = MagicMock()
+    session.post.return_value = _resp(
+        200, body={"ok": False, "message": "weird state"}
+    )
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "ok=false" in note
+
+
+def test_rename_400_failure():
+    session = MagicMock()
+    session.post.return_value = _resp(400, body={"message": "new_slug invalid"})
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "HTTP 400" in note
+
+
+def test_rename_500_failure():
+    session = MagicMock()
+    session.post.return_value = _resp(500, text="boom")
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "HTTP 500" in note
+
+
+def test_rename_network_error():
+    import requests as _req
+
+    session = MagicMock()
+    session.post.side_effect = _req.RequestException("timeout")
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    assert ok is False
+    assert "network error" in note
+
+
+def test_rename_malformed_json_body():
+    """Non-JSON body on 200 — _rename should still parse and treat as ok
+    if status is 200 and we can't read ok=False."""
+    session = MagicMock()
+    r = MagicMock()
+    r.status_code = 200
+    r.text = "not json"
+    r.json.side_effect = ValueError("not json")
+    session.post.return_value = r
+    ok, note = cleanup._rename(
+        session, "https://x", "secret", old_slug="old", new_slug="new"
+    )
+    # Body coerced to {}, ok != False, so treated as success.
+    assert ok is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _process_pair — pre-flight + full flow
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _stub_canonical_record():
+    """Return a record that _is_wiped_stub considers a stub."""
+    return {"slug": "canonical", "published_at": "2026-04-01T00:00:00Z"}
+
+
+def _populated_canonical_record():
+    return {
+        "slug": "canonical",
+        "can_we_open": "Yes",
+        "scenarios": [{"id": "s1"}],
+    }
+
+
+def test_process_pair_dry_run_skips_writes_but_runs_preflight():
+    """Dry run still does the pre-flight fetch (so the user sees real
+    state) but performs no DELETE or rename."""
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200, body={"sites": [_stub_canonical_record()]}
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=True,
+    )
+    assert ok is True
+    session.get.assert_called_once()
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_process_pair_refuses_to_delete_populated_canonical():
+    """Footgun guard: canonical record is populated, NOT a wiped stub.
+    Map entry must be wrong — refuse to delete and skip the pair."""
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200, body={"sites": [_populated_canonical_record()]}
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_process_pair_refuses_to_delete_populated_canonical_dry_run():
+    """Same guard applies in dry-run: surfaces the issue without writes."""
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200, body={"sites": [_populated_canonical_record()]}
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=True,
+    )
+    assert ok is False
+
+
+def test_process_pair_canonical_absent_proceeds():
+    """Canonical not in sites.json = absent = stub-equivalent. Proceed."""
+    session = MagicMock()
+    session.get.return_value = _resp(200, body={"sites": []})
+    session.delete.return_value = _resp(404)  # already gone
+    session.post.return_value = _resp(
+        200,
+        body={
+            "ok": True,
+            "action": "rename",
+            "overrides_moved": True,
+            "reviews_moved": False,
+        },
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is True
+
+
+def test_process_pair_happy_path():
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200, body={"sites": [_stub_canonical_record()]}
+    )
+    session.delete.return_value = _resp(200)
+    session.post.return_value = _resp(
+        200,
+        body={
+            "ok": True,
+            "action": "rename",
+            "overrides_moved": False,
+            "reviews_moved": False,
+        },
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is True
+
+
+def test_process_pair_delete_failure_aborts_rename():
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200, body={"sites": [_stub_canonical_record()]}
+    )
+    session.delete.return_value = _resp(500, text="bad")
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+    session.post.assert_not_called()
+
+
+def test_process_pair_rename_partial_failure_returns_false():
+    """Pre-flight passes, DELETE succeeds, but rename returns 502
+    rename_partial. Caller must surface this so the run reports failure
+    and is retried."""
+    session = MagicMock()
+    session.get.return_value = _resp(
+        200, body={"sites": [_stub_canonical_record()]}
+    )
+    session.delete.return_value = _resp(200)
+    session.post.return_value = _resp(
+        502,
+        body={
+            "ok": False,
+            "action": "rename_partial",
+            "sites_renamed": True,
+            "overrides_had_data": True,
+            "overrides_moved": False,
+            "overrides_error": "GitHub 422",
+            "reviews_had_data": False,
+            "reviews_moved": False,
+            "reviews_error": None,
+        },
+    )
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+
+
+def test_process_pair_preflight_fetch_failure_aborts():
+    """Pre-flight network failure: don't blindly proceed; abort the pair."""
+    import requests as _req
+
+    session = MagicMock()
+    session.get.side_effect = _req.RequestException("dns")
+    ok = cleanup._process_pair(
+        session,
+        "https://x",
+        "secret",
+        phantom="phantom",
+        canonical="canonical",
+        dry_run=False,
+    )
+    assert ok is False
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# main() — argparse + filtering
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_main_apply_without_secret_returns_2(monkeypatch, caplog):
+    monkeypatch.delenv("DASHBOARD_PUBLISH_SECRET", raising=False)
+    rc = cleanup.main(["--apply"])
+    assert rc == 2
+
+
+def test_main_pair_filter_no_match_returns_2(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "x")
+    rc = cleanup.main(["--apply", "--pair", "no-such-substring-anywhere"])
+    assert rc == 2
+
+
+def test_main_dry_run_no_secret_required(monkeypatch):
+    """Dry run should work without DASHBOARD_PUBLISH_SECRET (no writes)."""
+    monkeypatch.delenv("DASHBOARD_PUBLISH_SECRET", raising=False)
+    with patch.object(cleanup, "_process_pair", return_value=True) as mp:
+        rc = cleanup.main(["--dry-run"])
+    assert rc == 0
+    # All pairs were processed
+    assert mp.call_count == len(cleanup.PHANTOM_TO_CANONICAL)
+
+
+def test_main_pair_filter_matches_substring(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "x")
+    with patch.object(cleanup, "_process_pair", return_value=True) as mp:
+        rc = cleanup.main(["--apply", "--pair", "miami-beach"])
+    assert rc == 0
+    # Filter matches the Miami Beach phantom only
+    assert mp.call_count == 1
+    kwargs = mp.call_args.kwargs
+    assert "miami-beach" in kwargs["phantom"].lower()
+
+
+def test_main_failed_pair_returns_1(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_PUBLISH_SECRET", "x")
+    with patch.object(cleanup, "_process_pair", return_value=False):
+        rc = cleanup.main(["--apply", "--pair", "miami-beach"])
+    assert rc == 1


### PR DESCRIPTION
## Why
Three bugs in `scripts/cleanup_phantom_recovery_slugs.py` found by /check Phase 2 CoVe verification:

1. **`_rename` only checked HTTP 200, never inspected `overrides_moved`/`reviews_moved`.** The dashboard's `rename.ts` used to return 200 `ok: true` even when `commitOverridesJson` threw. A failed re-key looked identical to "no per-slug data existed." Net: sites.json renamed, overrides orphaned under the old slug, no signal to the operator.
2. **`_process_pair` did DELETE before rename without confirming the canonical slug was actually a wiped stub.** If the map entry is wrong on a re-run, the script would happily DELETE a populated record.
3. **Zero test coverage** for any of `_rename` / `_delete_stub` / `_process_pair`.

## What
- New `_is_wiped_stub()` predicate. A record with no `can_we_open`/`scenarios`/`sources` hydrated is a stub. A populated record is NOT a stub even if other fields are empty (deliberately conservative).
- New `_fetch_site_record()` to `GET /sites.json` and locate a slug.
- `_process_pair` now does a **pre-flight fetch BEFORE DELETE**. If canonical is populated, REFUSE to delete and skip the pair with a clear log message. Pre-flight runs in `--dry-run` too so the user sees real state.
- `_rename` now:
  - Treats `502 action=rename_partial` as failure and surfaces the full diagnostic body (`had_data`/`moved`/`error`) so retries converge.
  - Treats `200 ok:false` as failure (defensive).
  - Logs `overrides_moved`/`reviews_moved` on the success path.
  - Handles malformed JSON bodies without crashing.
- Added `tests/test_cleanup_phantom_recovery_slugs.py`: **38 tests** covering `_is_wiped_stub`, `_fetch_site_record`, `_delete_stub`, `_rename` (all status code paths including 502 partial), `_process_pair` (pre-flight guard, dry-run, full happy path, partial failure surfacing), and `main()` argparse + filter behavior.

## Test
```
uv run pytest tests/test_cleanup_phantom_recovery_slugs.py
38 passed in 0.16s
```
Sibling tests still green:
```
uv run pytest tests/test_cleanup_phantom_recovery_slugs.py tests/test_delete_dashboard_slugs.py tests/test_validate_rebl_slugs.py tests/test_recover_migration_wiped_sites.py
91 passed in 0.78s
```

## Pairs with
EDU-Ops-Team/dd-dashboard#26 (rename.ts returns 502 on partial re-key failure). The 502 handling here will only kick in once that PR is deployed; the 200-ok:false defensive path covers the current behavior.
