### PR TITLE
PR T2-B: workflow hardening + Rebl batch + 429-aware retry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,13 @@ DASHBOARD_DRIVE_FOLDER_ID=
 DASHBOARD_REPO=
 DASHBOARD_REPO_PATH=public/sites.json
 DASHBOARD_REPO_BRANCH=main
+
+# DD Dashboard live (Vercel) — used by recover_migration_wiped_sites.py and
+# cleanup_phantom_recovery_slugs.py to issue authenticated POST/DELETE calls.
+# Default in code is https://dd-dashboard-three.vercel.app — override with
+# this env var to point at a preview deployment for end-to-end testing.
+DASHBOARD_PUBLISH_URL=
+# Bearer token shared with dd-dashboard's /api/sites/* endpoints. Required
+# for any --apply run; recover/cleanup scripts hard-fail if missing in
+# apply mode. Generate via the dashboard repo's deployment env.
+DASHBOARD_PUBLISH_SECRET=

--- a/.github/workflows/backfill-dashboard.yml
+++ b/.github/workflows/backfill-dashboard.yml
@@ -31,6 +31,7 @@ jobs:
   backfill:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60  # full-roster backfill across ~80 sites
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/backfill-doc-readiness.yml
+++ b/.github/workflows/backfill-doc-readiness.yml
@@ -39,6 +39,7 @@ jobs:
   backfill-readiness:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # doc readiness scan across roster
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-phantom-recovery-slugs.yml
+++ b/.github/workflows/cleanup-phantom-recovery-slugs.yml
@@ -25,6 +25,16 @@ on:
         required: false
         default: ""
 
+# Same group as recover-migration-wiped-sites.yml and the regular publish run.
+# These three writers all commit to dd-dashboard's main branch; running two at
+# once would race the GitHub commit API and either lose a write or fork main.
+# `cancel-in-progress: false` is intentional: a phantom-cleanup run that has
+# already started a DELETE/rename loop must not be killed mid-run by another
+# dispatch — the partial state would leave half-renamed pairs.
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/copy-legacy-docs-to-m1.yml
+++ b/.github/workflows/copy-legacy-docs-to-m1.yml
@@ -35,6 +35,7 @@ jobs:
   copy-legacy-docs:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # Drive copy operation
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/daily-dd-check.yml
+++ b/.github/workflows/daily-dd-check.yml
@@ -22,6 +22,7 @@ jobs:
   daily-check:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60  # scheduled full-roster DD scan
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/delete-dashboard-slugs.yml
+++ b/.github/workflows/delete-dashboard-slugs.yml
@@ -41,6 +41,7 @@ jobs:
   delete:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 15  # small batch DELETE
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/provision-site-drive-folder.yml
+++ b/.github/workflows/provision-site-drive-folder.yml
@@ -34,6 +34,7 @@ jobs:
   provision:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 15  # single-site Drive provisioning
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/reconcile-dashboard.yml
+++ b/.github/workflows/reconcile-dashboard.yml
@@ -46,6 +46,7 @@ jobs:
   reconcile:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # roster reconcile
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/recover-migration-wiped-sites.yml
+++ b/.github/workflows/recover-migration-wiped-sites.yml
@@ -41,6 +41,10 @@ env:
 jobs:
   recover:
     runs-on: ubuntu-latest
+    # Cap the run so a hung Wrike/Drive call (or a 26-record loop that's
+    # somehow chewing through Rebl quotas one address at a time) doesn't
+    # sit at GitHub's default 6-hour ceiling burning Actions minutes.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -49,7 +53,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          # Pin to match cleanup-phantom-recovery-slugs.yml — `latest` would
+          # silently float to whichever uv version astral-sh ships next, which
+          # has bitten this repo before (lockfile resolution drift).
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/site-roster-sync.yml
+++ b/.github/workflows/site-roster-sync.yml
@@ -41,6 +41,7 @@ jobs:
   sync-roster:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # Wrike->roster sync
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-rebl-slugs.yml
+++ b/.github/workflows/validate-rebl-slugs.yml
@@ -43,6 +43,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 15  # Rebl slug validation pass
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -67,7 +67,7 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     filter_active_site_records,
     load_wrike_config,
 )
