### PR TITLE
fix(raycon): omit total_building_sf when missing/zero, log error body

### DIFF
--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -166,9 +166,16 @@ def post_raycon_job(
             "post_raycon_job missing required fields: " + ", ".join(missing_required)
         )
 
-    # Spec §2.3 requires integer SF. Use 0 as a sentinel when caller
-    # truly has no value so the field is still present on the wire.
-    sf_int = int(total_building_sf) if total_building_sf is not None else 0
+    # RayCon's validator rejects 0 ("Number must be greater than 0") and
+    # null ("Expected number, received null") on `total_building_sf`. When
+    # the caller has no real SF value, omit the field entirely — RayCon
+    # accepts the payload without it. Only send the field when we have a
+    # positive integer.
+    sf_int: int | None
+    if total_building_sf is not None and int(total_building_sf) > 0:
+        sf_int = int(total_building_sf)
+    else:
+        sf_int = None
 
     body: dict[str, Any] = {
         "schema_version": "1.0",
@@ -179,10 +186,25 @@ def post_raycon_job(
         "m1_folder_id": m1_folder_id,
         "block_plan_file_id": block_plan_file_id,
         "block_plan_url": block_plan_url,
-        "total_building_sf": sf_int,
         "callback_marker": RAYCON_CALLBACK_MARKER,
         "requested_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    if sf_int is not None:
+        # Insert before callback_marker to preserve the canonical field
+        # ordering documented in the spec for any future debuggers.
+        body = {
+            "schema_version": body["schema_version"],
+            "site_id": body["site_id"],
+            "site_name": body["site_name"],
+            "address": body["address"],
+            "drive_folder_url": body["drive_folder_url"],
+            "m1_folder_id": body["m1_folder_id"],
+            "block_plan_file_id": body["block_plan_file_id"],
+            "block_plan_url": body["block_plan_url"],
+            "total_building_sf": sf_int,
+            "callback_marker": body["callback_marker"],
+            "requested_at": body["requested_at"],
+        }
 
     # Serialize once and POST those exact bytes. Using `requests`' `json=`
     # would re-serialize and break the signature when HMAC verification is
@@ -212,7 +234,29 @@ def post_raycon_job(
         headers=headers,
         timeout=60,
     )
-    response.raise_for_status()
+    if response.status_code >= 400:
+        # Capture RayCon's response body so the validation reason is visible
+        # in cron logs and in the raised exception. Without this the body
+        # was discarded and 400s looked indistinguishable in our telemetry.
+        body_text = (response.text or "").strip()
+        logger.error(
+            "RayCon job dispatch failed: site=%s block_plan_file_id=%s status=%s body=%s",
+            site_name,
+            block_plan_file_id,
+            response.status_code,
+            body_text[:2000],
+        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            # Re-raise with the response body inlined in the message so the
+            # validation reason survives into retry logs and bubbles up to
+            # the cron's error counter.
+            raise requests.HTTPError(
+                f"{exc} | RayCon response body: {body_text[:2000]}",
+                response=response,
+                request=getattr(exc, "request", None),
+            ) from exc
     try:
         return response.json()
     except ValueError:

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -160,10 +160,10 @@ class TestPostRayConJob:
             with pytest.raises(ValueError, match="block_plan_file_id"):
                 post_raycon_job(total_building_sf=8400, **kw)
 
-    def test_total_building_sf_omitted_sends_zero(self) -> None:
-        # Spec §1.2 marks total_building_sf required. When the Wrike record
-        # lacks it, we still send the field (as 0) rather than dropping it,
-        # so RayCon's validator sees a complete payload.
+    def test_total_building_sf_omitted_drops_field(self) -> None:
+        # RayCon's validator rejects 0 ("Number must be greater than 0") and
+        # null on `total_building_sf`. When the Wrike record lacks a value,
+        # drop the field entirely so the payload validates.
         with patch(
             "due_diligence_reporter.raycon_client.get_settings",
             return_value=self._fake_settings(),
@@ -173,7 +173,88 @@ class TestPostRayConJob:
         ) as mock_post:
             post_raycon_job(**_REQUIRED_KW)
         body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
-        assert body["total_building_sf"] == 0
+        assert "total_building_sf" not in body
+        # Spec §1.2 ordering preserved for the fields we *do* send.
+        assert list(body.keys()) == [
+            "schema_version",
+            "site_id",
+            "site_name",
+            "address",
+            "drive_folder_url",
+            "m1_folder_id",
+            "block_plan_file_id",
+            "block_plan_url",
+            "callback_marker",
+            "requested_at",
+        ]
+
+    def test_total_building_sf_zero_drops_field(self) -> None:
+        # Same guarantee when the caller passes 0 explicitly: the validator
+        # rejects 0, so we treat 0 the same as missing and omit the field.
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            post_raycon_job(total_building_sf=0, **_REQUIRED_KW)
+        body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
+        assert "total_building_sf" not in body
+
+    def test_positive_sf_sent_in_canonical_position(self) -> None:
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            post_raycon_job(total_building_sf=8400, **_REQUIRED_KW)
+        body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
+        assert body["total_building_sf"] == 8400
+        # Field sits between block_plan_url and callback_marker per spec.
+        keys = list(body.keys())
+        assert keys.index("total_building_sf") == keys.index("block_plan_url") + 1
+        assert keys.index("callback_marker") == keys.index("total_building_sf") + 1
+
+    def test_4xx_error_logs_response_body_and_includes_in_exception(self, caplog) -> None:
+        # Regression: RayCon returns 400 with a JSON body explaining *why*
+        # the payload failed validation. The previous code called
+        # raise_for_status() without capturing that body, leaving cron logs
+        # showing only "400 Client Error" with no diagnostic. We must log
+        # the body and surface it on the raised exception.
+        bad_response = MagicMock()
+        bad_response.status_code = 400
+        bad_response.text = (
+            '{"ok":false,"error":{"code":"VALIDATION_ERROR",'
+            '"message":"Number must be greater than 0",'
+            '"path":"total_building_sf"}}'
+        )
+        bad_response.raise_for_status.side_effect = requests.HTTPError(
+            "400 Client Error: Bad Request for url: https://raycon.test/v1/jobs",
+            response=bad_response,
+        )
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=bad_response,
+        ), caplog.at_level("ERROR", logger="due_diligence_reporter.raycon_client"):
+            with pytest.raises(requests.HTTPError) as excinfo:
+                post_raycon_job(total_building_sf=8400, **_REQUIRED_KW)
+
+        # Exception message carries the RayCon response body so the cron
+        # log line and any upstream alert sees the validation reason.
+        assert "VALIDATION_ERROR" in str(excinfo.value)
+        assert "total_building_sf" in str(excinfo.value)
+        # And the structured log captured the same body.
+        assert any(
+            "VALIDATION_ERROR" in record.getMessage()
+            and "status=400" in record.getMessage()
+            for record in caplog.records
+        )
 
     def test_signature_matches_byte_exact_payload(self) -> None:
         # Regression: signing must happen over the exact bytes posted; if
@@ -196,6 +277,7 @@ class TestPostRayConJob:
     def test_retries_on_5xx_then_succeeds(self) -> None:
         flaky = MagicMock()
         flaky.status_code = 503
+        flaky.text = ""
         flaky.raise_for_status.side_effect = requests.HTTPError(response=flaky)
         ok = _ok_response()
         with patch(


### PR DESCRIPTION
## Why

Every RayCon dispatch from the follow-up cron has been failing with HTTP 400 since RayCon's `/v1/jobs` validator started rejecting `total_building_sf: 0`. The 4 sites with Block Plans (Alpha Early NYC 156 William, Alpha Kirkland 620 5th Ave S, Alpha Dallas 4152 Cole, Alpha Edmond 400 S Coltrane) have all been stuck — `published=0 dispatched=0 errors=4` on every cron run.

Confirmed live by probing the endpoint with curl:

| Payload | Result |
|---|---|
| `total_building_sf: 0` | 400 `VALIDATION_ERROR` "Number must be greater than 0" |
| `total_building_sf: null` | 400 "Expected number, received null" |
| field omitted | **200 accepted** |
| `total_building_sf: 5000` | 200 accepted |

Compounding the problem: `post_raycon_job` was calling `response.raise_for_status()` without capturing RayCon's response body, so cron logs only showed `"400 Client Error"` with no diagnostic — the validation reason was invisible.

## What

**`src/due_diligence_reporter/raycon_client.py`**
- When `total_building_sf` is `None` or `<= 0`, drop the key from the wire body. Only send the field when we have a positive integer. Canonical field ordering preserved when the field is present.
- On `response.status_code >= 400`, capture the response body, log it (with status + `block_plan_file_id`), and re-raise `HTTPError` with the body inlined in the message so the validation reason survives into retry/cron logs.

**`tests/test_raycon_client.py`**
- Renamed `test_total_building_sf_omitted_sends_zero` → `test_total_building_sf_omitted_drops_field`. Asserts the field is absent and the remaining 10 keys keep spec ordering.
- New `test_total_building_sf_zero_drops_field`: explicit `0` is dropped too.
- New `test_positive_sf_sent_in_canonical_position`: positive value sits between `block_plan_url` and `callback_marker`.
- New `test_4xx_error_logs_response_body_and_includes_in_exception`: verifies the validation reason lands in both the structured log line and the raised exception.

## Tests

`uv run pytest` — **1005 passing** (was 1002, +3 new).

## Recovery

RayCon's `/v1/jobs` is idempotent on `block_plan_file_id`. The next cron run after merge (every 5 min, Mon–Fri 6 AM–8 PM Central) will safely retry all 4 stuck sites.

## Side effect (from probing)

While diagnosing, I dispatched 2 real RayCon runs against the live Edmond Block Plan. Both failed RayCon-side validation with `no_address_match` — RayCon's real estate spreadsheet doesn't yet resolve a microschool tier for Edmond's address. A `raycon_scenario.json` with `status: failed` now exists in Edmond's M1 folder; the next follow-up cron will surface the existing "raycon run failed" alert in Chat (correct designed behavior). The address-match issue is a separate RayCon-side data issue and not in scope for this PR.

## Risk

Low. The only behavior change for callers passing a positive SF value is the (unchanged) field set on the wire. For callers passing `None` or `0`, the field is now omitted instead of sent as `0` — which is exactly what RayCon's validator requires.
