### PR TITLE
Tier 3: reporter polish (uv pin sweep, Retry-After cap+tests, argparse test, CHANGELOG)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,5 +77,8 @@ DASHBOARD_REPO_BRANCH=main
 DASHBOARD_PUBLISH_URL=
 # Bearer token shared with dd-dashboard's /api/sites/* endpoints. Required
 # for any --apply run; recover/cleanup scripts hard-fail if missing in
-# apply mode. Generate via the dashboard repo's deployment env.
+# apply mode. Generate with: openssl rand -hex 32
+# Set the same value in the dashboard repo's Vercel project secrets so
+# both sides authenticate against the same token. Rotate by generating
+# a new value, deploying it to dd-dashboard first, then updating here.
 DASHBOARD_PUBLISH_SECRET=

--- a/.github/workflows/backfill-dashboard.yml
+++ b/.github/workflows/backfill-dashboard.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/backfill-doc-readiness.yml
+++ b/.github/workflows/backfill-doc-readiness.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/copy-legacy-docs-to-m1.yml
+++ b/.github/workflows/copy-legacy-docs-to-m1.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/daily-dd-check.yml
+++ b/.github/workflows/daily-dd-check.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/delete-dashboard-slugs.yml
+++ b/.github/workflows/delete-dashboard-slugs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/provision-site-drive-folder.yml
+++ b/.github/workflows/provision-site-drive-folder.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/raycon-followup.yml
+++ b/.github/workflows/raycon-followup.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/reconcile-dashboard.yml
+++ b/.github/workflows/reconcile-dashboard.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/reprocess-mislabeled.yml
+++ b/.github/workflows/reprocess-mislabeled.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/site-roster-sync.yml
+++ b/.github/workflows/site-roster-sync.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/validate-rebl-slugs.yml
+++ b/.github/workflows/validate-rebl-slugs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.14"
 
       - name: Install dependencies
         run: uv sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,12 @@ changes do not get an entry.
   that use `astral-sh/setup-uv`. Previously most workflows used
   `version: "latest"`, which let lockfile-incompatible uv releases land
   silently between runs.
-- **`DASHBOARD_PUBLISH_URL` and `DASHBOARD_PUBLISH_SECRET` in
-  `.env.example`.** These were previously undocumented; the recover
-  script and dashboard publish flow both require them.
+- **`DASHBOARD_PUBLISH_SECRET` rotation procedure documented in
+  `.env.example`.** The variable itself was added in a prior change
+  (the workflow-hardening / Rebl batch / 429-aware retry release);
+  this entry adds the `openssl rand -hex 32` generation hint, the
+  Vercel-secret sync requirement, and the rotation order (deploy to
+  dd-dashboard first, then update here).
 
 ### Operator notes
 
@@ -49,13 +52,17 @@ endpoint via `canonical_slugs_for_addresses()`. Both an outage and a
 legitimate empty result return `{}`, but only the outage path logs:
 
 - **Rebl is down or rate-limited past the retry budget** (outage):
-  the wrapper logs at `ERROR` with `"canonical_slugs_for_addresses:
+  the batch wrapper logs at `ERROR` with `"canonical_slugs_for_addresses:
   Rebl batch resolve failed after retries; falling back to empty
   mapping (N address(es) affected)"` *with a traceback (`exc_info`)*
-  before returning `{}`. Equivalent ERROR for the singleton path:
-  `"canonical_slug_for_address: Rebl resolve failed after retries…"`
-  at `WARNING` level (singleton has caller fallback). Both originate
-  from the `due_diligence_reporter.rebl` logger.
+  before returning `{}`. The singleton wrapper logs the equivalent
+  message at `WARNING` level (it has a caller-supplied fallback so the
+  call site can still proceed) — `"canonical_slug_for_address: Rebl
+  resolve failed after retries…"` — also with `exc_info`. Both
+  originate from the `due_diligence_reporter.rebl` logger.
+  **Operator note:** if you grep only for `ERROR` during an incident,
+  you will miss singleton-path failures. Filter for the
+  `due_diligence_reporter.rebl` logger and include `WARNING`.
 - **Rebl returned a result but no addresses resolved** (legitimate
   empty / nothing-matched): silent — no log line. The wrapper just
   returns `{}`. This is normal when Rebl has not yet indexed a fresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to the Due Diligence Reporter that affect operators,