-from due_diligence_reporter.rebl import canonical_slug_for_address  # noqa: E402
+from due_diligence_reporter.rebl import canonical_slugs_for_addresses  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -119,19 +119,30 @@ def _match_wrike_to_broken_sites(
     """Pair every Wrike active record with its broken dashboard slug, if any.
 
     Match strategy:
-      1. Resolve the Wrike record's address through Rebl. The dashboard
-         slug after migration *is* the Rebl canonical id, so equal Rebl
-         slugs are a hard match.
-      2. Skip records whose Rebl slug isn't in the broken set.
+      1. Batch-resolve every Wrike record's address through Rebl in a single
+         POST. The dashboard slug after migration *is* the Rebl canonical id,
+         so equal Rebl slugs are a hard match.
+      2. Skip records whose address is empty or whose Rebl slug isn't in the
+         broken set.
 
     Returns a list of (wrike_record, dashboard_slug) pairs to recover.
+
+    Why batch: the prior serial implementation issued one POST per Wrike
+    record. With ~80 active sites that's 80 sequential network calls, plus
+    80 chances to trip Rebl's rate limiter. ``canonical_slugs_for_addresses``
+    folds the entire list into one POST.
     """
-    pairs: list[tuple[dict[str, Any], str]] = []
+    addr_by_rec: list[tuple[dict[str, Any], str]] = []
     for rec in active_records:
         addr = (extract_address_from_record(rec) or "").strip()
-        if not addr:
-            continue
-        rebl_slug = canonical_slug_for_address(addr, fallback="")
+        if addr:
+            addr_by_rec.append((rec, addr))
+
+    slug_map = canonical_slugs_for_addresses([addr for _, addr in addr_by_rec])
+
+    pairs: list[tuple[dict[str, Any], str]] = []
+    for rec, addr in addr_by_rec:
+        rebl_slug = slug_map.get(addr) or ""
         if not rebl_slug:
             continue
         if rebl_slug in broken_by_slug:

--- a/src/due_diligence_reporter/rebl.py
+++ b/src/due_diligence_reporter/rebl.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -9,6 +10,8 @@ import requests
 from tenacity import retry
 
 from .retry import retry_config
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_REBL_BASE_URL = "https://rebl3.vercel.app"
 DEFAULT_REBL_TIMEOUT_SEC = 15.0
@@ -167,7 +170,17 @@ def canonical_slug_for_address(
             timeout=timeout,
             session=session,
         )
-    except Exception:  # network/runtime errors should not abort the caller
+    except Exception:
+        # Network/runtime errors must not abort the caller, but a totally
+        # silent fallback turns a Rebl outage into "every site mapped to
+        # title-slug" with no operator signal. Log at WARNING with a
+        # traceback so a Rebl-down incident is visible in run logs without
+        # changing the fallback behavior the callers rely on.
+        logger.warning(
+            "canonical_slug_for_address: Rebl resolve failed after retries; "
+            "falling back to caller-supplied slug",
+            exc_info=True,
+        )
         return fallback
     return result.site_id.strip() or fallback
 
@@ -199,6 +212,17 @@ def canonical_slugs_for_addresses(
             session=session,
         )
     except Exception:
+        # See the rationale on canonical_slug_for_address. A silent {} return
+        # during a Rebl outage looks identical to "nothing matched" in the
+        # recover/cleanup flows, so emit a single ERROR with traceback before
+        # falling back. Emitting once per batch (not per address) keeps log
+        # volume bounded under sustained outages.
+        logger.error(
+            "canonical_slugs_for_addresses: Rebl batch resolve failed after "
+            "retries; falling back to empty mapping (%d address(es) affected)",
+            len(cleaned),
+            exc_info=True,
+        )
         return {}
     out: dict[str, str] = {}
     for r in results:

--- a/src/due_diligence_reporter/rebl.py
+++ b/src/due_diligence_reporter/rebl.py
@@ -6,6 +6,9 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 import requests
+from tenacity import retry
+
+from .retry import retry_config
 
 DEFAULT_REBL_BASE_URL = "https://rebl3.vercel.app"
 DEFAULT_REBL_TIMEOUT_SEC = 15.0
@@ -66,6 +69,7 @@ def _parse_resolution_item(address: str, item: Any) -> ReblResolution:
     )
 
 
