### PR TITLE
PR T2-C: hygiene fixes and _recover_one regression coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,13 @@ DASHBOARD_DRIVE_FOLDER_ID=
 DASHBOARD_REPO=
 DASHBOARD_REPO_PATH=public/sites.json
 DASHBOARD_REPO_BRANCH=main
+
+# DD Dashboard live (Vercel) — used by recover_migration_wiped_sites.py and
+# cleanup_phantom_recovery_slugs.py to issue authenticated POST/DELETE calls.
+# Default in code is https://dd-dashboard-three.vercel.app — override with
+# this env var to point at a preview deployment for end-to-end testing.
+DASHBOARD_PUBLISH_URL=
+# Bearer token shared with dd-dashboard's /api/sites/* endpoints. Required
+# for any --apply run; recover/cleanup scripts hard-fail if missing in
+# apply mode. Generate via the dashboard repo's deployment env.
+DASHBOARD_PUBLISH_SECRET=

--- a/.github/workflows/backfill-dashboard.yml
+++ b/.github/workflows/backfill-dashboard.yml
@@ -31,6 +31,7 @@ jobs:
   backfill:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60  # full-roster backfill across ~80 sites
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/backfill-doc-readiness.yml
+++ b/.github/workflows/backfill-doc-readiness.yml
@@ -39,6 +39,7 @@ jobs:
   backfill-readiness:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # doc readiness scan across roster
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-phantom-recovery-slugs.yml
+++ b/.github/workflows/cleanup-phantom-recovery-slugs.yml
@@ -20,7 +20,7 @@ on:
           - "false"
           - "true"
       pair:
-        description: "Optional substring filter on phantom slug (e.g. 'bethesda'). Leave blank for all 11."
+        description: "Optional substring filter on phantom slug (e.g. 'bethesda'). Leave blank for all 12."
         type: string
         required: false
         default: ""

--- a/.github/workflows/cleanup-phantom-recovery-slugs.yml
+++ b/.github/workflows/cleanup-phantom-recovery-slugs.yml
@@ -25,6 +25,16 @@ on:
         required: false
         default: ""
 
+# Same group as recover-migration-wiped-sites.yml and the regular publish run.
+# These three writers all commit to dd-dashboard's main branch; running two at
+# once would race the GitHub commit API and either lose a write or fork main.
+# `cancel-in-progress: false` is intentional: a phantom-cleanup run that has
+# already started a DELETE/rename loop must not be killed mid-run by another
+# dispatch — the partial state would leave half-renamed pairs.
+concurrency:
+  group: dd-pipeline
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-phantom-recovery-slugs.yml
+++ b/.github/workflows/cleanup-phantom-recovery-slugs.yml
@@ -1,10 +1,11 @@
 name: cleanup-phantom-recovery-slugs
 
 # One-shot cleanup for the 2026-05-01 recover_migration_wiped_sites.py run.
-# DELETEs the 11 wiped canonical-slug stubs and renames the 11 phantom
-# legacy-slug records onto their canonical slugs. After this runs, the
-# 11 sites that landed under wrong slugs are restored under canonical
-# slugs with their hydrated analytical fields intact.
+# DELETEs the 12 wiped canonical-slug stubs and renames the 12 stale
+# records (11 reporter-generated phantoms + 1 Miami Beach 300 typo'd
+# duplicate) onto their canonical slugs. After this runs, the 12 sites
+# that landed under wrong slugs are restored under canonical slugs with
+# their hydrated analytical fields intact.
 #
 # Manual dispatch only. Run with apply=false first to see the plan.
 

--- a/.github/workflows/copy-legacy-docs-to-m1.yml
+++ b/.github/workflows/copy-legacy-docs-to-m1.yml
@@ -35,6 +35,7 @@ jobs:
   copy-legacy-docs:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # Drive copy operation
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/daily-dd-check.yml
+++ b/.github/workflows/daily-dd-check.yml
@@ -22,6 +22,7 @@ jobs:
   daily-check:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60  # scheduled full-roster DD scan
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/delete-dashboard-slugs.yml
+++ b/.github/workflows/delete-dashboard-slugs.yml
@@ -41,6 +41,7 @@ jobs:
   delete:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 15  # small batch DELETE
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/provision-site-drive-folder.yml
+++ b/.github/workflows/provision-site-drive-folder.yml
@@ -34,6 +34,7 @@ jobs:
   provision:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 15  # single-site Drive provisioning
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/reconcile-dashboard.yml
+++ b/.github/workflows/reconcile-dashboard.yml
@@ -46,6 +46,7 @@ jobs:
   reconcile:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # roster reconcile
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/recover-migration-wiped-sites.yml
+++ b/.github/workflows/recover-migration-wiped-sites.yml
@@ -41,6 +41,10 @@ env:
 jobs:
   recover:
     runs-on: ubuntu-latest
