### PR TITLE
feat(raycon): accept v1.1 envelope and surface failed runs

### DIFF
--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -66,6 +66,7 @@ from due_diligence_reporter.m1_lookup import _resolve_m1_folder  # noqa: E402
 from due_diligence_reporter.raycon_client import (  # noqa: E402
     RayConSchemaError,
     post_raycon_job,
+    raycon_payload_failed,
     raycon_scenario_to_report_fields,
     read_raycon_scenario_from_m1,
 )
@@ -455,7 +456,25 @@ def _process_site(
             "dispatch_skipped": dispatch_result.get("dispatch_skipped"),
         }
 
-    # Scenario JSON is here — publish the report Doc if missing or stale.
+    # Scenario JSON is here — but did the run actually succeed? RayCon
+    # writes the same file with ``status: "failed"`` (and ``validation.passed:
+    # false``) when it can't compute scenarios. Publishing a Doc in that
+    # state would render an empty/zero-dollar scenario the dashboard
+    # treats as authoritative. Surface the failure as an alert row instead
+    # so EDU Ops sees it in Chat and we don't pollute the site's M1 folder.
+    if raycon_payload_failed(scenario):
+        report_fields = raycon_scenario_to_report_fields(scenario)
+        reason = report_fields.get("exec.raycon_failure_reason", "") or "unspecified"
+        return {
+            "site": site_name,
+            "alert": f"raycon run failed: {reason}",
+            "raycon_status": report_fields.get("exec.raycon_status", ""),
+            "raycon_run_id": report_fields.get("exec.raycon_run_id", ""),
+            "json_modified": scenario.get("_drive_modified_time", ""),
+        }
+
+    # Scenario JSON is here and the run succeeded — publish the report
+    # Doc if missing or stale.
     published = _find_published_doc(gc, m1_folder_id, site_name)
     json_modified = scenario.get("_drive_modified_time", "")
     doc_modified = (published or {}).get("modifiedTime", "") if published else ""

--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -436,42 +436,184 @@ def _scenario_breakdown(
     }
 
 