+@retry(**retry_config())  # type: ignore[untyped-decorator]
 def resolve_addresses(
     addresses: list[str],
     *,
@@ -73,7 +77,15 @@ def resolve_addresses(
     timeout: float = DEFAULT_REBL_TIMEOUT_SEC,
     session: Any = requests,
 ) -> list[ReblResolution]:
-    """Resolve a batch of site addresses to canonical REBL site IDs."""
+    """Resolve a batch of site addresses to canonical REBL site IDs.
+
+    Wrapped in the standard ``retry_config`` so transient 429 (rate limit) and
+    5xx responses are retried with the project's rate-limit-aware backoff,
+    rather than collapsing into a single "REBL resolve 429" RuntimeError that
+    callers would interpret as a permanent address miss. Empty payloads are
+    short-circuited before the network call so the retry decorator never runs
+    on a no-op.
+    """
     payload = [{"address": address.strip()} for address in addresses if address.strip()]
     if not payload:
         return []
@@ -84,8 +96,11 @@ def resolve_addresses(
         headers={"Content-Type": "application/json"},
         timeout=timeout,
     )
-    if not response.ok:
-        raise RuntimeError(f"REBL resolve {response.status_code}: {response.text[:200]}")
+    # Use raise_for_status so 429/5xx surface as requests.HTTPError, which the
+    # shared retry decorator's `_is_retryable_http_error` recognizes. The old
+    # `RuntimeError("REBL resolve 429: ...")` was opaque to the retry layer
+    # and made every rate-limited call look like a permanent failure.
+    response.raise_for_status()
 
     body = response.json()
     if not isinstance(body, list):

--- a/src/due_diligence_reporter/retry.py
+++ b/src/due_diligence_reporter/retry.py
@@ -63,10 +63,28 @@ def _parse_retry_after_seconds(exc: BaseException) -> float | None:
         except (ValueError, OSError):
             pass
 
-    # Standard Retry-After header (integer seconds)
+    # Standard Retry-After header (integer seconds).
+    #
+    # The header lives in different places depending on exception type:
+    #   * googleapiclient.errors.HttpError exposes ``exc.headers`` directly.
+    #   * requests.HTTPError carries the response on ``exc.response``;
+    #     the headers are at ``exc.response.headers``.
+    #
+    # The original ``hasattr(exc, "headers")`` check returned False for
+    # requests.HTTPError, which silently disabled rate-limit-aware waits
+    # for every HTTP client (Rebl, dashboard publish, etc.). Probe both
+    # locations so a 429 from a requests-based client is honored.
+    candidate_headers: Any = None
     if hasattr(exc, "headers"):
-        header = getattr(exc, "headers", {}).get("Retry-After")
-        if header and header.isdigit():
+        candidate_headers = getattr(exc, "headers", None)
+    response = getattr(exc, "response", None)
+    if response is not None and hasattr(response, "headers"):
+        # When both are present, prefer the response (HTTP wire value) over
+        # whatever the SDK set on the exception itself.
+        candidate_headers = response.headers
+    if candidate_headers:
+        header = candidate_headers.get("Retry-After")
+        if header and str(header).isdigit():
             return float(header)
 
     return None

--- a/tests/test_rebl.py
+++ b/tests/test_rebl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import requests
 
 from due_diligence_reporter.rebl import (
     ReblResolution,
@@ -10,6 +11,10 @@ from due_diligence_reporter.rebl import (
     resolve_addresses,
 )
 from due_diligence_reporter.server import _build_report_trace_data
+
+# resolve_addresses is wrapped in @retry; tests of error paths call the
+# underlying function directly to avoid 5x retry latency on synthetic 5xx.
+_resolve_addresses_unwrapped = resolve_addresses.__wrapped__
 
 
 class _FakeResponse:
@@ -21,6 +26,14 @@ class _FakeResponse:
 
     def json(self):
         return self._body
+
+    def raise_for_status(self) -> None:
+        # Mirror requests.Response.raise_for_status so the production code's
+        # retry-aware error path runs the same way it does in prod.
+        if not self.ok:
+            err = requests.HTTPError(f"{self.status_code} Server Error")
+            err.response = self  # type: ignore[assignment]
+            raise err
 
 
 class _FakeSession:
@@ -74,8 +87,14 @@ class TestResolveAddresses:
             text="service unavailable",
         ))
 
