### PR TITLE
feat(raycon): per-doc folder ping on every classified upload

### DIFF
--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -142,6 +142,88 @@ def _send_block_plan_failure_notification(
     )
 
 
+def _run_doc_arrival_folder_ping(
+    gc: GoogleClient,
+    *,
+    site_summary: dict[str, Any],
+    doc_type: str,
+    drive_file: dict[str, Any] | None,
+) -> dict[str, str]:
+    """Tell RayCon a new doc landed in the site's Drive folder.
+
+    Fired on every successful classified upload (CDS SIR, Worksmith
+    inspection, ISP, Block Plan). RayCon walks the folder server-side
+    using ``drive_folder_url`` and decides whether the document set is
+    now complete enough to start computing scenarios. The ping is
+    idempotent on RayCon's side, so duplicate fires are safe.
+
+    Returns a status dict the caller can attach to the per-attachment
+    ``uploaded`` row. Failures are surfaced in the dict (``status`` =
+    ``error`` + ``error`` message) but never raise — a flaky RayCon
+    must not block a successful Drive upload from being marked done.
+    The cron-driven safety net in ``scripts/raycon_followup.py`` will
+    re-fire any missed pings.
+    """
+    from .raycon_client import post_raycon_folder_ping
+
+    site_id = str(site_summary.get("id", "")).strip()
+    site_name = str(site_summary.get("title", "")).strip()
+    site_address = str(site_summary.get("address", "")).strip()
+    drive_folder_url = str(site_summary.get("drive_folder_url", "")).strip()
+
+    if not (site_id and site_name and site_address and drive_folder_url):
+        return {
+            "status": "skipped",
+            "reason": "missing site_id/title/address/drive_folder_url",
+        }
+
+    try:
+        m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+    except Exception as e:
+        return {"status": "error", "error": f"resolve M1 failed: {e}"}
+    if not m1_folder_id:
+        return {"status": "skipped", "reason": "no M1 folder"}
+
+    file_id = str((drive_file or {}).get("id", ""))
+    file_url = str((drive_file or {}).get("webViewLink", ""))
+
+    try:
+        response = post_raycon_folder_ping(
+            site_id=site_id,
+            site_name=site_name,
+            address=site_address,
+            drive_folder_url=drive_folder_url,
+            m1_folder_id=m1_folder_id,
+            doc_type=doc_type,
+            file_id=file_id,
+            file_url=file_url,
+        )
+    except Exception as e:
+        # Never break the upload on a flaky RayCon ping; cron safety net
+        # in scripts/raycon_followup.py will re-fire missed dispatches.
+        logger.warning(
+            "RayCon folder ping failed for site=%s doc_type=%s file_id=%s: %s",
+            site_name,
+            doc_type,
+            file_id or "(none)",
+            e,
+        )
+        return {"status": "error", "error": str(e)}
+
+    logger.info(
+        "RayCon folder ping accepted for site=%s doc_type=%s file_id=%s status=%s",
+        site_name,
+        doc_type,
+        file_id or "(none)",
+        response.get("status", "accepted"),
+    )
+    return {
+        "status": str(response.get("status", "accepted")),
+        "doc_type": doc_type,
+        "file_id": file_id,
+    }
+
+
 def _run_block_plan_downstream(
     gc: GoogleClient,
     *,
@@ -633,6 +715,20 @@ def process_email(
                     "drive_link": drive_file.get("webViewLink"),
                     "retry_existing_upload": True,
                 })
+
+            # Per-doc folder ping: tell RayCon a new doc landed so it can
+            # walk the folder and decide if the document set is complete
+            # enough to start. Fired for ALL classified doc types
+            # (CDS SIR, Worksmith inspection, ISP, Block Plan). Block
+            # Plan also still fires the full job dispatch below.
+            if drive_file is not None and uploaded:
+                folder_ping = _run_doc_arrival_folder_ping(
+                    gc,
+                    site_summary=site_summary,
+                    doc_type=doc_type,
+                    drive_file=drive_file,
+                )
+                uploaded[-1]["raycon_folder_ping"] = folder_ping
 
             if doc_type == "block_plan" and drive_file is not None:
                 block_plan_content = extract_text_from_pdf_bytes(file_bytes)