+    # Cap the run so a hung Wrike/Drive call (or a 26-record loop that's
+    # somehow chewing through Rebl quotas one address at a time) doesn't
+    # sit at GitHub's default 6-hour ceiling burning Actions minutes.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -49,7 +53,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          # Pin to match cleanup-phantom-recovery-slugs.yml — `latest` would
+          # silently float to whichever uv version astral-sh ships next, which
+          # has bitten this repo before (lockfile resolution drift).
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/site-roster-sync.yml
+++ b/.github/workflows/site-roster-sync.yml
@@ -41,6 +41,7 @@ jobs:
   sync-roster:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30  # Wrike->roster sync
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-rebl-slugs.yml
+++ b/.github/workflows/validate-rebl-slugs.yml
@@ -43,6 +43,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 15  # Rebl slug validation pass
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/scripts/cleanup_phantom_recovery_slugs.py
+++ b/scripts/cleanup_phantom_recovery_slugs.py
@@ -13,16 +13,16 @@ the dashboard:
     14 sites: hydrated under their canonical slug (Update commits) ✓
      1 site: hydrated under the wrong existing slug (Miami Beach 300
              trace landed on 400-71st-st-miami-beach-fl) ✗
-    11 sites: published as new records under reporter-generated
+    12 sites: published as new records under reporter-generated
              legacy slugs (Add alpha-school-* commits). The wiped
              canonical-slug stubs were left untouched. ✗
 
-This script fixes the 11-phantom case in two steps per pair:
+This script fixes the 12-phantom case in two steps per pair:
   1. DELETE the wiped canonical-slug stub (it's empty).
   2. Rename the phantom legacy slug onto the canonical slug.
 
-Outcome: 11 canonical slugs become populated with the hydrated data
-the phantoms hold, 11 phantom legacy-slug records disappear.
+Outcome: 12 canonical slugs become populated with the hydrated data
+the phantoms hold, 12 phantom legacy-slug records disappear.
 
 Miami Beach 300 is handled separately (single re-run of the patched
 recovery script). This cleanup does NOT touch 400-71st-st-miami-beach-fl.
@@ -53,7 +53,13 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DASHBOARD_BASE_URL = "https://dd-dashboard-three.vercel.app"
+# Dashboard URL is overridable via env var so this script can be repointed at
+# a preview deployment for end-to-end tests without code changes. Mirrors the
+# pattern in scripts/recover_migration_wiped_sites.py (DASHBOARD_PUBLISH_URL).
+_DEFAULT_DASHBOARD_URL = "https://dd-dashboard-three.vercel.app"
+DASHBOARD_BASE_URL = (
+    os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_DASHBOARD_URL
+).rstrip("/")
 
 # Lightweight predicate for "this canonical-slug record looks like a wiped
 # stub." The recovery wipe leaves the slug present in sites.json but with
@@ -439,7 +445,7 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=(
             "Filter to a single phantom slug (substring match). "
-            "May be repeated. Default: process all 11 pairs."
+            "May be repeated. Default: process all 12 pairs."
         ),
     )
     args = parser.parse_args(argv)

--- a/scripts/cleanup_phantom_recovery_slugs.py
+++ b/scripts/cleanup_phantom_recovery_slugs.py
@@ -13,19 +13,18 @@ the dashboard:
     14 sites: hydrated under their canonical slug (Update commits) ✓
      1 site: hydrated under the wrong existing slug (Miami Beach 300
              trace landed on 400-71st-st-miami-beach-fl) ✗
-    12 sites: published as new records under reporter-generated
+    11 sites: published as new records under reporter-generated
              legacy slugs (Add alpha-school-* commits). The wiped
              canonical-slug stubs were left untouched. ✗
+  (14 + 1 + 11 = 26, matching the wiped-site count in recover_migration_wiped_sites.py.)
 