+# Status values from RayCon's top-level envelope. RayCon emits ``"failed"``
+# when validation didn't pass (no scenarios computed); ``"completed"`` /
+# ``"success"`` for a happy run. Anything else is treated as completed for
+# back-compat with payloads that predate the envelope.
+RAYCON_FAILED_STATUSES: frozenset[str] = frozenset({"failed", "error"})
+
+
+def raycon_payload_status(payload: dict[str, Any]) -> str:
+    """Return the lower-cased top-level ``status`` if present, else ``""``.
+
+    A blank string means the payload has no envelope status — treat it as
+    a successful (legacy-flat) result for back-compat.
+    """
+    return str(payload.get("status", "") or "").strip().lower()
+
+
+def raycon_payload_failed(payload: dict[str, Any]) -> bool:
+    """Whether the payload represents a failed RayCon run.
+
+    A run is failed if either:
+      * top-level ``status`` is in :data:`RAYCON_FAILED_STATUSES`, or
+      * ``validation.passed`` is explicitly ``False``.
+
+    A missing/blank status with no validation block is *not* failed —
+    that's the legacy flat-payload shape.
+    """
+    if raycon_payload_status(payload) in RAYCON_FAILED_STATUSES:
+        return True
+    validation = payload.get("validation") or {}
+    if isinstance(validation, dict) and validation.get("passed") is False:
+        return True
+    return False
+
+
+def _payload_failure_reason(payload: dict[str, Any]) -> str:
+    """Build a human-readable failure reason from validation + summary.
+
+    Prefer ``validation.errors`` (machine-actionable list); fall back to
+    ``analysis.summary`` (RayCon's plain-English explanation). Returns ``""``
+    when there's nothing to report.
+    """
+    parts: list[str] = []
+    validation = payload.get("validation") or {}
+    if isinstance(validation, dict):
+        errors = validation.get("errors") or []
+        if isinstance(errors, list):
+            parts.extend(str(e).strip() for e in errors if str(e).strip())
+    if not parts:
+        analysis = payload.get("analysis") or {}
+        if isinstance(analysis, dict):
+            summary = str(analysis.get("summary", "") or "").strip()
+            if summary:
+                parts.append(summary)
+    return "; ".join(parts)
+
+
+def _payload_summary(payload: dict[str, Any]) -> str:
+    """Plain-English RayCon summary if present (top-level or under ``analysis``)."""
+    summary = str(payload.get("summary", "") or "").strip()
+    if summary:
+        return summary
+    analysis = payload.get("analysis") or {}
+    if isinstance(analysis, dict):
+        return str(analysis.get("summary", "") or "").strip()
+    return ""
+
+
+def _payload_block_plan_used(payload: dict[str, Any]) -> str:
+    """Drive file id of the Block Plan RayCon actually consumed, if known.
+
+    Per the v1.1 envelope, RayCon reports this under
+    ``provenance.selected_block_plan.id``. Older flat payloads echoed it as
+    ``block_plan_file_id`` at the top level — we accept either.
+    """
+    bp = str(payload.get("block_plan_file_id", "") or "").strip()
+    if bp:
+        return bp
+    provenance = payload.get("provenance") or {}
+    if isinstance(provenance, dict):
+        sel = provenance.get("selected_block_plan") or {}
+        if isinstance(sel, dict):
+            return str(sel.get("id", "") or "").strip()
+    return ""
+
+
+def _extract_scenarios(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(fastest_open, max_capacity)`` dicts from either envelope.
+
+    RayCon's v1.1 envelope nests scenarios under ``analysis.``; the
+    original v1.0 spec had them at the top level. We accept both for
+    forward/back compat. Each return value is always a dict — empty when
+    the source key is missing or ``null`` — so callers can treat the
+    "no scenario" case uniformly.
+    """
+    analysis = payload.get("analysis") if isinstance(payload.get("analysis"), dict) else {}
+
+    def _pick(key: str) -> dict[str, Any]:
+        # Prefer envelope (analysis.*); fall back to top level for legacy
+        # flat payloads. Either may be explicitly ``null``, in which case
+        # we return an empty dict so downstream rendering is consistent.
+        if isinstance(analysis, dict) and key in analysis:
+            value = analysis.get(key)
+            return value if isinstance(value, dict) else {}
+        value = payload.get(key)
+        return value if isinstance(value, dict) else {}
+
+    return _pick("fastest_open"), _pick("max_capacity")
+
+
 def raycon_scenario_to_report_fields(payload: dict[str, Any]) -> dict[str, str]:
     """Translate a parsed ``raycon_scenario.json`` into report-field keys.
 
-    The output dict matches the contract previously satisfied by the
+    Accepts both envelope shapes:
+
+    * **v1.1 envelope** (current production): scenarios live under
+      ``analysis.fastest_open`` / ``analysis.max_capacity``; top-level
+      ``status`` and ``validation`` describe whether the run succeeded.
+    * **v1.0 flat** (original spec, kept for back-compat): scenarios at
+      the top level, no ``status`` envelope.
+
+    On a failed run (``status`` in :data:`RAYCON_FAILED_STATUSES` or
+    ``validation.passed == False``) all ``exec.cost_*``, ``*_capex``, and
+    ``*_open_date`` fields are emitted blank so we don't publish a Doc that
+    looks like a successful zero-dollar scenario. ``exec.raycon_status`` and
+    ``exec.raycon_failure_reason`` carry the explanation.
+
+    Always-emitted traceability fields (regardless of status):
+      * ``exec.raycon_status``
+      * ``exec.raycon_failure_reason``
+      * ``exec.raycon_run_id``
+      * ``exec.raycon_summary``
+      * ``exec.raycon_block_plan_used``
+
+    The output contract for ``exec.fastest_open_*`` / ``exec.cost_<bucket>_*`` /
+    ``exec.max_capacity_*`` matches the contract previously satisfied by the
     synchronous /v1/chat integration so the rest of the report pipeline
-    (Google Doc builder, dashboard publisher) is unaffected by this
-    cutover.
+    (Google Doc builder, dashboard publisher) is unaffected.
     """
     fields: dict[str, str] = {}
 
-    fastest = payload.get("fastest_open") or {}
-    if isinstance(fastest, dict):
-        fields["exec.fastest_open_capex"] = _format_currency(fastest.get("grand_total"))
-        fields["exec.fastest_open_open_date"] = _weeks_to_open_date(
-            fastest.get("timeline_weeks")
-        )
-        fields.update(_scenario_breakdown(fastest, "fastest_open"))
-    else:
+    # Envelope-level traceability — always populated, even on failure.
+    fields["exec.raycon_status"] = raycon_payload_status(payload)
+    fields["exec.raycon_failure_reason"] = _payload_failure_reason(payload)
+    fields["exec.raycon_run_id"] = str(payload.get("raycon_run_id", "") or "").strip()
+    fields["exec.raycon_summary"] = _payload_summary(payload)
+    fields["exec.raycon_block_plan_used"] = _payload_block_plan_used(payload)
+
+    failed = raycon_payload_failed(payload)
+    fastest, max_cap = _extract_scenarios(payload)
+
+    # On a failed run, force every scenario field blank — emitting $0 here
+    # would be indistinguishable from a successful zero-cost scenario and
+    # downstream readers (Doc builder, dashboard) would mis-render it.
+    if failed:
         fields["exec.fastest_open_capex"] = ""
         fields["exec.fastest_open_open_date"] = ""
         fields.update(
             {f"exec.cost_{k}_fastest_open": "" for k, _ in RAYCON_BREAKDOWN_ROWS}
         )
-
-    max_cap = payload.get("max_capacity") or {}
-    if isinstance(max_cap, dict):
-        fields["exec.max_capacity_capex"] = _format_currency(max_cap.get("grand_total"))
-        fields["exec.max_capacity_open_date"] = _weeks_to_open_date(
-            max_cap.get("timeline_weeks")
-        )
-        fields.update(_scenario_breakdown(max_cap, "max_capacity"))
-    else:
         fields["exec.max_capacity_capex"] = ""
         fields["exec.max_capacity_open_date"] = ""
         fields.update(
             {f"exec.cost_{k}_max_capacity": "" for k, _ in RAYCON_BREAKDOWN_ROWS}
         )
+        return fields
+
+    fields["exec.fastest_open_capex"] = _format_currency(fastest.get("grand_total"))
+    fields["exec.fastest_open_open_date"] = _weeks_to_open_date(
+        fastest.get("timeline_weeks")
+    )
+    fields.update(_scenario_breakdown(fastest, "fastest_open"))
+
+    fields["exec.max_capacity_capex"] = _format_currency(max_cap.get("grand_total"))
+    fields["exec.max_capacity_open_date"] = _weeks_to_open_date(
+        max_cap.get("timeline_weeks")
+    )
+    fields.update(_scenario_breakdown(max_cap, "max_capacity"))
 
     return fields

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -3410,6 +3410,77 @@ def _format_skill_document(
                 lines.append(f"  {label}: {v}")
             lines.append("")
 
+    elif skill_name == "RayCon Scenario":
+        # The skill_data is the full parsed raycon_scenario.json plus a
+        # flattened ``report_data_fields`` map. We surface envelope status
+        # first (so a failed run is unmistakable), then scenarios when
+        # available, then provenance.
+        rdf = data.get("report_data_fields", {}) or {}
+        status = rdf.get("exec.raycon_status", "") or "completed"
+        run_id = rdf.get("exec.raycon_run_id", "")
+        bp_used = rdf.get("exec.raycon_block_plan_used", "")
+        summary = rdf.get("exec.raycon_summary", "")
+        failure_reason = rdf.get("exec.raycon_failure_reason", "")
+
+        lines.extend([
+            "RayCon Run",
+            f"  Status: {status}",
+            f"  Run ID: {run_id or 'N/A'}",
+            f"  Block Plan File ID: {bp_used or 'N/A'}",
+        ])
+        if summary:
+            lines.append(f"  Summary: {summary}")
+        lines.append("")
+
+        if failure_reason:
+            lines.extend([
+                "Validation Errors",
+                f"  {failure_reason}",
+                "",
+                "No scenario pricing was produced. The Block Plan, SIR, or other",
+                "inputs need to be corrected and re-uploaded for RayCon to retry.",
+                "",
+            ])
+        else:
+            # Scenario summary table — capex + open date for both buckets.
+            lines.extend([
+                "Scenario Summary",
+                f"  Fastest Open  CapEx: {rdf.get('exec.fastest_open_capex', 'N/A')}",
+                f"  Fastest Open  Open Date: {rdf.get('exec.fastest_open_open_date', 'N/A')}",
+                f"  Max Capacity  CapEx: {rdf.get('exec.max_capacity_capex', 'N/A')}",
+                f"  Max Capacity  Open Date: {rdf.get('exec.max_capacity_open_date', 'N/A')}",
+                "",
+            ])
+            # Detailed cost breakdown table — row keys come from
+            # RAYCON_BREAKDOWN_ROWS so the column count matches the V3
+            # template exactly.
+            lines.append("Detailed Cost Breakdown")
+            for row_key, row_label in RAYCON_BREAKDOWN_ROWS:
+                fo = rdf.get(f"exec.cost_{row_key}_fastest_open", "")
+                mc = rdf.get(f"exec.cost_{row_key}_max_capacity", "")
+                lines.append(f"  {row_label}: Fastest Open {fo} | Max Capacity {mc}")
+            lines.append("")
+
+        # Always surface RayCon's room schedule when present — useful even
+        # on failed runs, because the rooms tell us what RayCon read out
+        # of the Block Plan before it got stuck on validation.
+        analysis = data.get("analysis")
+        rooms = []
+        if isinstance(analysis, dict) and isinstance(analysis.get("rooms"), list):
+            rooms = analysis["rooms"]
+        elif isinstance(data.get("rooms"), list):  # legacy flat shape
+            rooms = data["rooms"]
+        if rooms:
+            lines.append("Room Schedule")
+            for room in rooms:
+                if not isinstance(room, dict):
+                    continue
+                name = room.get("name", "")
+                rtype = room.get("type", "")
+                sqft = room.get("sqft", "")
+                lines.append(f"  {name} ({rtype}): {sqft} SF")
+            lines.append("")
+
     elif skill_name == "School Approval":
         lines.extend([
             "State Requirements",

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -17,6 +17,8 @@ from due_diligence_reporter.raycon_client import (
     _compute_hmac_signature,
     post_raycon_folder_ping,
     post_raycon_job,
+    raycon_payload_failed,
+    raycon_payload_status,
     raycon_scenario_to_report_fields,
     read_raycon_scenario_from_m1,
 )
@@ -616,3 +618,229 @@ class TestRayConScenarioToReportFields:
         # so verify the actual behavior: empty dict path → $0, blank date.
         assert fields["exec.fastest_open_capex"] == "$0"
         assert fields["exec.fastest_open_open_date"] == ""
+
+
+# ---------------------------------------------------------------------------
+# v1.1 envelope: scenarios under analysis.*, top-level status, validation
+# ---------------------------------------------------------------------------
+
+
+class TestRayConPayloadEnvelope:
+    """RayCon's production v1.1 payload nests scenarios under ``analysis.``
+    and adds a top-level ``status`` + ``validation`` block. DDR has to
+    accept both the v1.1 envelope and the v1.0 flat shape, and must never
+    publish a successful-looking Doc for a failed run."""
+
+    def test_status_helper_lowercases_and_defaults_blank(self) -> None:
+        assert raycon_payload_status({"status": "FAILED"}) == "failed"
+        assert raycon_payload_status({"status": "  Completed  "}) == "completed"
+        assert raycon_payload_status({}) == ""
+        assert raycon_payload_status({"status": None}) == ""
+
+    def test_failed_helper_detects_failed_status(self) -> None:
+        assert raycon_payload_failed({"status": "failed"}) is True
+        assert raycon_payload_failed({"status": "error"}) is True
+        assert raycon_payload_failed({"status": "completed"}) is False
+        assert raycon_payload_failed({}) is False
+
+    def test_failed_helper_detects_validation_passed_false(self) -> None:
+        # Even if status is missing/optimistic, validation.passed=false
+        # is authoritative — don't publish a successful-looking Doc.
+        payload = {"status": "completed", "validation": {"passed": False}}
+        assert raycon_payload_failed(payload) is True
+
+    def test_failed_helper_treats_missing_validation_as_not_failed(self) -> None:
+        # Legacy flat payloads have no validation block; absence ≠ failure.
+        assert raycon_payload_failed({"fastest_open": {}}) is False
+
+    def test_envelope_payload_maps_scenarios_under_analysis(self) -> None:
+        """v1.1 envelope: scenarios live under ``analysis.fastest_open`` /
+        ``analysis.max_capacity``. The mapper must read from there and
+        produce the same exec.* keys it does for the flat shape."""
+        payload = {
+            "schema_version": "1.0",
+            "status": "completed",
+            "raycon_run_id": "rc_2026_05_05_abc",
+            "analysis": {
+                "fastest_open": {
+                    "grand_total": 412000,
+                    "timeline_weeks": 14,
+                    "soft_costs": 32000,
+                    "gc_fee": 28000,
+                    "contingency": 18000,
+                    "furniture": 24000,
+                    "categories": [
+                        {"category": "Demolition", "subtotal": 12000},
+                        {"category": "MEP / Fire / Life Safety", "subtotal": 86000},
+                    ],
+                },
+                "max_capacity": {
+                    "grand_total": 587000,
+                    "timeline_weeks": 22,
+                    "categories": [],
+                },
+            },
+            "validation": {"passed": True, "errors": [], "warnings": []},
+            "provenance": {
+                "selected_block_plan": {"id": "bp-file-456"},
+            },
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert fields["exec.fastest_open_capex"] == "$412,000"
+        assert fields["exec.max_capacity_capex"] == "$587,000"
+        assert fields["exec.fastest_open_open_date"]  # 14 weeks out, non-empty
+        assert fields["exec.cost_demolition_fastest_open"] == "$12,000"
+        assert fields["exec.cost_mep_fire_life_safety_fastest_open"] == "$86,000"
+        assert fields["exec.cost_soft_costs_fastest_open"] == "$32,000"
+        assert fields["exec.cost_grand_total_fastest_open"] == "$412,000"
+        # Traceability fields populated
+        assert fields["exec.raycon_status"] == "completed"
+        assert fields["exec.raycon_run_id"] == "rc_2026_05_05_abc"
+        assert fields["exec.raycon_block_plan_used"] == "bp-file-456"
+        assert fields["exec.raycon_failure_reason"] == ""
+
+    def test_envelope_prefers_analysis_over_top_level_when_both_present(self) -> None:
+        """If RayCon ever (mistakenly) sends both, we trust the envelope so
+        we don't accidentally read a stale top-level mirror."""
+        payload = {
+            "schema_version": "1.0",
+            "fastest_open": {"grand_total": 999999},  # should be ignored
+            "analysis": {
+                "fastest_open": {"grand_total": 100000, "timeline_weeks": 10},
+                "max_capacity": {"grand_total": 200000, "timeline_weeks": 20},
+            },
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert fields["exec.fastest_open_capex"] == "$100,000"
+
+    def test_failed_status_blanks_all_scenario_fields(self) -> None:
+        """Failed run: $0 is the wrong default — it would render as a real
+        zero-cost scenario in the dashboard. We emit blanks instead and
+        surface the failure reason for the published Doc."""
+        payload = {
+            "schema_version": "1.0",
+            "status": "failed",
+            "analysis": {"fastest_open": None, "max_capacity": None},
+            "validation": {
+                "passed": False,
+                "errors": [
+                    "Real estate spreadsheet did not resolve a usable microschool tier for this address (status: no_address_match)."
+                ],
+            },
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert fields["exec.fastest_open_capex"] == ""
+        assert fields["exec.max_capacity_capex"] == ""
+        assert fields["exec.fastest_open_open_date"] == ""
+        assert fields["exec.max_capacity_open_date"] == ""
+        for row_key, _ in RAYCON_BREAKDOWN_ROWS:
+            assert fields[f"exec.cost_{row_key}_fastest_open"] == ""
+            assert fields[f"exec.cost_{row_key}_max_capacity"] == ""
+        assert fields["exec.raycon_status"] == "failed"
+        assert "no_address_match" in fields["exec.raycon_failure_reason"]
+
+    def test_failed_via_validation_passed_false_blanks_scenarios(self) -> None:
+        """Status optimistic but validation says no — still treat as failure."""
+        payload = {
+            "schema_version": "1.0",
+            "status": "completed",  # RayCon optimistic
+            "analysis": {
+                "fastest_open": {"grand_total": 100, "timeline_weeks": 4},
+                "max_capacity": {"grand_total": 200, "timeline_weeks": 8},
+            },
+            "validation": {"passed": False, "errors": ["missing inputs"]},
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        # validation overrides optimistic status — scenario fields blanked.
+        assert fields["exec.fastest_open_capex"] == ""
+        assert fields["exec.max_capacity_capex"] == ""
+        assert fields["exec.raycon_failure_reason"] == "missing inputs"
+
+    def test_failure_reason_falls_back_to_analysis_summary(self) -> None:
+        """When validation.errors is empty, surface analysis.summary so the
+        published Doc still has *something* to explain why we failed."""
+        payload = {
+            "status": "failed",
+            "analysis": {"summary": "Block Plan rooms inconsistent with SIR."},
+            "validation": {"passed": False, "errors": []},
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert (
+            fields["exec.raycon_failure_reason"]
+            == "Block Plan rooms inconsistent with SIR."
+        )
+
+    def test_block_plan_used_falls_back_to_provenance(self) -> None:
+        """v1.1 envelope reports the consumed Block Plan id under
+        ``provenance.selected_block_plan.id`` rather than echoing
+        ``block_plan_file_id`` at the top level."""
+        payload = {
+            "status": "completed",
+            "analysis": {"fastest_open": {}, "max_capacity": {}},
+            "provenance": {"selected_block_plan": {"id": "prov-bp-789"}},
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert fields["exec.raycon_block_plan_used"] == "prov-bp-789"
+
+    def test_legacy_flat_payload_still_works(self) -> None:
+        """Back-compat: spec v1.0 flat payloads (no envelope) keep working.
+        This is the contract the original /v1/chat tests captured."""
+        payload = {
+            "schema_version": "1.0",
+            "fastest_open": {
+                "grand_total": 250000,
+                "timeline_weeks": 8,
+                "categories": [{"category": "Demolition", "subtotal": 5000}],
+            },
+            "max_capacity": {"grand_total": 400000, "timeline_weeks": 16},
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert fields["exec.fastest_open_capex"] == "$250,000"
+        assert fields["exec.max_capacity_capex"] == "$400,000"
+        assert fields["exec.cost_demolition_fastest_open"] == "$5,000"
+        # No envelope means no failure, no traceability values.
+        assert fields["exec.raycon_status"] == ""
+        assert fields["exec.raycon_failure_reason"] == ""
+
+    def test_real_payload_pbg_failed_run(self) -> None:
+        """Regression test built from the real RayCon payload for
+        Alpha Palm Beach Gardens (rc_20260505195427_ab6414fec5). RayCon
+        returned ``status: failed`` because the address didn't resolve to a
+        microschool tier; DDR must blank scenarios and surface the reason."""
+        payload = {
+            "schema_version": "1.0",
+            "raycon_run_id": "rc_20260505195427_ab6414fec5",
+            "status": "failed",
+            "site": {
+                "site_id": "PBG-live-verify",
+                "site_name": "Alpha Palm Beach Gardens",
+                "total_building_sf": 5560,
+            },
+            "analysis": {
+                "summary": "RayCon could not complete scenario pricing for Alpha Palm Beach Gardens. See validation errors.",
+                "rooms": [{"name": "1 ENTRY", "type": "lobby", "sqft": 180}],
+                "fastest_open": None,
+                "max_capacity": None,
+                "ray_review": None,
+            },
+            "provenance": {
+                "selected_block_plan": {"id": "14C7o_nwNqM9O-TsHzLYTqbBhHad6rKsg"},
+            },
+            "validation": {
+                "passed": False,
+                "errors": [
+                    "Real estate spreadsheet did not resolve a usable microschool tier for this address (status: no_address_match)."
+                ],
+                "warnings": [],
+            },
+        }
+        fields = raycon_scenario_to_report_fields(payload)
+        assert fields["exec.raycon_status"] == "failed"
+        assert fields["exec.raycon_run_id"] == "rc_20260505195427_ab6414fec5"
+        assert (
+            fields["exec.raycon_block_plan_used"]
+            == "14C7o_nwNqM9O-TsHzLYTqbBhHad6rKsg"
+        )
+        assert "no_address_match" in fields["exec.raycon_failure_reason"]
+        assert fields["exec.fastest_open_capex"] == ""
+        assert fields["exec.max_capacity_capex"] == ""

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -204,6 +204,164 @@ class TestProcessSite:
 
 
 # ---------------------------------------------------------------------------
+# Failed RayCon runs surface as alerts, not published Docs
+# ---------------------------------------------------------------------------
+
+
+class TestFailedScenarioAlerts:
+    """When ``raycon_scenario.json`` arrives with ``status: failed`` (or
+    ``validation.passed: false``), the followup must NOT publish a Doc —
+    that would render an empty/zero-cost scenario the dashboard treats as
+    real. Instead surface the failure as an alert row that flows through
+    the existing Chat alert path."""
+
+    @patch("scripts.raycon_followup.save_skill_report")
+    @patch("scripts.raycon_followup._find_published_doc")
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_failed_status_returns_alert_not_published_doc(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+        mock_find_doc,
+        mock_save,
+    ):
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        # RayCon's real failed-run shape — envelope with status:failed and a
+        # validation.errors list explaining why scenarios couldn't compute.
+        mock_read_scenario.return_value = {
+            "schema_version": "1.0",
+            "status": "failed",
+            "raycon_run_id": "rc_pbg_abc",
+            "analysis": {
+                "summary": "RayCon could not complete scenario pricing.",
+                "fastest_open": None,
+                "max_capacity": None,
+            },
+            "validation": {
+                "passed": False,
+                "errors": ["no_address_match: tier not resolved"],
+            },
+            "_drive_modified_time": "2026-05-05T19:54:30Z",
+        }
+        mock_find_doc.return_value = None
+
+        gc = MagicMock()
+        row = _process_site(
+            gc,
+            _site(),
+            dry_run=False,
+            alert_after=timedelta(minutes=60),
+        )
+
+        assert "alert" in row
+        assert "raycon run failed" in row["alert"]
+        assert "no_address_match" in row["alert"]
+        assert row["raycon_status"] == "failed"
+        assert row["raycon_run_id"] == "rc_pbg_abc"
+        # Critical: no Doc published for a failed run.
+        mock_save.assert_not_called()
+        assert "published" not in row
+
+    @patch("scripts.raycon_followup.save_skill_report")
+    @patch("scripts.raycon_followup._find_published_doc")
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_validation_passed_false_alone_blocks_publish(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+        mock_find_doc,
+        mock_save,
+    ):
+        """Even with optimistic ``status: completed``, validation.passed=false
+        prevents publishing."""
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        mock_read_scenario.return_value = {
+            "schema_version": "1.0",
+            "status": "completed",
+            "analysis": {
+                "fastest_open": {"grand_total": 100, "timeline_weeks": 4},
+                "max_capacity": {"grand_total": 200, "timeline_weeks": 8},
+            },
+            "validation": {"passed": False, "errors": ["missing inputs"]},
+            "_drive_modified_time": "2026-05-05T20:00:00Z",
+        }
+        mock_find_doc.return_value = None
+
+        gc = MagicMock()
+        row = _process_site(
+            gc,
+            _site(),
+            dry_run=False,
+            alert_after=timedelta(minutes=60),
+        )
+
+        assert "alert" in row
+        assert "missing inputs" in row["alert"]
+        mock_save.assert_not_called()
+
+    @patch("scripts.raycon_followup.save_skill_report")
+    @patch("scripts.raycon_followup._find_published_doc")
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_successful_envelope_payload_still_publishes(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+        mock_find_doc,
+        mock_save,
+    ):
+        """Sanity: a v1.1 envelope with ``status: completed`` and
+        ``validation.passed: true`` still flows to publish like before."""
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        mock_read_scenario.return_value = {
+            "schema_version": "1.0",
+            "status": "completed",
+            "raycon_run_id": "rc_happy_xyz",
+            "analysis": {
+                "fastest_open": {"grand_total": 412000, "timeline_weeks": 14},
+                "max_capacity": {"grand_total": 587000, "timeline_weeks": 22},
+            },
+            "validation": {"passed": True, "errors": []},
+            "_drive_modified_time": "2026-05-05T20:00:00Z",
+        }
+        mock_find_doc.return_value = None
+
+        async def _fake_save(**_kwargs):
+            return {"status": "success", "doc_url": "https://docs.google.com/d/abc"}
+
+        mock_save.side_effect = _fake_save
+
+        gc = MagicMock()
+        row = _process_site(
+            gc,
+            _site(),
+            dry_run=False,
+            alert_after=timedelta(minutes=60),
+        )
+
+        assert row.get("published") is True
+        assert row.get("doc_url") == "https://docs.google.com/d/abc"
+        mock_save.assert_called_once()
+        # Verify report_data_fields populated with envelope traceability.
+        call_kwargs = mock_save.call_args.kwargs
+        rdf = call_kwargs["skill_data"]["report_data_fields"]
+        assert rdf["exec.fastest_open_capex"] == "$412,000"
+        assert rdf["exec.raycon_status"] == "completed"
+        assert rdf["exec.raycon_run_id"] == "rc_happy_xyz"
+
+
+# ---------------------------------------------------------------------------
 # Safety-net dispatch (cron-driven post_raycon_job)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Tier 1 + Tier 2 from the gap report. Make the DDR parser accept RayCon's real
production envelope (v1.1), don't silently publish $0 Docs on failed runs,
and surface envelope traceability in the report.

The original v1.0 spec said scenarios live at the top level of
`raycon_scenario.json`. RayCon's actual production payload nests them under
`analysis.fastest_open` / `analysis.max_capacity` and adds a top-level
`status` and `validation` block. Old payloads still work — envelope wins
when both shapes are present.

## What changed

### `src/due_diligence_reporter/raycon_client.py`

- New constant `RAYCON_FAILED_STATUSES = {"failed", "error"}`
- New helpers:
  - `raycon_payload_status(payload)` — lowercased top-level `status`
  - `raycon_payload_failed(payload)` — true if status is failed/error OR `validation.passed == False`
  - `_payload_failure_reason(payload)` — joins `validation.errors[]`, falls back to `analysis.summary`
  - `_payload_summary(payload)` — pulls `analysis.summary`
  - `_payload_block_plan_used(payload)` — top-level `block_plan_file_id` then `provenance.selected_block_plan.id`
  - `_extract_scenarios(payload)` — returns `(fastest_open, max_capacity)` from envelope first, top-level fallback
- `raycon_scenario_to_report_fields` rewritten:
  - On failure → blanks all `exec.fastest_open_*`, `exec.cost_*`, `exec.max_capacity_*` fields (no zero-cost scenario)
  - Always emits 5 traceability fields: `exec.raycon_status`, `exec.raycon_failure_reason`, `exec.raycon_run_id`, `exec.raycon_summary`, `exec.raycon_block_plan_used`

### `scripts/raycon_followup.py`

- Failure-path bypass before publish: if scenario JSON arrives but `raycon_payload_failed(scenario)` is True, returns an alert row (`alert: "raycon run failed: …", raycon_status, raycon_run_id`) and does NOT call `save_skill_report`.

### `src/due_diligence_reporter/server.py`

- New `RayCon Scenario` branch in `_format_skill_document` (before the existing School Approval branch) — renders RayCon Run header (status, run_id, block_plan_file_id, summary), Validation Errors block on failure, Scenario Summary + Detailed Cost Breakdown on success, plus Room Schedule from `analysis.rooms` or top-level `rooms`. Reads everything from `data["report_data_fields"]`, so it handles both shapes cleanly.

## Tests

15 new tests — full suite **991 passing** (was 976 on main):

`tests/test_raycon_client.py` — `TestRayConPayloadEnvelope` (12 tests):
- status helper lowercases & defaults
- failed helper detects `failed` status, `validation.passed=false`, missing-validation case
- envelope payload maps scenarios under `analysis.*`
- envelope wins over top-level when both present
- failed status blanks all scenario fields
- failed via `validation.passed=false` blanks scenarios
- failure reason falls back to `analysis.summary`
- block_plan_used falls back to `provenance.selected_block_plan.id`
- legacy flat payload still works
- **real-payload regression** for PBG (`rc_20260505195427_ab6414fec5`)

`tests/test_raycon_followup.py` — `TestFailedScenarioAlerts` (3 tests):
- failed status returns alert row, no published Doc
- `validation.passed=false` alone blocks publish
- successful envelope payload still publishes (sanity)

## Out of scope (parking lot)

- Tier 3: consume `analysis.site_context.sir_structured` (duplicates CDS) and `document_summaries` — punted.
- Spec doc bump: `raycon_ddr_integration_spec.md` → v1.1 documenting the envelope (additive; `schema_version` stays "1.0" per spec §5).

## Test plan

- `uv run pytest tests/test_raycon_client.py tests/test_raycon_followup.py -v` ✅ 56 passing
- `uv run pytest` ✅ 991 passing