--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -1,14 +1,21 @@
 """RayCon async hand-off client.
 
-DDR pings RayCon's `/v1/jobs` endpoint when a Block Plan lands in a
-site's M1 folder. RayCon then reads the Block Plan from Drive on its
-own, derives the room schedule, runs the Fastest Open / Max Capacity
-scenarios, and writes a single ``raycon_scenario.json`` file back into
-the same M1 folder.
+DDR pings RayCon's `/v1/jobs` endpoint in two flavors:
+
+1. **Job dispatch** (``post_raycon_job``) — sent when a Block Plan
+   lands in a site's M1 folder. Carries ``block_plan_file_id`` as the
+   idempotency key. RayCon runs Fastest Open / Max Capacity scenarios
+   and writes ``raycon_scenario.json`` back into the same M1 folder.
+2. **Folder ping** (``post_raycon_folder_ping``) — sent on every other
+   classified doc arrival (CDS SIR, Worksmith inspection, ISP). Lighter
+   payload, no Block Plan handle. RayCon walks the Drive folder server-
+   side and decides whether the document set is now complete enough to
+   start computing. Idempotent on RayCon's side.
 
 This module owns:
 
-* ``post_raycon_job`` — the outbound POST (auth + retry).
+* ``post_raycon_job`` — the outbound POST for Block Plan triggers.
+* ``post_raycon_folder_ping`` — the lightweight per-doc heads-up.
 * ``read_raycon_scenario_from_m1`` — picks up the JSON RayCon left
   for us in the per-site M1 folder.
 * ``raycon_scenario_to_report_fields`` — maps the parsed JSON into the
@@ -211,6 +218,101 @@ def post_raycon_job(
     except ValueError:
         # RayCon is allowed to return an empty body on success; preserve
         # observability without breaking the caller.
+        return {"status": "accepted"}
+
+
+@retry(**retry_config())  # type: ignore[untyped-decorator]
+def post_raycon_folder_ping(
+    *,
+    site_id: str,
+    site_name: str,
+    address: str,
+    drive_folder_url: str,
+    m1_folder_id: str,
+    doc_type: str = "",
+    file_id: str = "",
+    file_url: str = "",
+) -> dict[str, Any]:
+    """Lightweight ping that a new doc landed in a site's Drive folder.
+
+    Sent on every classified upload (CDS SIR, Worksmith inspection, ISP
+    — and also Block Plan, alongside the full ``post_raycon_job`` call).
+    RayCon walks the folder server-side using ``drive_folder_url`` and
+    decides whether the document set is now complete enough to start
+    computing. The body is intentionally minimal: only ``site_id``,
+    ``drive_folder_url``, and ``m1_folder_id`` are strictly required
+    on the wire; ``doc_type`` / ``file_id`` / ``file_url`` are
+    informational hints and may be empty when called from the cron
+    safety net.
+
+    Same endpoint as ``post_raycon_job`` (``/v1/jobs``). RayCon
+    distinguishes a folder ping from a job dispatch by the absence of
+    ``block_plan_file_id`` in the body. Idempotent on RayCon's side
+    — re-firing for the same ``file_id`` is a no-op.
+
+    Auth, signing, and retry behavior match ``post_raycon_job``.
+    """
+    settings = get_settings()
+    missing_required: list[str] = []
+    for arg_name, arg_value in (
+        ("site_id", site_id),
+        ("site_name", site_name),
+        ("address", address),
+        ("drive_folder_url", drive_folder_url),
+        ("m1_folder_id", m1_folder_id),
+    ):
+        if not arg_value:
+            missing_required.append(arg_name)
+    if missing_required:
+        raise ValueError(
+            "post_raycon_folder_ping missing required fields: "
+            + ", ".join(missing_required)
+        )
+
+    body: dict[str, Any] = {
+        "schema_version": "1.0",
+        "site_id": site_id,
+        "site_name": site_name,
+        "address": address,
+        "drive_folder_url": drive_folder_url,
+        "m1_folder_id": m1_folder_id,
+        "event": "folder_updated",
+        "callback_marker": RAYCON_CALLBACK_MARKER,
+        "requested_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if doc_type:
+        body["doc_type"] = doc_type
+    if file_id:
+        body["file_id"] = file_id
+    if file_url:
+        body["file_url"] = file_url
+
+    body_bytes = json.dumps(body, separators=(",", ":"), sort_keys=False).encode("utf-8")
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if settings.raycon_webhook_secret:
+        headers["X-RayCon-Signature"] = _compute_hmac_signature(
+            settings.raycon_webhook_secret, body_bytes
+        )
+    if settings.raycon_api_key:
+        headers["X-RayCon-API-Key"] = settings.raycon_api_key
+
+    logger.info(
+        "RayCon folder ping: site=%s doc_type=%s file_id=%s",
+        site_name,
+        doc_type or "(unspecified)",
+        file_id or "(none)",
+    )
+    response = requests.post(
+        settings.raycon_jobs_url,
+        data=body_bytes,
+        headers=headers,
+        timeout=60,
+    )
+    response.raise_for_status()
+    try:
+        return response.json()
+    except ValueError:
         return {"status": "accepted"}
 
 

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -16,6 +16,7 @@ from due_diligence_reporter.inbox_scanner import (
     _generate_drive_filename,
     _is_internal_sender,
     _run_block_plan_downstream,
+    _run_doc_arrival_folder_ping,
     _walk_parts,
     has_site_identity,
     process_email,
@@ -1161,5 +1162,151 @@ class TestBlockPlanDownstream:
                 block_plan_file_id="block123",
             )
         mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Per-doc folder ping (RayCon /v1/jobs lightweight notification)
+# ---------------------------------------------------------------------------
+
+
+class TestDocArrivalFolderPing:
+    """On every classified upload — SIR, Worksmith inspection, ISP, Block
+    Plan — we ping RayCon's /v1/jobs with the folder URL so it can decide
+    whether the document set is complete enough to start computing."""
+
+    _SITE = {
+        "id": "IEBLOCK123",
+        "title": "Alpha Keller",
+        "address": "123 Main St, Keller, TX",
+        "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+    }
+    _DRIVE_FILE = {
+        "id": "file-1",
+        "webViewLink": "https://drive.google.com/file/d/file-1/view",
+    }
+
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.raycon_client.post_raycon_folder_ping")
+    def test_ping_fires_for_sir_upload(
+        self, mock_ping, mock_resolve_m1
+    ):
+        mock_resolve_m1.return_value = ("m1-folder-id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        gc = MagicMock()
+
+        result = _run_doc_arrival_folder_ping(
+            gc,
+            site_summary=self._SITE,
+            doc_type="sir",
+            drive_file=self._DRIVE_FILE,
+        )
+
+        assert result["status"] == "accepted"
+        assert result["doc_type"] == "sir"
+        kwargs = mock_ping.call_args.kwargs
+        assert kwargs["site_id"] == "IEBLOCK123"
+        assert kwargs["site_name"] == "Alpha Keller"
+        assert kwargs["address"] == "123 Main St, Keller, TX"
+        assert kwargs["drive_folder_url"].endswith("/site_abc")
+        assert kwargs["m1_folder_id"] == "m1-folder-id"
+        assert kwargs["doc_type"] == "sir"
+        assert kwargs["file_id"] == "file-1"
+        assert kwargs["file_url"].endswith("/view")
+
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.raycon_client.post_raycon_folder_ping")
+    def test_ping_fires_for_each_doc_type(
+        self, mock_ping, mock_resolve_m1
+    ):
+        mock_resolve_m1.return_value = ("m1-folder-id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        gc = MagicMock()
+
+        for dt in ("sir", "building_inspection", "isp", "block_plan"):
+            mock_ping.reset_mock()
+            result = _run_doc_arrival_folder_ping(
+                gc,
+                site_summary=self._SITE,
+                doc_type=dt,
+                drive_file=self._DRIVE_FILE,
+            )
+            assert result["status"] == "accepted", dt
+            assert mock_ping.call_args.kwargs["doc_type"] == dt
+
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.raycon_client.post_raycon_folder_ping")
+    def test_ping_failure_does_not_raise(self, mock_ping, mock_resolve_m1):
+        """A flaky RayCon must not break a successful Drive upload."""
+        mock_resolve_m1.return_value = ("m1-folder-id", "M1")
+        mock_ping.side_effect = RuntimeError("RayCon 503")
+        gc = MagicMock()
+
+        result = _run_doc_arrival_folder_ping(
+            gc,
+            site_summary=self._SITE,
+            doc_type="sir",
+            drive_file=self._DRIVE_FILE,
+        )
+
+        assert result["status"] == "error"
+        assert "RayCon 503" in result["error"]
+
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.raycon_client.post_raycon_folder_ping")
+    def test_ping_skipped_when_site_summary_incomplete(
+        self, mock_ping, mock_resolve_m1
+    ):
+        """Missing site_id / address / drive_folder_url → graceful skip,
+        not an error. Inbox classifier already gated on these earlier."""
+        gc = MagicMock()
+        result = _run_doc_arrival_folder_ping(
+            gc,
+            site_summary={
+                "id": "",  # incomplete
+                "title": "Alpha Keller",
+                "address": "123 Main",
+                "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+            },
+            doc_type="sir",
+            drive_file=self._DRIVE_FILE,
+        )
+        assert result["status"] == "skipped"
+        assert "missing" in result["reason"]
+        mock_resolve_m1.assert_not_called()
+        mock_ping.assert_not_called()
+
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.raycon_client.post_raycon_folder_ping")
+    def test_ping_skipped_when_m1_folder_unresolvable(
+        self, mock_ping, mock_resolve_m1
+    ):
+        mock_resolve_m1.return_value = (None, None)
+        gc = MagicMock()
+        result = _run_doc_arrival_folder_ping(
+            gc,
+            site_summary=self._SITE,
+            doc_type="sir",
+            drive_file=self._DRIVE_FILE,
+        )
+        assert result["status"] == "skipped"
+        assert "M1" in result["reason"]
+        mock_ping.assert_not_called()
+
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.raycon_client.post_raycon_folder_ping")
+    def test_ping_returns_error_when_m1_resolution_raises(
+        self, mock_ping, mock_resolve_m1
+    ):
+        mock_resolve_m1.side_effect = RuntimeError("Drive 401")
+        gc = MagicMock()
+        result = _run_doc_arrival_folder_ping(
+            gc,
+            site_summary=self._SITE,
+            doc_type="isp",
+            drive_file=self._DRIVE_FILE,
+        )
+        assert result["status"] == "error"
+        assert "resolve M1" in result["error"]
+        mock_ping.assert_not_called()
 
 

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -15,6 +15,7 @@ from due_diligence_reporter.raycon_client import (
     RAYCON_SCENARIO_FILENAME,
     RayConSchemaError,
     _compute_hmac_signature,
+    post_raycon_folder_ping,
     post_raycon_job,
     raycon_scenario_to_report_fields,
     read_raycon_scenario_from_m1,
@@ -219,6 +220,149 @@ class TestPostRayConJob:
             return_value=response,
         ):
             result = post_raycon_job(total_building_sf=8400, **_REQUIRED_KW)
+        assert result == {"status": "accepted"}
+
+
+# ---------------------------------------------------------------------------
+# post_raycon_folder_ping
+# ---------------------------------------------------------------------------
+
+
+_PING_REQUIRED_KW: dict[str, object] = {
+    "site_id": "S-123",
+    "site_name": "Test Site",
+    "address": "100 Main St, Austin, TX",
+    "drive_folder_url": "https://drive.google.com/drive/folders/parent-abc",
+    "m1_folder_id": "m1-xyz",
+}
+
+
+class TestPostRayConFolderPing:
+    """Per-doc folder ping: lighter body, same /v1/jobs URL.
+
+    Sent on every classified upload (CDS SIR, Worksmith inspection, ISP,
+    Block Plan). RayCon walks the folder server-side and decides whether
+    the document set is complete. Idempotent on RayCon's side.
+    """
+
+    def _fake_settings(self):
+        settings = MagicMock()
+        settings.raycon_jobs_url = "https://raycon.test/v1/jobs"
+        settings.raycon_webhook_secret = "shared-secret"
+        settings.raycon_api_key = ""
+        return settings
+
+    def test_happy_path_sends_minimal_body_and_hmac(self) -> None:
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            result = post_raycon_folder_ping(
+                doc_type="sir",
+                file_id="file-1",
+                file_url="https://drive.google.com/file/d/file-1/view",
+                **_PING_REQUIRED_KW,
+            )
+
+        assert result == {"status": "accepted"}
+        kwargs = mock_post.call_args.kwargs
+        # Same endpoint as post_raycon_job.
+        assert mock_post.call_args.args[0] == "https://raycon.test/v1/jobs"
+        assert "json" not in kwargs
+        body_bytes = kwargs["data"]
+        body = json.loads(body_bytes.decode("utf-8"))
+
+        # Required fields present.
+        assert body["schema_version"] == "1.0"
+        assert body["site_id"] == "S-123"
+        assert body["site_name"] == "Test Site"
+        assert body["address"] == "100 Main St, Austin, TX"
+        assert body["drive_folder_url"].endswith("/parent-abc")
+        assert body["m1_folder_id"] == "m1-xyz"
+        assert body["event"] == "folder_updated"
+        assert body["callback_marker"] == "raycon_scenario.json"
+        assert body["requested_at"].endswith("Z")
+
+        # Informational hints included.
+        assert body["doc_type"] == "sir"
+        assert body["file_id"] == "file-1"
+        assert body["file_url"].endswith("/view")
+
+        # NO Block Plan handle on the wire — that's how RayCon
+        # distinguishes a folder ping from a job dispatch.
+        assert "block_plan_file_id" not in body
+        assert "block_plan_url" not in body
+        assert "total_building_sf" not in body
+
+        # HMAC matches.
+        sig_header = kwargs["headers"]["X-RayCon-Signature"]
+        expected = hmac.new(b"shared-secret", body_bytes, hashlib.sha256).hexdigest()
+        assert sig_header == f"sha256={expected}"
+
+    def test_optional_hint_fields_omitted_when_not_provided(self) -> None:
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            post_raycon_folder_ping(**_PING_REQUIRED_KW)
+
+        body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
+        # Optional hints not on the wire when caller didn't supply them.
+        assert "doc_type" not in body
+        assert "file_id" not in body
+        assert "file_url" not in body
+        # Required fields still present.
+        assert body["site_id"] == "S-123"
+        assert body["m1_folder_id"] == "m1-xyz"
+
+    def test_missing_required_field_raises(self) -> None:
+        kw = dict(_PING_REQUIRED_KW)
+        kw["drive_folder_url"] = ""
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                post_raycon_folder_ping(**kw)
+        assert "drive_folder_url" in str(excinfo.value)
+        assert "folder_ping" in str(excinfo.value)
+
+    def test_missing_secret_skips_signature_header(self) -> None:
+        settings = self._fake_settings()
+        settings.raycon_webhook_secret = ""
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=settings,
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            post_raycon_folder_ping(**_PING_REQUIRED_KW)
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert "X-RayCon-Signature" not in headers
+        assert "X-RayCon-API-Key" not in headers
+        assert headers["Content-Type"] == "application/json"
+
+    def test_empty_response_body_returns_default_status(self) -> None:
+        empty = MagicMock()
+        empty.status_code = 202
+        empty.raise_for_status.return_value = None
+        empty.json.side_effect = ValueError("no body")
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=empty,
+        ):
+            result = post_raycon_folder_ping(**_PING_REQUIRED_KW)
         assert result == {"status": "accepted"}
 
 


### PR DESCRIPTION
## What

Every successful classified upload (CDS SIR, Worksmith inspection, ISP, Block Plan) now sends a lightweight ping to RayCon's `/v1/jobs` with the site's `drive_folder_url`. RayCon walks the folder server-side and decides whether the document set is complete enough to start computing scenarios.

## Why

RayCon won't run until it has all required documents. We need to tell it to re-check the folder every time a new doc arrives — not only when the Block Plan lands. This unblocks the case where Block Plan arrives first and the SIR/inspection/ISP trickle in afterward (or vice versa).

Per user direction: same `/v1/jobs` endpoint, no `doc_type` field, RayCon figures it out from Drive.

## How

**`post_raycon_folder_ping` (new) — `src/due_diligence_reporter/raycon_client.py`**
- Same URL as `post_raycon_job` (`settings.raycon_jobs_url`)
- Required: `site_id, site_name, address, drive_folder_url, m1_folder_id`
- Optional hints: `doc_type, file_id, file_url` (only added when truthy)
- Body includes `event: "folder_updated"`, `schema_version: "1.0"`, `callback_marker`, `requested_at`
- **Deliberately omits** `block_plan_file_id` / `block_plan_url` / `total_building_sf` — that's RayCon's signal it's a folder ping, not a job
- Same HMAC + retry behavior as `post_raycon_job`

**`_run_doc_arrival_folder_ping` (new) — `src/due_diligence_reporter/inbox_scanner.py`**
- Resolves M1 folder, calls `post_raycon_folder_ping`, returns status dict
- Fail-safe: never raises; returns `{"status": "error", ...}` on failure
- Skips gracefully when site_summary missing required fields or M1 unresolvable

**Wire-in — `_process_email_message`**
- Fires immediately after every successful classified upload, **before** `_run_block_plan_downstream`
- Guard: `if drive_file is not None and uploaded:` — no fire on dry-run or upload failures
- Block Plan still **also** calls `_run_block_plan_downstream` for the full job dispatch

## Safety

- Ping failure never breaks a successful Drive upload (caught and logged on `uploaded[-1]["raycon_folder_ping"]`)
- Cron safety net from #73 still re-fires anything missed
- Block Plan flow unchanged — both paths fire (folder ping + full job)

## Tests

11 new tests, full suite **976 passing**:

`tests/test_raycon_client.py::TestPostRayConFolderPing` (5):
- happy path sends minimal body + HMAC
- optional hint fields omitted when not provided
- missing required field raises
- missing secret skips signature header
- empty response body returns default status

`tests/test_inbox_scanner.py::TestDocArrivalFolderPing` (6):
- ping fires for SIR upload
- ping fires for each of the 4 doc types
- ping failure does not raise
- ping skipped when site_summary incomplete
- ping skipped when M1 folder unresolvable
- ping returns error when M1 resolution raises