+CI workflows, or external integrations.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/),
+but only entries that change observable behavior or operator contracts are
+recorded here. Internal refactors, test additions, and pure documentation
+changes do not get an entry.
+
+## [Unreleased]
+
+### Changed
+
+- **`scripts/recover_migration_wiped_sites.py`: `--apply` / `--dry-run` are
+  now a required mutually-exclusive group.** Previously, a bare invocation
+  silently dry-ran. It now exits 2 with an argparse usage error. Every CI
+  workflow that calls this script must pass exactly one of `--apply` or
+  `--dry-run`. The `recover-migration-wiped-sites.yml` workflow already
+  threads the appropriate flag from its dispatch input; ad-hoc local runs
+  must do the same.
+
+### Added
+
+- **Retry-After parser hardening (`src/due_diligence_reporter/retry.py`).**
+  `_parse_retry_after_seconds` now reads the header from both `exc.headers`
+  (Google API style) and `exc.response.headers` (`requests.HTTPError`
+  style). Prior to this change, every `requests`-based 429 fell back to
+  exponential backoff because the Retry-After path was silently disabled.
+  Affects Rebl, dashboard publish, and any other `requests`-based client.
+- **Retry-After parser cap (defense-in-depth).** The parser now caps
+  the returned value at 1200 seconds (20 minutes). The downstream wait
+  strategy was already capping; the parser-level cap protects callers
+  that bypass the wait strategy.
+- **uv version pinned to `0.5.14` across all GitHub Actions workflows**
+  that use `astral-sh/setup-uv`. Previously most workflows used
+  `version: "latest"`, which let lockfile-incompatible uv releases land
+  silently between runs.
+- **`DASHBOARD_PUBLISH_URL` and `DASHBOARD_PUBLISH_SECRET` in
+  `.env.example`.** These were previously undocumented; the recover
+  script and dashboard publish flow both require them.
+
+### Operator notes
+
+#### Rebl outage vs. "no matches" — log signature
+
+The recovery and validation scripts call Rebl's batch slug-resolution
+endpoint via `canonical_slugs_for_addresses()`. Both an outage and a
+legitimate empty result return `{}`, but only the outage path logs:
+
+- **Rebl is down or rate-limited past the retry budget** (outage):
+  the wrapper logs at `ERROR` with `"canonical_slugs_for_addresses:
+  Rebl batch resolve failed after retries; falling back to empty
+  mapping (N address(es) affected)"` *with a traceback (`exc_info`)*
+  before returning `{}`. Equivalent ERROR for the singleton path:
+  `"canonical_slug_for_address: Rebl resolve failed after retries…"`
+  at `WARNING` level (singleton has caller fallback). Both originate
+  from the `due_diligence_reporter.rebl` logger.
+- **Rebl returned a result but no addresses resolved** (legitimate
+  empty / nothing-matched): silent — no log line. The wrapper just
+  returns `{}`. This is normal when Rebl has not yet indexed a fresh
+  batch of records.
+
+To tell them apart in workflow logs: look for an ERROR (or WARNING
+for the singleton path) from `due_diligence_reporter.rebl` with a
+traceback. Its presence means outage; its absence means Rebl was
+healthy and just had nothing for these addresses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,17 @@ changes do not get an entry.
   style). Prior to this change, every `requests`-based 429 fell back to
   exponential backoff because the Retry-After path was silently disabled.
   Affects Rebl, dashboard publish, and any other `requests`-based client.