-This script fixes the 12-phantom case in two steps per pair:
+This script fixes both the 11-phantom case and the Miami Beach 300
+wrong-slug case via the same DELETE+rename per-pair procedure (12 pairs total):
   1. DELETE the wiped canonical-slug stub (it's empty).
   2. Rename the phantom legacy slug onto the canonical slug.
 
 Outcome: 12 canonical slugs become populated with the hydrated data
-the phantoms hold, 12 phantom legacy-slug records disappear.
-
-Miami Beach 300 is handled separately (single re-run of the patched
-recovery script). This cleanup does NOT touch 400-71st-st-miami-beach-fl.
+the stale records hold, 12 stale records disappear.
 
 Auth
 ----
@@ -445,7 +444,7 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=(
             "Filter to a single phantom slug (substring match). "
-            "May be repeated. Default: process all 12 pairs."
+            "May be repeated. Default: process all 12 pairs (11 phantoms + Miami Beach 300)."
         ),
     )
     args = parser.parse_args(argv)

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -208,8 +208,18 @@ def _recover_one(
             site_owner=site_owner,
             force_slug=dashboard_slug,
         )
-    except Exception as e:
-        logger.exception("%s [%s]: backfill_one raised: %s", title, dashboard_slug, e)
+    except Exception:
+        # logger.exception attaches the traceback automatically via exc_info=True.
+        # We intentionally don't %s-format the exception message here: backfill_one
+        # error strings have historically embedded the raw address (e.g. "failed to
+        # fetch trace for 123 Main St, Anytown XX"). Keeping the args slug-only and
+        # letting the traceback carry the detail keeps the single-line summary
+        # readable in GHA logs without re-leaking PII at the top level.
+        logger.exception(
+            "backfill_one raised for %s [slug=%s]",
+            title,
+            dashboard_slug,
+        )
         return False
 
 

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -67,7 +67,7 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     filter_active_site_records,
     load_wrike_config,
 )
