### PR TITLE
test(permit-history): add missing rebl_resolution arg to _minimal_trace_args (fixes 3 pre-existing failures)

### DIFF
--- a/tests/test_permit_history.py
+++ b/tests/test_permit_history.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from due_diligence_reporter.rebl import ReblResolution
 from due_diligence_reporter.server import (
     _analyze_permit_flags,
     _build_report_trace_data,
@@ -238,6 +239,10 @@ def test_format_permit_report_fields_empty_flags():
 
 
 def _minimal_trace_args(**overrides) -> dict:
+    # `rebl_resolution` is required by `_build_report_trace_data`. These
+    # supplemental_evidence tests don't care about Rebl behaviour, so we
+    # pass a default (empty) ReblResolution. The Rebl-specific assertions
+    # live in tests/test_rebl.py.
     base = {
         "site_name": "Test Site",
         "report_date": "2026-04-03",
@@ -248,6 +253,7 @@ def _minimal_trace_args(**overrides) -> dict:
         "unmatched": [],
         "hyperlink_trace": {},
         "token_evidence": None,
+        "rebl_resolution": ReblResolution(),
     }
     return {**base, **overrides}
 


### PR DESCRIPTION
## Summary

Fixes the 3 pre-existing `tests/test_permit_history.py` failures that PR #71 had to deselect to keep the test suite green. After this PR, the full suite runs **957 passed, 0 failed, 0 deselected**.

## What was broken

```
FAILED tests/test_permit_history.py::test_trace_supplemental_evidence_included_for_non_template_keys
FAILED tests/test_permit_history.py::test_trace_supplemental_evidence_omitted_when_empty
FAILED tests/test_permit_history.py::test_trace_supplemental_evidence_template_keys_not_duplicated

TypeError: _build_report_trace_data() missing 1 required positional argument: 'rebl_resolution'
```

## Root cause

At some point `src/due_diligence_reporter/server.py::_build_report_trace_data` gained a required `rebl_resolution: ReblResolution` parameter (used to populate the `rebl` block of the report trace JSON):

```python
def _build_report_trace_data(
    site_name: str,
    report_date: str,
    doc_id: str,
    doc_url: str | None,
    replacements: dict[str, str],
    unfilled: list[str],
    unmatched: list[str],
    hyperlink_trace: dict[str, Any],
    token_evidence: dict[str, str] | None,
    rebl_resolution: ReblResolution,   # <-- added later, no default
) -> dict[str, Any]:
```

The companion test file `tests/test_rebl.py` was updated for the new signature, but `tests/test_permit_history.py` was missed. Its `_minimal_trace_args` helper still constructs the kwargs dict without `rebl_resolution`, so every call through the helper raises `TypeError`.

These failures have been latent on `main` ever since the parameter was added — they don't actually exercise stale assertions, they just can't construct the call.

## Fix

Test-only change. Two edits in `tests/test_permit_history.py`:

1. Import `ReblResolution`:
   ```python
   from due_diligence_reporter.rebl import ReblResolution
   ```
2. Add `rebl_resolution=ReblResolution()` to `_minimal_trace_args`:
   ```python
   base = {
       ...
       "token_evidence": None,
       "rebl_resolution": ReblResolution(),
   }
   ```

`ReblResolution` is a `@dataclass(frozen=True)` whose every field has a default (`address_submitted=""`, `resolution_status="not_requested"`, `site_id=""`, `url=""`, etc.), so the no-arg constructor produces a valid neutral value.

This default is appropriate here because the three affected tests only assert on `supplemental_evidence` behaviour — they never inspect the `rebl` field. Rebl-specific assertions live in `tests/test_rebl.py` and continue to use real `ReblResolution(...)` instances with populated fields.

No production code is touched.

## Why not give `rebl_resolution` a default in production code?

Considered and rejected. Every production call site already passes a real `ReblResolution`, and making it `Optional` in production would silently mask the case where a caller forgets to wire Rebl results into the trace JSON (which is something we want to fail loudly on). The bug is in the test helper, not in the function signature, so the fix belongs in the test.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `tests/test_permit_history.py` | 21 passed, 3 failed | **24 passed** |
| Full test suite | 954 passed, 3 deselected (PR #71) | **957 passed, 0 deselected** |

```
$ uv run pytest -q
.................................................. [100%]
957 passed in 24.80s
```

## Out of scope

- The MCP Hive cold-start fix is in PR #71 and stands on its own. This PR can land in either order relative to #71 — they touch disjoint files.