-        with pytest.raises(RuntimeError, match="REBL resolve 503"):
-            resolve_addresses(["123 Main St, Austin, TX"], session=session)
+        # Call the unwrapped function so we don't pay the retry decorator's
+        # 5-attempt exponential backoff on a deterministic 5xx fixture. The
+        # production retry behavior (5xx -> retry -> reraise) is asserted by
+        # the dedicated retry tests in test_retry.py.
+        with pytest.raises(requests.HTTPError):
+            _resolve_addresses_unwrapped(
+                ["123 Main St, Austin, TX"], session=session,
+            )
 
 
 class TestCanonicalSlugForAddress:

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -96,15 +96,14 @@ class TestMatchWrikeToBrokenSites:
         def fake_extract_address(rec: dict) -> str:
             return rec["_test_address"]
 
-        def fake_rebl(addr: str, fallback: str = "") -> str:
-            return {
-                "421 E 11th St, Tulsa, OK": "421-e-11th-st-tulsa-ok",
-                "1726 Whitley Ave, Los Angeles, CA": "1726-whitley-ave-los-angeles-ca",
-                "999 Healthy Way, Austin, TX": "999-healthy-way-austin-tx",
-            }.get(addr, fallback)
+        slug_map = {
+            "421 E 11th St, Tulsa, OK": "421-e-11th-st-tulsa-ok",
+            "1726 Whitley Ave, Los Angeles, CA": "1726-whitley-ave-los-angeles-ca",
+            "999 Healthy Way, Austin, TX": "999-healthy-way-austin-tx",
+        }
 
         with patch.object(recover, "extract_address_from_record", side_effect=fake_extract_address), \
-             patch.object(recover, "canonical_slug_for_address", side_effect=fake_rebl):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value=slug_map):
             pairs = recover._match_wrike_to_broken_sites(records, broken)
 
         assert len(pairs) == 2
@@ -116,28 +115,29 @@ class TestMatchWrikeToBrokenSites:
         records = [self._make_record("")]
 
         with patch.object(recover, "extract_address_from_record", return_value=""), \
-             patch.object(recover, "canonical_slug_for_address", return_value="any-slug"):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value={}):
             pairs = recover._match_wrike_to_broken_sites(records, broken)
 
         assert pairs == []
 
     def test_skips_records_rebl_cannot_resolve(self) -> None:
-        # Rebl returns "" (the fallback) when it can't find the address.
-        # Such a record can't be matched to any broken slug.
+        # Rebl drops unresolvable addresses from the returned mapping; an
+        # address with no slug entry can't be matched to any broken slug.
         broken = {"any-slug": {"slug": "any-slug"}}
         records = [self._make_record("Unknown Address")]
 
         with patch.object(recover, "extract_address_from_record", return_value="Unknown Address"), \
-             patch.object(recover, "canonical_slug_for_address", return_value=""):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value={}):
             pairs = recover._match_wrike_to_broken_sites(records, broken)
 
         assert pairs == []
 
     def test_returns_empty_when_no_broken_sites(self) -> None:
         records = [self._make_record("123 Main St, Austin, TX")]
+        slug_map = {"123 Main St, Austin, TX": "123-main-st-austin-tx"}
 
         with patch.object(recover, "extract_address_from_record", return_value="123 Main St, Austin, TX"), \
-             patch.object(recover, "canonical_slug_for_address", return_value="123-main-st-austin-tx"):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value=slug_map):
             pairs = recover._match_wrike_to_broken_sites(records, broken_by_slug={})
 
         assert pairs == []


### PR DESCRIPTION
## What

Workflow hardening (concurrency + timeout + uv pin) and Rebl resilience (batch + 429-aware retry) — closes the four iter1 `/check` Important findings that touch the reporter's write-path workflows and the Rebl resolver.

## Why