-- **Retry-After parser cap (defense-in-depth).** The parser now caps
-  the returned value at 1200 seconds (20 minutes). The downstream wait
-  strategy was already capping; the parser-level cap protects callers
-  that bypass the wait strategy.
+- **Retry-After parser cap on the integer-header branch (defense-in-depth).**
+  `_parse_retry_after_seconds` now caps the value returned from the
+  integer-header branch at `_RETRY_AFTER_MAX_SECONDS` (1200 seconds /
+  20 minutes) and emits a `WARNING` on the
+  `due_diligence_reporter.retry` logger when the upstream value
+  exceeds the cap. The ISO-timestamp branch remains uncapped at the
+  parser level by design — `_rate_limit_aware_wait` clips both branches
+  via `min(parsed, _RETRY_AFTER_MAX_SECONDS)` so callers that go through
+  the wait strategy are protected on both paths. The parser-level cap
+  exists for callers that bypass the wait strategy (e.g. one-shot
+  diagnostics) and for the per-call WARNING signal.
 - **uv version pinned to `0.5.14` across all GitHub Actions workflows**
   that use `astral-sh/setup-uv`. Previously most workflows used
   `version: "latest"`, which let lockfile-incompatible uv releases land

--- a/scripts/recover_migration_wiped_sites.py
+++ b/scripts/recover_migration_wiped_sites.py
@@ -26,6 +26,13 @@ Run
     uv run python scripts/recover_migration_wiped_sites.py --apply
     uv run python scripts/recover_migration_wiped_sites.py --apply --site austin
 
+BREAKING CHANGE (2026-05-01)
+----------------------------
+``--apply`` and ``--dry-run`` are now a *required* mutually-exclusive group.
+A bare invocation (``python recover_migration_wiped_sites.py``) used to
+silently dry-run; it now exits 2 with a usage error. CI workflows must
+always pass exactly one of the two flags. See ``CHANGELOG.md`` for context.
+
 Env (from .env):
     DASHBOARD_PUBLISH_URL, DASHBOARD_PUBLISH_SECRET
     plus the usual pipeline env (Wrike, Google)

--- a/src/due_diligence_reporter/retry.py
+++ b/src/due_diligence_reporter/retry.py
@@ -92,7 +92,15 @@ def _parse_retry_after_seconds(exc: BaseException) -> float | None:
     if candidate_headers:
         header = candidate_headers.get("Retry-After")
         if header and str(header).isdigit():
-            return min(float(header), _RETRY_AFTER_MAX_SECONDS)
+            value = float(header)
+            if value > _RETRY_AFTER_MAX_SECONDS:
+                logger.warning(
+                    "Retry-After header %s exceeds cap %.0fs; clamping",
+                    header,
+                    _RETRY_AFTER_MAX_SECONDS,
+                )
+                return _RETRY_AFTER_MAX_SECONDS
+            return value
 
     return None
 
@@ -125,8 +133,10 @@ def _rate_limit_aware_wait(retry_state: RetryCallState) -> float:
     if exc is not None:
         wait_secs = _parse_retry_after_seconds(exc)
         if wait_secs is not None:
-            # Cap at 20 minutes to avoid infinite waits
-            capped = min(wait_secs, 1200)
+            # Cap at 20 minutes to avoid infinite waits. Use the shared
+            # constant so the parser-level cap (header path) and caller-level
+            # cap (covers ISO-timestamp path) stay locked together.
+            capped = min(wait_secs, _RETRY_AFTER_MAX_SECONDS)
             logger.info(
                 "Rate limited — waiting %.0f seconds before retry (attempt %d/%d)",
                 capped,

--- a/src/due_diligence_reporter/retry.py
+++ b/src/due_diligence_reporter/retry.py
@@ -38,6 +38,13 @@ BACKOFF_MAX = 30
 
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
+# Defense-in-depth: cap parsed Retry-After at 20 minutes inside the parser
+# itself so a malicious or buggy upstream returning ``Retry-After: 99999999``
+# can't blow up the wait calculation in callers that forget to cap it. The
+# downstream ``_rate_limit_aware_wait`` also caps at 1200, so this is
+# belt-and-suspenders.
+_RETRY_AFTER_MAX_SECONDS = 1200.0
+
 
 def _parse_retry_after_seconds(exc: BaseException) -> float | None:
     """Extract the number of seconds to wait from a 429 response.
@@ -85,7 +92,7 @@ def _parse_retry_after_seconds(exc: BaseException) -> float | None:
     if candidate_headers:
         header = candidate_headers.get("Retry-After")
         if header and str(header).isdigit():
-            return float(header)
+            return min(float(header), _RETRY_AFTER_MAX_SECONDS)
 
     return None
 

--- a/src/due_diligence_reporter/retry.py
+++ b/src/due_diligence_reporter/retry.py
@@ -26,7 +26,10 @@ from tenacity import (
     wait_exponential,
 )
 
-logger = logging.getLogger("[retry]")
+# Use the module's dotted name so log filters scoped to
+# ``due_diligence_reporter.*`` capture our records (matches the
+# ``due_diligence_reporter.rebl`` and ``.run`` loggers used elsewhere).
+logger = logging.getLogger(__name__)
 
 # Max 5 attempts total (1 initial + 4 retries) — enough to survive a
 # Gmail API 429 with a ~15-minute coolback window.

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -329,10 +329,17 @@ class TestMainArgparseContract:
     def test_main_rejects_apply_and_dry_run_together(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """--apply and --dry-run are mutually exclusive."""
+        """--apply and --dry-run are mutually exclusive.
+
+        We assert the argparse mutex error string "not allowed with"
+        directly. ``--dry-run`` always appears in the usage line on any
+        argparse error, so a fallback like ``"--dry-run" in captured.err``
+        would silently survive a regression that removed the mutex group.
+        """
         with pytest.raises(SystemExit) as exc_info:
             recover.main(["--apply", "--dry-run"])
         assert exc_info.value.code == 2
         captured = capsys.readouterr()
-        assert "not allowed with" in captured.err.lower() or \
-               "--dry-run" in captured.err
+        assert "not allowed with" in captured.err.lower(), (
+            f"Expected argparse mutex error 'not allowed with' in stderr; got: {captured.err!r}"
+        )

--- a/tests/test_recover_migration_wiped_sites.py
+++ b/tests/test_recover_migration_wiped_sites.py
@@ -301,3 +301,38 @@ class TestRecoverOneThreadsForceSlug:
             "exception message must not be %%s-formatted into the summary line; "
             f"got: {summary_messages!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# main() argparse contract
+#
+# The script uses a required mutually-exclusive group for --apply / --dry-run
+# (see scripts/recover_migration_wiped_sites.py). A CI workflow that forgets
+# to pass either flag must fail loudly rather than silently dry-run, since the
+# old behavior (no flag = dry-run) was a footgun.
+# ---------------------------------------------------------------------------
+
+
+class TestMainArgparseContract:
+    def test_main_exits_when_neither_apply_nor_dry_run_passed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Bare invocation must argparse-exit, not silently dry-run."""
+        with pytest.raises(SystemExit) as exc_info:
+            recover.main([])
+        # argparse exits 2 on usage errors.
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "--apply" in captured.err
+        assert "--dry-run" in captured.err
+
+    def test_main_rejects_apply_and_dry_run_together(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--apply and --dry-run are mutually exclusive."""
+        with pytest.raises(SystemExit) as exc_info:
+            recover.main(["--apply", "--dry-run"])
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "not allowed with" in captured.err.lower() or \
+               "--dry-run" in captured.err

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -195,6 +195,53 @@ class TestParseRetryAfterSeconds:
         assert result is not None
         assert result == 1  # max(negative + 5, 1) = 1
 
+    def test_parses_retry_after_from_response_headers(self) -> None:
+        """requests.HTTPError carries the header on exc.response.headers.
+
+        Regression test for the iter1 fix: prior to the dual-source probe,
+        ``hasattr(exc, "headers")`` returned False for requests.HTTPError
+        and rate-limit-aware waits were silently disabled for every
+        requests-based client (Rebl, dashboard publish, etc.).
+        """
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "45"}
+        exc = requests.HTTPError(response=response)
+        assert _parse_retry_after_seconds(exc) == 45.0
+
+    def test_parses_retry_after_from_exc_headers(self) -> None:
+        """googleapiclient.errors.HttpError exposes headers directly on the exception."""
+
+        class _FakeGoogleHttpError(Exception):
+            headers = {"Retry-After": "30"}
+
+        assert _parse_retry_after_seconds(_FakeGoogleHttpError()) == 30.0
+
+    def test_caps_retry_after_at_20_minutes(self) -> None:
+        """Defense-in-depth: cap parsed Retry-After at 1200s in the parser."""
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "999999999"}
+        exc = requests.HTTPError(response=response)
+        assert _parse_retry_after_seconds(exc) == 1200.0
+
+    def test_ignores_non_integer_retry_after_header(self) -> None:
+        """HTTP-date format is not handled; non-digit headers return None."""
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        exc = requests.HTTPError(response=response)
+        assert _parse_retry_after_seconds(exc) is None
+
+    def test_response_headers_take_precedence_over_exc_headers(self) -> None:
+        """When both exc.headers and exc.response.headers exist, prefer the wire value."""
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "60"}
+
+        class _DualSource(Exception):
+            headers = {"Retry-After": "10"}
+
+        exc = _DualSource()
+        exc.response = response  # type: ignore[attr-defined]
+        assert _parse_retry_after_seconds(exc) == 60.0
+
 
 # ---------------------------------------------------------------------------
 # Wrike _wrike_get integration test

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -219,11 +219,31 @@ class TestParseRetryAfterSeconds:
         assert _parse_retry_after_seconds(_FakeGoogleHttpError()) == 30.0
 
     def test_caps_retry_after_at_20_minutes(self) -> None:
-        """Defense-in-depth: cap parsed Retry-After at 1200s in the parser."""
+        """Defense-in-depth: cap parsed Retry-After at the constant in the parser.
+
+        Asserts against ``_RETRY_AFTER_MAX_SECONDS`` so that if the cap
+        ever shifts, this test follows in lockstep with production code.
+        /check iter2 IMP-C caught the prior literal ``1200.0`` here
+        defeating iter1's constant unification.
+        """
         response = MagicMock(spec=requests.Response)
         response.headers = {"Retry-After": "999999999"}
         exc = requests.HTTPError(response=response)
-        assert _parse_retry_after_seconds(exc) == 1200.0
+        assert _parse_retry_after_seconds(exc) == _RETRY_AFTER_MAX_SECONDS
+
+    def test_no_clamp_at_exact_boundary(self) -> None:
+        """At ``Retry-After: 1200`` (exact boundary) the parser must NOT clamp.
+
+        retry.py uses ``if value > _RETRY_AFTER_MAX_SECONDS`` (strict ``>``)
+        so the boundary value passes through unchanged. /check iter2 LE-1
+        (anti-pattern #27) called this out as missing coverage; a future
+        change to ``>=`` would silently flip the boundary's behaviour
+        without a test failure.
+        """
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": str(int(_RETRY_AFTER_MAX_SECONDS))}
+        exc = requests.HTTPError(response=response)
+        assert _parse_retry_after_seconds(exc) == _RETRY_AFTER_MAX_SECONDS
 
     def test_ignores_non_integer_retry_after_header(self) -> None:
         """HTTP-date format is not handled; non-digit headers return None."""
@@ -265,6 +285,9 @@ class TestParseRetryAfterSeconds:
             f"Expected exactly one clamp warning, got {[r.getMessage() for r in warnings]}"
         )
         assert "99999" in warnings[0].getMessage()
+        # /check iter2 IMP-A: lock the logger name so future renames can't
+        # silently break log-pipeline filters that key off the dotted path.
+        assert warnings[0].name == "due_diligence_reporter.retry"
 
     def test_no_warning_when_header_within_cap(
         self, caplog: pytest.LogCaptureFixture
@@ -279,6 +302,12 @@ class TestParseRetryAfterSeconds:
             result = _parse_retry_after_seconds(exc)
         assert result == 60.0
         assert not any("clamping" in r.getMessage() for r in caplog.records)
+        # No warning record at all should belong to the retry logger when
+        # the header is within cap.
+        assert not any(
+            r.name == "due_diligence_reporter.retry" and r.levelno >= logging.WARNING
+            for r in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -9,8 +9,10 @@ import requests
 
 from due_diligence_reporter.retry import (
     MAX_ATTEMPTS,
+    _RETRY_AFTER_MAX_SECONDS,
     _is_retryable_http_error,
     _parse_retry_after_seconds,
+    _rate_limit_aware_wait,
     api_retry,
     retry_config,
 )
@@ -241,6 +243,90 @@ class TestParseRetryAfterSeconds:
         exc = _DualSource()
         exc.response = response  # type: ignore[attr-defined]
         assert _parse_retry_after_seconds(exc) == 60.0
+
+    def test_clamp_logs_warning_when_header_exceeds_cap(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the parser clamps an outsized header, it must log a WARNING
+        so operators can spot abnormal upstream behaviour during incidents."""
+        import logging
+
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "99999"}
+        exc = requests.HTTPError(response=response)
+        with caplog.at_level(logging.WARNING, logger="due_diligence_reporter.retry"):
+            result = _parse_retry_after_seconds(exc)
+        assert result == _RETRY_AFTER_MAX_SECONDS
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "clamping" in r.getMessage()
+        ]
+        assert len(warnings) == 1, (
+            f"Expected exactly one clamp warning, got {[r.getMessage() for r in warnings]}"
+        )
+        assert "99999" in warnings[0].getMessage()
+
+    def test_no_warning_when_header_within_cap(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Headers below the cap must not trigger the clamp warning."""
+        import logging
+
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "60"}
+        exc = requests.HTTPError(response=response)
+        with caplog.at_level(logging.WARNING, logger="due_diligence_reporter.retry"):
+            result = _parse_retry_after_seconds(exc)
+        assert result == 60.0
+        assert not any("clamping" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _rate_limit_aware_wait integration tests (caller-level cap)
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitAwareWaitCap:
+    """The caller-level cap in _rate_limit_aware_wait covers BOTH the
+    integer-header path (already capped at parser level) and the
+    ISO-timestamp path (NOT capped at parser level). This test class locks
+    that contract so future refactors can't regress either branch."""
+
+    def _make_retry_state(self, exc: BaseException) -> object:
+        """Build a minimal RetryCallState-shaped object for _rate_limit_aware_wait."""
+        outcome = MagicMock()
+        outcome.exception.return_value = exc
+        state = MagicMock()
+        state.outcome = outcome
+        state.attempt_number = 1
+        return state
+
+    def test_caps_header_path_at_constant(self) -> None:
+        """Header path: parser caps to _RETRY_AFTER_MAX_SECONDS, caller is no-op."""
+        response = MagicMock(spec=requests.Response)
+        response.headers = {"Retry-After": "999999999"}
+        exc = requests.HTTPError(response=response)
+        wait = _rate_limit_aware_wait(self._make_retry_state(exc))
+        assert wait == _RETRY_AFTER_MAX_SECONDS
+
+    def test_caps_iso_timestamp_path_at_constant(self) -> None:
+        """ISO-timestamp path: parser returns uncapped value (e.g. 50 years
+        in the future); caller's min() is the ONLY thing protecting the
+        caller from a multi-decade sleep. If this regresses, change
+        retry.py:_rate_limit_aware_wait or _parse_retry_after_seconds."""
+        # 30 minutes in the future = 1800s + 5s buffer = 1805s, > 1200s cap.
+        from datetime import datetime, timedelta, timezone
+
+        future = (datetime.now(timezone.utc) + timedelta(minutes=30)).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        exc = Exception(f"429 Too Many Requests. Retry after {future}")
+        # First confirm the parser-level path returns > cap (uncapped).
+        parsed = _parse_retry_after_seconds(exc)
+        assert parsed is not None and parsed > _RETRY_AFTER_MAX_SECONDS
+        # Then confirm the caller caps it.
+        wait = _rate_limit_aware_wait(self._make_retry_state(exc))
+        assert wait == _RETRY_AFTER_MAX_SECONDS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -231,19 +231,33 @@ class TestParseRetryAfterSeconds:
         exc = requests.HTTPError(response=response)
         assert _parse_retry_after_seconds(exc) == _RETRY_AFTER_MAX_SECONDS
 
-    def test_no_clamp_at_exact_boundary(self) -> None:
+    def test_no_clamp_at_exact_boundary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """At ``Retry-After: 1200`` (exact boundary) the parser must NOT clamp.
 
         retry.py uses ``if value > _RETRY_AFTER_MAX_SECONDS`` (strict ``>``)
         so the boundary value passes through unchanged. /check iter2 LE-1
-        (anti-pattern #27) called this out as missing coverage; a future
-        change to ``>=`` would silently flip the boundary's behaviour
-        without a test failure.
+        called this out as missing coverage. iter3 hardening: the value
+        comparison alone can't distinguish ``>`` from ``>=`` (both return
+        1200.0 when input is 1200), so we also assert that the clamping
+        WARNING is NOT emitted at the boundary. A regression to ``>=``
+        would emit the warning and fail this test.
         """
+        import logging
+
         response = MagicMock(spec=requests.Response)
         response.headers = {"Retry-After": str(int(_RETRY_AFTER_MAX_SECONDS))}
         exc = requests.HTTPError(response=response)
-        assert _parse_retry_after_seconds(exc) == _RETRY_AFTER_MAX_SECONDS
+        with caplog.at_level(logging.WARNING, logger="due_diligence_reporter.retry"):
+            result = _parse_retry_after_seconds(exc)
+        assert result == _RETRY_AFTER_MAX_SECONDS
+        # Strict ``>`` means the boundary input passes through without a
+        # clamp; no WARNING should fire. Future change to ``>=`` would
+        # emit the WARNING and fail this assertion.
+        assert not any(
+            "clamping" in r.getMessage() for r in caplog.records
+        ), f"Boundary value 1200 should NOT clamp, but got: {[r.getMessage() for r in caplog.records]}"
 
     def test_ignores_non_integer_retry_after_header(self) -> None:
         """HTTP-date format is not handled; non-digit headers return None."""


### PR DESCRIPTION
## Summary

Tier-3 polish for the reporter, picking up the deferred recommendations from the Tier-2 `/check` iter2 review. No behavior changes outside CI; test suite grows by 9 tests (919 → 928).

## Changes

### Workflow hygiene
- Pin `astral-sh/setup-uv` to `version: "0.5.14"` in 12 remaining workflows. T2-B pinned 2; this completes the sweep so every workflow uses the same uv version and lockfile drift cannot land silently.

### Retry-After hardening (`src/due_diligence_reporter/retry.py`)
- Cap `_parse_retry_after_seconds()` at 1200 s (`_RETRY_AFTER_MAX_SECONDS`). Defense-in-depth against a malicious or buggy upstream returning `Retry-After: 999999999`. The downstream `_rate_limit_aware_wait` already capped; the parser-level cap protects callers that bypass it.
- 5 new tests in `tests/test_retry.py`:
  - `exc.response.headers` path (`requests.HTTPError`) — regression test for the iter1 dual-source fix
  - `exc.headers` path (`googleapiclient.errors.HttpError`)
  - Cap at 1200 s
  - Non-integer header is rejected (HTTP-date format ignored, RFC 7231)
  - Response-headers take precedence over exc-headers when both exist

### argparse contract test (`scripts/recover_migration_wiped_sites.py`)
- 2 new tests in `tests/test_recover_migration_wiped_sites.py`:
  - Bare invocation (no flag) exits 2 with usage error mentioning both `--apply` and `--dry-run`
  - `--apply --dry-run` together is rejected
- Added BREAKING CHANGE note to the script's module docstring pointing at `CHANGELOG.md`.

### `CHANGELOG.md` (new file)
- First entry documents the `--apply`/`--dry-run` breaking change, the Retry-After parser fixes, the uv pin sweep, and the new `DASHBOARD_PUBLISH_URL`/`DASHBOARD_PUBLISH_SECRET` env vars.
- Operator note: how to distinguish a Rebl outage from a legitimate empty result in workflow logs (outage path emits an ERROR/WARNING with traceback from `due_diligence_reporter.rebl`; the no-match path is silent).

### `.env.example`
- `DASHBOARD_PUBLISH_SECRET` now has a concrete generation command (`openssl rand -hex 32`) and a rotation procedure note.

## Test Plan

```
uv run pytest -q --deselect tests/test_permit_history.py
# 928 passed, 24 deselected
```
