### PR TITLE
fix(report): correct Referenced Reports table, single citations block, ASCII punctuation

### DIFF
--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -16,6 +16,21 @@ from .report_schema import LINK_DISPLAY_LABELS, LINK_TOKENS
 logger = logging.getLogger(__name__)
 
 SOURCE_QUALITY_NOTES_KEY = "_internal.source_quality_notes"
+CITATIONS_BLOCK_KEY = "exec.citations_block"
+
+# Map of non-ASCII punctuation characters that JC's style requires we replace
+# with their ASCII equivalents before the report is rendered.
+_ASCII_PUNCTUATION_MAP: dict[str, str] = {
+    "\u2014": "--",   # em dash
+    "\u2013": "-",    # en dash
+    "\u2018": "'",    # left single quote
+    "\u2019": "'",    # right single quote / apostrophe
+    "\u201c": '"',    # left double quote
+    "\u201d": '"',    # right double quote
+    "\u2026": "...",  # horizontal ellipsis
+    "\u2212": "-",    # minus sign
+    "\u00a0": " ",    # non-breaking space
+}
 
 # ---------------------------------------------------------------------------
 # Style constants — reproduce the V3 template visual appearance
@@ -348,6 +363,33 @@ def _canonicalize_note_text(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+def _sanitize_ascii_punctuation(text: str) -> str:
+    """Replace common non-ASCII punctuation with ASCII equivalents.
+
+    JC style requires plain ASCII -- no em-dashes, en-dashes, smart quotes,
+    ellipses, or non-breaking spaces in narrative text.
+    """
+    if not text:
+        return text
+    for src, dst in _ASCII_PUNCTUATION_MAP.items():
+        if src in text:
+            text = text.replace(src, dst)
+    return text
+
+
+def _strip_field_footnote_block(value: str) -> str:
+    """Remove trailing [N]-footnote definitions from a bulleted field.
+
+    Used when a consolidated citations block is provided -- per-field
+    footnote definitions become noise. Inline [N] markers in bullet text
+    are preserved so they can resolve against the consolidated block.
+    """
+    bullets, _footnotes = _split_bullets_and_footnotes(value)
+    if not bullets:
+        return value.strip()
+    return "\n".join(f"- {bullet}" for bullet in bullets)
+
+
 def _normalize_bulleted_field(value: str) -> str:
     """Deduplicate repeated footnotes and renumber citation markers."""
     bullets, footnotes = _split_bullets_and_footnotes(value)
@@ -451,6 +493,17 @@ def _normalize_replacements_for_rendering(
 ) -> dict[str, str]:
     """Prepare narrative fields for clean Google Doc rendering."""
     normalized = dict(replacements)
+
+    # Pass 1: ASCII-sanitize every non-link narrative value. Link tokens are
+    # left untouched so URLs are not mangled.
+    for key, value in list(normalized.items()):
+        if not isinstance(value, str):
+            continue
+        if _is_link_token(key):
+            continue
+        if value:
+            normalized[key] = _sanitize_ascii_punctuation(value)
+
     source_quality_lines: list[str] = []
 
     for token in (
@@ -467,9 +520,17 @@ def _normalize_replacements_for_rendering(
         normalized[token] = cleaned
         source_quality_lines.extend(warnings)
 
+    has_citations_block = bool(normalized.get(CITATIONS_BLOCK_KEY, "").strip())
+
     for token in ("exec.acquisition_conditions", "exec.tradeoffs_and_deficiencies"):
         value = normalized.get(token, "")
-        if value.strip():
+        if not value.strip():
+            continue
+        if has_citations_block:
+            # Single citations block lives at end of Supporting Notes; drop
+            # per-field footnote definitions so we don't render two sections.
+            normalized[token] = _strip_field_footnote_block(value)
+        else:
             normalized[token] = _normalize_bulleted_field(value)
 
     existing = normalized.get(SOURCE_QUALITY_NOTES_KEY, "").strip()
@@ -1189,6 +1250,25 @@ def build_dd_report_doc(
 
     b6.insert_text("\n")
 
+    # Citations -- single consolidated block when the agent provides it
+    citations_val = _resolve_value(replacements, CITATIONS_BLOCK_KEY, "")
+    if citations_val.strip():
+        cite_label_start, cite_label_end = b6.insert_text("Citations\n")
+        b6.style_text(
+            cite_label_start,
+            cite_label_end - 1,
+            bold=True,
+            font_size=11,
+            font_family="Arial",
+        )
+        for raw_line in citations_val.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            line_start, line_end = b6.insert_paragraph(line)
+            b6.style_text(line_start, line_end - 1, font_size=8, font_family="Arial")
+        b6.insert_text("\n")
+
     # Referenced Reports heading
     b6.insert_heading("Referenced Reports", level=2)
 
@@ -1214,28 +1294,31 @@ def build_dd_report_doc(
         source_table_data.append((_reference_type_label(token), label, display, url))
 
     phase7_requests: list[dict[str, Any]] = []
-    # Populate in reverse
+    # Populate in strict reverse order: rows reverse, then within each row
+    # iterate columns in strict reverse (col 2 -> col 1 -> col 0). Inserts
+    # are applied sequentially by batchUpdate; reading cached cell indices
+    # from the pre-insert document is only safe when each subsequent insert
+    # is at a *lower* index than the previous, otherwise earlier inserts
+    # shift later cached indices and cell content gets mixed.
     for row_idx in range(len(source_table_data) - 1, -1, -1):
         row = source_table_data[row_idx]
-        type_text = row[0]
-        label_text = row[1]
-        value_text = row[2]
-
-        # Value column
-        if value_text:
-            val_idx = _cell_index(source_table, row_idx, 2)
+        for col_idx in range(2, -1, -1):
+            text = row[col_idx]
+            if not text:
+                continue
+            cell_idx = _cell_index(source_table, row_idx, col_idx)
             phase7_requests.append({
                 "insertText": {
-                    "location": {"index": val_idx},
-                    "text": value_text,
+                    "location": {"index": cell_idx},
+                    "text": text,
                 }
             })
-            # Apply hyperlink if URL is present
-            if len(row) > 3 and row[3] is not None:
+            # Hyperlink only on the value column (col 2) when URL is present
+            if col_idx == 2 and len(row) > 3 and row[3] is not None:
                 url = row[3]
                 phase7_requests.append({
                     "updateTextStyle": {
-                        "range": {"startIndex": val_idx, "endIndex": val_idx + len(value_text)},
+                        "range": {"startIndex": cell_idx, "endIndex": cell_idx + len(text)},
                         "textStyle": {
                             "link": {"url": url},
                             "foregroundColor": {"color": {"rgbColor": _LINK_BLUE}},
@@ -1244,30 +1327,9 @@ def build_dd_report_doc(
                     }
                 })
                 hyperlink_trace["applied"] += 1
-                # Find original token for tracing
                 if row_idx > 0:
                     token_key = _SOURCE_DOC_ROWS[row_idx - 1][1]
                     hyperlink_trace["found_tokens"].append(token_key)
-
-        # Type column
-        if type_text:
-            type_idx = _cell_index(source_table, row_idx, 0)
-            phase7_requests.append({
-                "insertText": {
-                    "location": {"index": type_idx},
-                    "text": type_text,
-                }
-            })
-
-        # Label column
-        if label_text:
-            label_idx = _cell_index(source_table, row_idx, 1)
-            phase7_requests.append({
-                "insertText": {
-                    "location": {"index": label_idx},
-                    "text": label_text,
-                }
-            })
 
     if phase7_requests:
         _batch_update(docs_service, doc_id, phase7_requests)

--- a/tests/test_google_doc_builder.py
+++ b/tests/test_google_doc_builder.py
@@ -10,6 +10,7 @@ from due_diligence_reporter.google_doc_builder import (
     _HEADER_ROWS,
     _LINK_GAP_LABELS,
     _SOURCE_DOC_ROWS,
+    CITATIONS_BLOCK_KEY,
     SOURCE_QUALITY_NOTES_KEY,
     _cell_index,
     _doc_end_index,
@@ -19,6 +20,7 @@ from due_diligence_reporter.google_doc_builder import (
     _normalize_replacements_for_rendering,
     _resolve_link_value,
     _resolve_value,
+    _sanitize_ascii_punctuation,
     _split_bullets_and_footnotes,
     build_dd_report_doc,
 )
@@ -765,3 +767,195 @@ class TestNarrativeNormalization:
             "[Not found -- School Approval source could not be validated/read]"
         )
         assert "School Approval.docx" in replacements[SOURCE_QUALITY_NOTES_KEY]
+
+
+class TestAsciiPunctuationSanitizer:
+    def test_replaces_em_and_en_dashes(self) -> None:
+        assert _sanitize_ascii_punctuation("10 weeks \u2014 admin CUP") == "10 weeks -- admin CUP"
+        assert _sanitize_ascii_punctuation("$3\u20137/SF") == "$3-7/SF"
+
+    def test_replaces_smart_quotes(self) -> None:
+        assert _sanitize_ascii_punctuation("\u201chello\u201d") == '"hello"'
+        assert _sanitize_ascii_punctuation("it\u2019s a test") == "it's a test"
+
+    def test_replaces_ellipsis_minus_and_nbsp(self) -> None:
+        assert _sanitize_ascii_punctuation("foo\u2026") == "foo..."
+        assert _sanitize_ascii_punctuation("\u22125") == "-5"
+        assert _sanitize_ascii_punctuation("a\u00a0b") == "a b"
+
+    def test_passes_through_ascii_unchanged(self) -> None:
+        assert _sanitize_ascii_punctuation("plain ascii -- text") == "plain ascii -- text"
+        assert _sanitize_ascii_punctuation("") == ""
+
+    def test_normalize_replacements_sanitizes_narrative_fields(self) -> None:
+        repl = _normalize_replacements_for_rendering({
+            "exec.c_permit_timeline": "10 weeks \u2014 admin CUP",
+            "exec.acquisition_conditions": "- Landlord must provide TI \u2014 6 months\n- Range $3\u20137/SF",
+            "exec.tradeoffs_and_deficiencies": "- It\u2019s old",
+        })
+        assert "\u2014" not in repl["exec.c_permit_timeline"]
+        assert "--" in repl["exec.c_permit_timeline"]
+        assert "\u2014" not in repl["exec.acquisition_conditions"]
+        assert "\u2013" not in repl["exec.acquisition_conditions"]
+        assert "$3-7/SF" in repl["exec.acquisition_conditions"]
+        assert "\u2019" not in repl["exec.tradeoffs_and_deficiencies"]
+        assert "It's old" in repl["exec.tradeoffs_and_deficiencies"]
+
+    def test_normalize_replacements_does_not_mangle_link_urls(self) -> None:
+        url = "https://example.com/path?a=1\u20132"  # contrived URL with en-dash
+        repl = _normalize_replacements_for_rendering({
+            "sources.sir_link": url,
+        })
+        # Link tokens are excluded from sanitization to avoid mangling URLs.
+        assert repl["sources.sir_link"] == url
+
+
+class TestCitationsBlockConsolidation:
+    def test_strips_per_field_footnotes_when_block_present(self) -> None:
+        repl = _normalize_replacements_for_rendering({
+            "exec.acquisition_conditions": (
+                "- TI allowance ~$45,000 [1]\n"
+                "- ADA ramp required [2]\n"
+                "\n"
+                "[1] Building Inspection p.3\n"
+                "[2] SIR p.7"
+            ),
+            "exec.tradeoffs_and_deficiencies": (
+                "- Fire alarm > 15 years old [1]\n"
+                "\n"
+                "[1] Building Inspection p.10"
+            ),
+            CITATIONS_BLOCK_KEY: (
+                "[1] Building Inspection p.3\n"
+                "[2] SIR p.7\n"
+                "[3] Building Inspection p.10"
+            ),
+        })
+
+        assert "[1] Building Inspection p.3" not in repl["exec.acquisition_conditions"]
+        assert "[2] SIR p.7" not in repl["exec.acquisition_conditions"]
+        assert "[1] Building Inspection p.10" not in repl["exec.tradeoffs_and_deficiencies"]
+        # Inline markers in bullet text are preserved
+        assert "[1]" in repl["exec.acquisition_conditions"]
+        assert "[2]" in repl["exec.acquisition_conditions"]
+
+    def test_normalizes_per_field_footnotes_when_block_absent(self) -> None:
+        # Without a citations block, the existing per-field renumbering still runs.
+        repl = _normalize_replacements_for_rendering({
+            "exec.acquisition_conditions": (
+                "- TI allowance ~$45,000 [1]\n"
+                "\n"
+                "[1] Building Inspection p.3"
+            ),
+        })
+        assert "[1] Building Inspection p.3" in repl["exec.acquisition_conditions"]
+
+    def test_citations_block_renders_once_in_supporting_notes(self) -> None:
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {
+            "meta.site_name": "Test",
+            "meta.report_date": "04/14/2026",
+            "exec.acquisition_conditions": (
+                "- TI allowance [1]\n\n[1] Building Inspection p.3"
+            ),
+            "exec.tradeoffs_and_deficiencies": (
+                "- Fire alarm old [1]\n\n[1] Building Inspection p.10"
+            ),
+            CITATIONS_BLOCK_KEY: (
+                "[1] Building Inspection p.3\n[2] Building Inspection p.10"
+            ),
+        }
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        inserted_text = "\n".join(
+            request["insertText"]["text"]
+            for call_args in docs_svc.documents.return_value.batchUpdate.call_args_list
+            for request in call_args.kwargs["body"]["requests"]
+            if "insertText" in request
+        )
+
+        # The Citations heading appears exactly once.
+        assert inserted_text.count("Citations\n") == 1
+        # And appears between Trade-Offs and Referenced Reports.
+        assert (
+            inserted_text.index("Trade-Offs and Deficiencies\n")
+            < inserted_text.index("Citations\n")
+            < inserted_text.index("Referenced Reports\n")
+        )
+
+    def test_citations_block_omitted_when_not_provided(self) -> None:
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {
+            "meta.site_name": "Test",
+            "meta.report_date": "04/14/2026",
+        }
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        inserted_text = "\n".join(
+            request["insertText"]["text"]
+            for call_args in docs_svc.documents.return_value.batchUpdate.call_args_list
+            for request in call_args.kwargs["body"]["requests"]
+            if "insertText" in request
+        )
+        assert "Citations\n" not in inserted_text
+
+
+class TestReferencedReportsTableInsertOrder:
+    """Phase 7 must populate cells in strict reverse so cached cell indices
+    remain valid as inserts shift the document."""
+
+    def test_phase7_inserts_are_in_descending_index_order(self) -> None:
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {
+            "meta.site_name": "Test",
+            "meta.report_date": "04/14/2026",
+            "sources.sir_link": "https://drive.google.com/file/d/sir1",
+            "sources.inspection_link": "https://drive.google.com/file/d/insp1",
+            "sources.block_plan_link": "https://drive.google.com/file/d/block1",
+            "sources.rebl_link": "https://rebl3.vercel.app/site/test",
+            "sources.e_occupancy_link": "https://drive.google.com/file/d/eocc1",
+            "sources.school_approval_link": "https://drive.google.com/file/d/sa1",
+            "sources.opening_plan_link": "https://drive.google.com/file/d/op1",
+        }
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        # The Referenced Reports (source documents) table is the 4th table.
+        # Phase 7 is the batchUpdate that inserts the source-table cell text.
+        # Identify it by looking for the batch whose insertText payload contains
+        # the literal header strings "Type", "Document", "Link".
+        source_table_batch = None
+        for call_args in docs_svc.documents.return_value.batchUpdate.call_args_list:
+            requests = call_args.kwargs["body"]["requests"]
+            inserted_strings = [
+                r["insertText"]["text"] for r in requests if "insertText" in r
+            ]
+            if (
+                "Type" in inserted_strings
+                and "Document" in inserted_strings
+                and "Link" in inserted_strings
+                and "Site Investigation Report (SIR)" in inserted_strings
+            ):
+                source_table_batch = requests
+                break
+
+        assert source_table_batch is not None, "Could not find Phase 7 batchUpdate"
+
+        # Every insertText location index must be strictly non-increasing.
+        # If the loop ever inserts at a larger index after a smaller one,
+        # cached indices for later cells get shifted and content corrupts.
+        insert_indices = [
+            r["insertText"]["location"]["index"]
+            for r in source_table_batch
+            if "insertText" in r
+        ]
+        for prev, cur in zip(insert_indices, insert_indices[1:]):
+            assert cur <= prev, (
+                f"Phase 7 insert order is not strictly reverse: "
+                f"index {cur} follows {prev}"
+            )


### PR DESCRIPTION
## Summary

Fixes three rendering issues in `google_doc_builder.py` exposed by the live Palm Beach Gardens DD report.

## Bugs fixed

**1. Referenced Reports table corruption (Phase 7)**

Cells were populated in (col 2 -> col 0 -> col 1) order using cached pre-insert indices. Inserting at col 0 (a lower index) after col 2 shifted col 1's cached index, so col 1 text landed inside col 0. The PBG report header rendered as `TyDocumentpe`, row 1 as `SoSite Investigation Report (SIR)urce folder`, col 1 empty in every row.

Now iterates strictly reverse-row x reverse-col (col 2 -> col 1 -> col 0), matching the working Phase 5 cost-table pattern.

**2. Two citations sections instead of one**

`exec.acquisition_conditions` and `exec.tradeoffs_and_deficiencies` each rendered their own `[1]..[N]` footnote group, producing two separate citation sections in the report.

Adds support for a single consolidated `exec.citations_block` token. When provided, it renders once at the end of Supporting Notes (above Referenced Reports) and per-field footnote definitions are stripped. Inline `[N]` markers in bullets are preserved.

**3. Em-dashes / en-dashes / smart quotes throughout the report**

Live PBG report had ` -- `, `$3-7/SF`, `$22,650-$52,850` rendered with non-ASCII characters, violating JC style.

Adds an ASCII sanitizer applied inside `_normalize_replacements_for_rendering` to all non-link narrative values:
- U+2014 (em-dash) -> `--`
- U+2013 (en-dash) -> `-`
- U+2018/2019 (smart single quotes) -> `'`
- U+201C/201D (smart double quotes) -> `"`
- U+2026 (ellipsis) -> `...`
- U+2212 (minus) -> `-`
- U+00A0 (non-breaking space) -> ` `

Link tokens are excluded so URLs are never mangled.

## Tests

- 11 new tests (5 sanitizer, 4 citations block, 1 Phase 7 ordering regression, 1 omission)
- Full suite: 1002 passing (was 991 on main)

The Phase 7 regression test asserts that `insertText` location indices in the Referenced Reports batch are strictly non-increasing, which catches any future regression of the cell-shift bug.