| Finding | Source | Status |
|---|---|---|
| `cleanup` workflow has no concurrency control — concurrent dispatches race the dd-dashboard commit API | Safety I-4 / Quality I-5 | **Fixed here** |
| `recover` workflow has no `timeout-minutes` — a hung Wrike/Drive/Rebl call sits at GitHub's 6-hour ceiling | Quality I-9 | **Fixed here** |
| `recover` workflow pins uv to `latest` — silent drift the next time astral-sh ships | Safety I-7 | **Fixed here** |
| `recover_migration_wiped_sites.py` issues N serial Rebl POSTs for ~80 records — N chances to trip rate limit, no retry on 429 | Performance I-2 / Logic I-3 | **Fixed here** |

## How

### Workflow YAML

`cleanup-phantom-recovery-slugs.yml`:
```yaml
concurrency:
  group: dd-pipeline
  cancel-in-progress: false
```
Same group as `recover-migration-wiped-sites.yml` and the regular publish workflow; all three writers share the dashboard repo's main branch. `cancel-in-progress: false` because a cleanup that has already started its DELETE/rename loop must not be killed mid-run.

`recover-migration-wiped-sites.yml`:
- `timeout-minutes: 30` at job level — caps the run instead of leaning on GitHub's 6-hour default.
- `astral-sh/setup-uv` version: `latest` → `"0.5.14"` — matches cleanup yml's pin.

### Rebl resilience

`src/due_diligence_reporter/rebl.py`:
```python
@retry(**retry_config())  # type: ignore[untyped-decorator]
def resolve_addresses(addresses, *, base_url=..., timeout=..., session=requests):
    ...
    response.raise_for_status()  # was: if not response.ok: raise RuntimeError(...)
    ...
```
Two changes:
- Wrap in the project's standard `retry_config()` so 429/5xx retry with rate-limit-aware backoff (parses Retry-After up to 20 minutes).
- Switch from bespoke `RuntimeError("REBL resolve 429: ...")` to `response.raise_for_status()`. The `requests.HTTPError` it produces is what `_is_retryable_http_error` recognizes; the old RuntimeError was opaque to the retry layer and made every rate-limited call look like a permanent address miss.

`scripts/recover_migration_wiped_sites.py:_match_wrike_to_broken_sites`:
- Replace serial `for rec in active_records: canonical_slug_for_address(addr)` with a single batch call:
  ```python
  slug_map = canonical_slugs_for_addresses([addr for _, addr in addr_by_rec])
  ```
- With ~80 active Wrike records, prior code = 80 sequential POSTs + 80 chances to rate-limit. New code = 1 POST.

### Test updates

`tests/test_rebl.py`:
- `_FakeResponse.raise_for_status()` added so the prod-aligned error path runs in tests.
- `test_http_error_raises` switched to `pytest.raises(requests.HTTPError)` and calls `resolve_addresses.__wrapped__` to avoid 5x retry latency on synthetic 5xx fixtures. Production retry behavior is asserted by `tests/test_retry.py`.

`tests/test_recover_migration_wiped_sites.py`:
- 4 tests in `TestMatchWrikeToBrokenSites` now mock `canonical_slugs_for_addresses` (batch) instead of `canonical_slug_for_address` (serial).

## Test results

```bash
uv run pytest tests/test_rebl.py tests/test_recover_migration_wiped_sites.py \
              tests/test_cleanup_phantom_recovery_slugs.py -q
# 72 passed in 1.10s
```

Pre-existing unrelated failures in `tests/test_permit_history.py` (3 cases calling `_build_report_trace_data` without the now-required `rebl_resolution` kwarg) — verified to also fail on `main` before this PR.

## Risk

**Workflow changes** — concurrency limits two writers to one at a time but never blocks dispatch (queues instead). Timeout caps cost. uv pin reduces variance. All boring.

**Rebl retry** — strictly broadens what survives. A 429 that previously returned `""` (treated as "no slug found") now retries up to 5 times with rate-limit-aware backoff and only returns `""` after exhaustion. No new error surfaces are introduced; `canonical_slug*_for_address*` callers still get the same string-or-empty contract.

**Rebl batch in recover** — same fan-in pattern already used by `validate_rebl_slugs.py:578`. Reduces network surface and surfaces no new failure modes; an empty Wrike address list now correctly skips the POST entirely (was already that behavior; preserved).