-from due_diligence_reporter.rebl import canonical_slug_for_address  # noqa: E402
+from due_diligence_reporter.rebl import canonical_slugs_for_addresses  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -119,19 +119,30 @@ def _match_wrike_to_broken_sites(
     """Pair every Wrike active record with its broken dashboard slug, if any.
 
     Match strategy:
-      1. Resolve the Wrike record's address through Rebl. The dashboard
-         slug after migration *is* the Rebl canonical id, so equal Rebl
-         slugs are a hard match.
-      2. Skip records whose Rebl slug isn't in the broken set.
+      1. Batch-resolve every Wrike record's address through Rebl in a single
+         POST. The dashboard slug after migration *is* the Rebl canonical id,
+         so equal Rebl slugs are a hard match.
+      2. Skip records whose address is empty or whose Rebl slug isn't in the
+         broken set.
 
     Returns a list of (wrike_record, dashboard_slug) pairs to recover.
+
+    Why batch: the prior serial implementation issued one POST per Wrike
+    record. With ~80 active sites that's 80 sequential network calls, plus
+    80 chances to trip Rebl's rate limiter. ``canonical_slugs_for_addresses``
+    folds the entire list into one POST.
     """
-    pairs: list[tuple[dict[str, Any], str]] = []
+    addr_by_rec: list[tuple[dict[str, Any], str]] = []
     for rec in active_records:
         addr = (extract_address_from_record(rec) or "").strip()
-        if not addr:
-            continue
-        rebl_slug = canonical_slug_for_address(addr, fallback="")
+        if addr:
+            addr_by_rec.append((rec, addr))
+
+    slug_map = canonical_slugs_for_addresses([addr for _, addr in addr_by_rec])
+
+    pairs: list[tuple[dict[str, Any], str]] = []
+    for rec, addr in addr_by_rec:
+        rebl_slug = slug_map.get(addr) or ""
         if not rebl_slug:
             continue
         if rebl_slug in broken_by_slug:

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -177,14 +177,19 @@ def _recover_one(
         return False
 
     if dry_run:
+        # Mask PII (street address + site_owner name) from the dry-run log line.
+        # GHA workflow logs are visible to every collaborator on the repo, and
+        # the recover workflow runs across active sites whose owners may not
+        # have consented to having their name and street address surfaced in
+        # CI logs. The slug, school_type, and Drive URL are sufficient for an
+        # operator to identify a row at a glance; if the operator needs the
+        # full record, the Wrike record id is one click away.
         logger.info(
-            "DRY_RUN: would recover %s [slug=%s | drive=%s | addr=%s | type=%s | owner=%s]",
+            "DRY_RUN: would recover %s [slug=%s | drive=%s | type=%s]",
             title,
             dashboard_slug,
             drive_url,
-            address,
             school_type,
-            site_owner,
         )
         return True
 
@@ -210,15 +215,21 @@ def _recover_one(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    # Require an explicit choice to match cleanup_phantom_recovery_slugs.py's
+    # behavior: a missing flag now exits 2 rather than silently dry-running.
+    # In CI the workflow always passes one of --apply or --dry-run; locally,
+    # this prevents a careless `python recover_migration_wiped_sites.py` from
+    # being interpreted as "dry-run, but for real on the next paste."
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
         "--apply",
         action="store_true",
-        help="Actually issue POSTs to recover sites. Default is dry-run.",
+        help="Actually issue POSTs to recover sites.",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--dry-run",
         action="store_true",
-        help="Explicit dry-run (default behaviour). Mutually exclusive with --apply.",
+        help="Preview recovery actions without issuing POSTs.",
     )
     parser.add_argument(
         "--site",
@@ -229,15 +240,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if args.apply and args.dry_run:
-        logger.error("--apply and --dry-run are mutually exclusive")
-        return 2
-
     apply = bool(args.apply)
     if not apply:
-        logger.info(
-            "DRY_RUN mode (default). Pass --apply to actually issue POSTs."
-        )
+        logger.info("DRY_RUN mode. Pass --apply to actually issue POSTs.")
 
     if apply and not os.environ.get("DASHBOARD_PUBLISH_SECRET"):
         logger.error("--apply requires DASHBOARD_PUBLISH_SECRET in env")

--- a/src/due_diligence_reporter/rebl.py
+++ b/src/due_diligence_reporter/rebl.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -9,6 +10,8 @@ import requests
 from tenacity import retry
 
 from .retry import retry_config
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_REBL_BASE_URL = "https://rebl3.vercel.app"
 DEFAULT_REBL_TIMEOUT_SEC = 15.0
@@ -167,7 +170,17 @@ def canonical_slug_for_address(
             timeout=timeout,
             session=session,
         )
-    except Exception:  # network/runtime errors should not abort the caller
+    except Exception:
+        # Network/runtime errors must not abort the caller, but a totally
+        # silent fallback turns a Rebl outage into "every site mapped to
+        # title-slug" with no operator signal. Log at WARNING with a
+        # traceback so a Rebl-down incident is visible in run logs without
+        # changing the fallback behavior the callers rely on.
+        logger.warning(
+            "canonical_slug_for_address: Rebl resolve failed after retries; "
+            "falling back to caller-supplied slug",
+            exc_info=True,
+        )
         return fallback
     return result.site_id.strip() or fallback
 
@@ -199,6 +212,17 @@ def canonical_slugs_for_addresses(
             session=session,
         )
     except Exception:
+        # See the rationale on canonical_slug_for_address. A silent {} return
+        # during a Rebl outage looks identical to "nothing matched" in the
+        # recover/cleanup flows, so emit a single ERROR with traceback before
+        # falling back. Emitting once per batch (not per address) keeps log
+        # volume bounded under sustained outages.
+        logger.error(
+            "canonical_slugs_for_addresses: Rebl batch resolve failed after "
+            "retries; falling back to empty mapping (%d address(es) affected)",
+            len(cleaned),
+            exc_info=True,
+        )
         return {}
     out: dict[str, str] = {}
     for r in results:

--- a/src/due_diligence_reporter/rebl.py
+++ b/src/due_diligence_reporter/rebl.py
@@ -6,6 +6,9 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 import requests
+from tenacity import retry
+
+from .retry import retry_config
 
 DEFAULT_REBL_BASE_URL = "https://rebl3.vercel.app"
 DEFAULT_REBL_TIMEOUT_SEC = 15.0
@@ -66,6 +69,7 @@ def _parse_resolution_item(address: str, item: Any) -> ReblResolution:
     )
 
 
+@retry(**retry_config())  # type: ignore[untyped-decorator]
 def resolve_addresses(
     addresses: list[str],
     *,
@@ -73,7 +77,15 @@ def resolve_addresses(
     timeout: float = DEFAULT_REBL_TIMEOUT_SEC,
     session: Any = requests,
 ) -> list[ReblResolution]:
-    """Resolve a batch of site addresses to canonical REBL site IDs."""
+    """Resolve a batch of site addresses to canonical REBL site IDs.
+
+    Wrapped in the standard ``retry_config`` so transient 429 (rate limit) and
+    5xx responses are retried with the project's rate-limit-aware backoff,
+    rather than collapsing into a single "REBL resolve 429" RuntimeError that
+    callers would interpret as a permanent address miss. Empty payloads are
+    short-circuited before the network call so the retry decorator never runs
+    on a no-op.
+    """
     payload = [{"address": address.strip()} for address in addresses if address.strip()]
     if not payload:
         return []
@@ -84,8 +96,11 @@ def resolve_addresses(
         headers={"Content-Type": "application/json"},
         timeout=timeout,
     )
-    if not response.ok:
-        raise RuntimeError(f"REBL resolve {response.status_code}: {response.text[:200]}")
+    # Use raise_for_status so 429/5xx surface as requests.HTTPError, which the
+    # shared retry decorator's `_is_retryable_http_error` recognizes. The old
+    # `RuntimeError("REBL resolve 429: ...")` was opaque to the retry layer
+    # and made every rate-limited call look like a permanent failure.
+    response.raise_for_status()
 
     body = response.json()
     if not isinstance(body, list):

--- a/src/due_diligence_reporter/retry.py
+++ b/src/due_diligence_reporter/retry.py
@@ -63,10 +63,28 @@ def _parse_retry_after_seconds(exc: BaseException) -> float | None:
         except (ValueError, OSError):
             pass
 
-    # Standard Retry-After header (integer seconds)
+    # Standard Retry-After header (integer seconds).
+    #
+    # The header lives in different places depending on exception type:
+    #   * googleapiclient.errors.HttpError exposes ``exc.headers`` directly.
+    #   * requests.HTTPError carries the response on ``exc.response``;
+    #     the headers are at ``exc.response.headers``.
+    #
+    # The original ``hasattr(exc, "headers")`` check returned False for
+    # requests.HTTPError, which silently disabled rate-limit-aware waits
+    # for every HTTP client (Rebl, dashboard publish, etc.). Probe both
+    # locations so a 429 from a requests-based client is honored.
+    candidate_headers: Any = None
     if hasattr(exc, "headers"):
-        header = getattr(exc, "headers", {}).get("Retry-After")
-        if header and header.isdigit():
+        candidate_headers = getattr(exc, "headers", None)
+    response = getattr(exc, "response", None)
+    if response is not None and hasattr(response, "headers"):
+        # When both are present, prefer the response (HTTP wire value) over
+        # whatever the SDK set on the exception itself.
+        candidate_headers = response.headers
+    if candidate_headers:
+        header = candidate_headers.get("Retry-After")
+        if header and str(header).isdigit():
             return float(header)
 
     return None

--- a/tests/test_rebl.py
+++ b/tests/test_rebl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import requests
 
 from due_diligence_reporter.rebl import (
     ReblResolution,
@@ -10,6 +11,10 @@ from due_diligence_reporter.rebl import (
     resolve_addresses,
 )
 from due_diligence_reporter.server import _build_report_trace_data
+
+# resolve_addresses is wrapped in @retry; tests of error paths call the
+# underlying function directly to avoid 5x retry latency on synthetic 5xx.
+_resolve_addresses_unwrapped = resolve_addresses.__wrapped__
 
 
 class _FakeResponse:
@@ -21,6 +26,14 @@ class _FakeResponse:
 
     def json(self):
         return self._body
+
+    def raise_for_status(self) -> None:
+        # Mirror requests.Response.raise_for_status so the production code's
+        # retry-aware error path runs the same way it does in prod.
+        if not self.ok:
+            err = requests.HTTPError(f"{self.status_code} Server Error")
+            err.response = self  # type: ignore[assignment]
+            raise err
 
 
 class _FakeSession:
@@ -74,8 +87,14 @@ class TestResolveAddresses:
             text="service unavailable",
         ))
 
-        with pytest.raises(RuntimeError, match="REBL resolve 503"):
-            resolve_addresses(["123 Main St, Austin, TX"], session=session)
+        # Call the unwrapped function so we don't pay the retry decorator's
+        # 5-attempt exponential backoff on a deterministic 5xx fixture. The
+        # production retry behavior (5xx -> retry -> reraise) is asserted by
+        # the dedicated retry tests in test_retry.py.
+        with pytest.raises(requests.HTTPError):
+            _resolve_addresses_unwrapped(
+                ["123 Main St, Austin, TX"], session=session,
+            )
 
 
 class TestCanonicalSlugForAddress:

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -96,15 +96,14 @@ class TestMatchWrikeToBrokenSites:
         def fake_extract_address(rec: dict) -> str:
             return rec["_test_address"]
 
-        def fake_rebl(addr: str, fallback: str = "") -> str:
-            return {
-                "421 E 11th St, Tulsa, OK": "421-e-11th-st-tulsa-ok",
-                "1726 Whitley Ave, Los Angeles, CA": "1726-whitley-ave-los-angeles-ca",
-                "999 Healthy Way, Austin, TX": "999-healthy-way-austin-tx",
-            }.get(addr, fallback)
+        slug_map = {
+            "421 E 11th St, Tulsa, OK": "421-e-11th-st-tulsa-ok",
+            "1726 Whitley Ave, Los Angeles, CA": "1726-whitley-ave-los-angeles-ca",
+            "999 Healthy Way, Austin, TX": "999-healthy-way-austin-tx",
+        }
 
         with patch.object(recover, "extract_address_from_record", side_effect=fake_extract_address), \
-             patch.object(recover, "canonical_slug_for_address", side_effect=fake_rebl):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value=slug_map):
             pairs = recover._match_wrike_to_broken_sites(records, broken)
 
         assert len(pairs) == 2
@@ -116,28 +115,29 @@ class TestMatchWrikeToBrokenSites:
         records = [self._make_record("")]
 
         with patch.object(recover, "extract_address_from_record", return_value=""), \
-             patch.object(recover, "canonical_slug_for_address", return_value="any-slug"):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value={}):
             pairs = recover._match_wrike_to_broken_sites(records, broken)
 
         assert pairs == []
 
     def test_skips_records_rebl_cannot_resolve(self) -> None:
-        # Rebl returns "" (the fallback) when it can't find the address.
-        # Such a record can't be matched to any broken slug.
+        # Rebl drops unresolvable addresses from the returned mapping; an
+        # address with no slug entry can't be matched to any broken slug.
         broken = {"any-slug": {"slug": "any-slug"}}
         records = [self._make_record("Unknown Address")]
 
         with patch.object(recover, "extract_address_from_record", return_value="Unknown Address"), \
-             patch.object(recover, "canonical_slug_for_address", return_value=""):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value={}):
             pairs = recover._match_wrike_to_broken_sites(records, broken)
 
         assert pairs == []
 
     def test_returns_empty_when_no_broken_sites(self) -> None:
         records = [self._make_record("123 Main St, Austin, TX")]
+        slug_map = {"123 Main St, Austin, TX": "123-main-st-austin-tx"}
 
         with patch.object(recover, "extract_address_from_record", return_value="123 Main St, Austin, TX"), \
-             patch.object(recover, "canonical_slug_for_address", return_value="123-main-st-austin-tx"):
+             patch.object(recover, "canonical_slugs_for_addresses", return_value=slug_map):
             pairs = recover._match_wrike_to_broken_sites(records, broken_by_slug={})
 
         assert pairs == []

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
 
@@ -244,8 +246,10 @@ class TestRecoverOneThreadsForceSlug:
         assert ok is False
         mock_backfill.assert_not_called()
 
-    def test_recover_one_returns_false_when_backfill_raises(self) -> None:
-        """backfill_one exceptions must be caught and surfaced as False.
+    def test_recover_one_returns_false_when_backfill_raises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """backfill_one exceptions must be caught, logged, and surfaced as False.
 
         The recovery loop processes ~26 records; one transient publisher
         error must not abort the whole run. ``_recover_one`` is responsible
@@ -254,17 +258,28 @@ class TestRecoverOneThreadsForceSlug:
         stays accurate. If this guard regresses, the recover_migration
         workflow becomes "all-or-nothing" and a single 502 from the publish
         endpoint loses the rest of the batch.
+
+        We also assert that:
+          1. ``logger.exception`` (ERROR level + traceback) fires — the only
+             operator signal that a site silently failed.
+          2. The exception message text (which historically embeds raw
+             addresses, e.g. "publish endpoint 502 for 123 Main St") is NOT
+             %s-formatted into the top-level log line. The traceback may
+             carry it, but the summary line must be slug-only so PII
+             doesn't appear in the run summary that operators skim.
         """
         rec = self._make_record()
+        leak_marker = "123-Main-St-PII-leak-marker"
 
         def raising_backfill(*args, **kwargs):
-            raise RuntimeError("publish endpoint 502")
+            raise RuntimeError(f"publish endpoint 502 for {leak_marker}")
 
         with patch.object(recover, "backfill_one", side_effect=raising_backfill), \
              patch.object(recover, "extract_address_from_record", return_value=rec["_test_address"]), \
              patch.object(recover, "extract_google_folder_from_record", return_value=rec["_test_drive"]), \
              patch.object(recover, "extract_school_type_from_record", return_value="K-8"), \
-             patch.object(recover, "extract_p1_from_record", return_value={"name": "Greg"}):
+             patch.object(recover, "extract_p1_from_record", return_value={"name": "Greg"}), \
+             caplog.at_level("ERROR", logger="recover_migration_wiped_sites"):
             ok = recover._recover_one(
                 gc=None,
                 rec=rec,
@@ -273,3 +288,16 @@ class TestRecoverOneThreadsForceSlug:
             )
 
         assert ok is False
+        # Operator-visibility guarantee: logger.exception fired at ERROR level.
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert error_records, "backfill failure must surface an ERROR log"
+        assert any(r.exc_info for r in error_records), (
+            "logger.exception must attach the traceback (exc_info)"
+        )
+        # PII guarantee: the formatted top-level message must not contain the
+        # raw exception text. The traceback may; the summary line must not.
+        summary_messages = [r.getMessage() for r in error_records]
+        assert all(leak_marker not in msg for msg in summary_messages), (
+            "exception message must not be %%s-formatted into the summary line; "
+            f"got: {summary_messages!r}"
+        )

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -216,3 +216,60 @@ class TestRecoverOneThreadsForceSlug:
 
         assert ok is True
         mock_backfill.assert_not_called()
+
+    def test_recover_one_returns_false_on_empty_drive_url(self) -> None:
+        """A Wrike record with no Drive folder cannot be recovered.
+
+        ``_recover_one`` returns False without calling backfill_one. Without
+        this guard the publisher would be invoked with an empty drive URL,
+        crash deep inside the trace fetcher, and leave the run in an
+        ambiguous "site present in matched pairs but no Update commit"
+        state for the operator to untangle. The early False keeps the
+        failed-list accounting honest.
+        """
+        rec = self._make_record()
+
+        with patch.object(recover, "backfill_one") as mock_backfill, \
+             patch.object(recover, "extract_address_from_record", return_value=rec["_test_address"]), \
+             patch.object(recover, "extract_google_folder_from_record", return_value=""), \
+             patch.object(recover, "extract_school_type_from_record", return_value="K-8"), \
+             patch.object(recover, "extract_p1_from_record", return_value={"name": "Greg"}):
+            ok = recover._recover_one(
+                gc=None,
+                rec=rec,
+                dashboard_slug="any-slug",
+                dry_run=False,
+            )
+
+        assert ok is False
+        mock_backfill.assert_not_called()
+
+    def test_recover_one_returns_false_when_backfill_raises(self) -> None:
+        """backfill_one exceptions must be caught and surfaced as False.
+
+        The recovery loop processes ~26 records; one transient publisher
+        error must not abort the whole run. ``_recover_one`` is responsible
+        for catching the exception, logging it, and returning False so the
+        loop can continue to the next site and the failed-list accounting
+        stays accurate. If this guard regresses, the recover_migration
+        workflow becomes "all-or-nothing" and a single 502 from the publish
+        endpoint loses the rest of the batch.
+        """
+        rec = self._make_record()
+
+        def raising_backfill(*args, **kwargs):
+            raise RuntimeError("publish endpoint 502")
+
+        with patch.object(recover, "backfill_one", side_effect=raising_backfill), \
+             patch.object(recover, "extract_address_from_record", return_value=rec["_test_address"]), \
+             patch.object(recover, "extract_google_folder_from_record", return_value=rec["_test_drive"]), \
+             patch.object(recover, "extract_school_type_from_record", return_value="K-8"), \
+             patch.object(recover, "extract_p1_from_record", return_value={"name": "Greg"}):
+            ok = recover._recover_one(
+                gc=None,
+                rec=rec,
+                dashboard_slug="any-slug",
+                dry_run=False,
+            )
+
+        assert ok is False


### PR DESCRIPTION
## What

Hygiene cleanup on the reporter side and `_recover_one` regression coverage — closes the remaining iter1 `/check` Important findings (docstring drift, env-var override, CLI consistency, PII in CI logs, missing tests).

## Why

| Finding | Source | Status |
|---|---|---|
| `cleanup_phantom_recovery_slugs.py` docstring + `--pair` help still say "11" after PR #67 added the 12th pair | Quality I-3 | **Fixed here** |
| `cleanup_phantom_recovery_slugs.py` `DASHBOARD_BASE_URL` is a hard-coded constant — can't be repointed at preview without a code edit | Quality I-1 | **Fixed here** |
| `recover_migration_wiped_sites.py` accepts no flag and silently dry-runs; cleanup script requires the caller to pick — operator foot-gun | Quality I-7 / DX | **Fixed here** |
| `_recover_one` dry-run logs full street address + site_owner name to GHA workflow logs (visible to every repo collaborator) | Safety I-9 / Privacy | **Fixed here** |
| No regression coverage for the two `_recover_one` early-False paths (empty Drive URL, backfill_one raises) | Quality I-6 / IMP-Q5 | **Fixed here** |

## How

### Docstring drift: 11 → 12

Three places hard-code the phantom-pair count; PR #67 added a 12th pair (Burlingame Park Rd) but didn't sweep the doc strings. Updated:
- `scripts/cleanup_phantom_recovery_slugs.py` lines 16, 20, 24, 25 (module docstring)
- `scripts/cleanup_phantom_recovery_slugs.py` line 442 (`--pair` argparse help)
- `.github/workflows/cleanup-phantom-recovery-slugs.yml` line 23 (input description)

### Env-var-overridable DASHBOARD_BASE_URL

`cleanup_phantom_recovery_slugs.py:56`:
```python
_DEFAULT_DASHBOARD_URL = "https://dd-dashboard-three.vercel.app"
DASHBOARD_BASE_URL = (
    os.environ.get("DASHBOARD_PUBLISH_URL") or _DEFAULT_DASHBOARD_URL
).rstrip("/")
```
Mirrors the pattern in `recover_migration_wiped_sites.py:_dashboard_base_url`. Same env-var name (`DASHBOARD_PUBLISH_URL`) so an operator can set it once for both scripts.

### CLI flag consistency

`recover_migration_wiped_sites.py` switched to:
```python
mode = parser.add_mutually_exclusive_group(required=True)
mode.add_argument("--apply", action="store_true", ...)
mode.add_argument("--dry-run", action="store_true", ...)
```
A missing flag now exits 2 instead of silently dry-running. Matches the cleanup script's behavior and prevents a careless `python recover_migration_wiped_sites.py` from being interpreted as "dry-run, but for real on the next paste."

In CI both `recover-migration-wiped-sites.yml:144-149` and `cleanup-phantom-recovery-slugs.yml:62-66` always pass one of `--apply` or `--dry-run`, so this is a no-op for the workflow path. It only changes ad-hoc local invocations.

### PII masking in dry-run logs

`_recover_one` dry-run log line:
```python
# before
"DRY_RUN: would recover %s [slug=%s | drive=%s | addr=%s | type=%s | owner=%s]"

# after
"DRY_RUN: would recover %s [slug=%s | drive=%s | type=%s]"
```
GHA workflow logs are visible to every collaborator on the repo. Slug + school_type + Drive URL are enough to identify a row; the Wrike record id is one click away if an operator needs the full record.

### `_recover_one` regression tests

Two new tests in `tests/test_recover_migration_wiped_sites.py::TestRecoverOneThreadsForceSlug`:

- `test_recover_one_returns_false_on_empty_drive_url` — asserts a Wrike record with no Drive folder returns False without ever calling `backfill_one`. Without this guard the publisher would crash deep inside the trace fetcher and leave failed-list accounting wrong.
- `test_recover_one_returns_false_when_backfill_raises` — asserts a publisher exception is caught and surfaced as False so the recovery loop continues to the next site. If this guard regresses, recover becomes "all-or-nothing" and a single 502 loses the rest of the batch.

## Test

```bash
uv run pytest tests/test_recover_migration_wiped_sites.py \
              tests/test_cleanup_phantom_recovery_slugs.py -q
# 63 passed
uv run pytest -q --deselect tests/test_permit_history.py::test_trace_supplemental_evidence_included_for_non_template_keys \
                 --deselect tests/test_permit_history.py::test_trace_supplemental_evidence_omitted_when_empty \
                 --deselect tests/test_permit_history.py::test_trace_supplemental_evidence_template_keys_not_duplicated
# 942 passed
```
3 deselected failures are pre-existing on main (rebl_resolution kwarg drift in `_build_report_trace_data`).

CLI smoke test:
```
$ uv run python scripts/recover_migration_wiped_sites.py
usage: recover_migration_wiped_sites.py [-h] (--apply | --dry-run) [--site SITE]
error: one of the arguments --apply --dry-run is required
```

## Risk

Workflow path unchanged — both YAMLs always pass an explicit mode flag. The CLI break only affects ad-hoc local invocations, which is the desired behavior. Docstring/help-text changes are no-ops at runtime. PII removal strictly reduces the log surface and operators can recover the missing fields from Wrike.
