### PR TITLE
fix(raycon): normalize drive_folder_url before dispatch

### DIFF
--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -43,6 +43,7 @@ from .config import get_settings
 from .google_client import GoogleClient
 from .m1_lookup import _resolve_m1_folder
 from .retry import retry_config
+from .utils import extract_folder_id_from_url
 
 logger = logging.getLogger("[raycon_client]")
 
@@ -115,6 +116,45 @@ def _compute_hmac_signature(secret: str, body_bytes: bytes) -> str:
     return f"sha256={digest}"
 
 
+def _normalize_drive_folder_url(value: str) -> str | None:
+    """Return a clean canonical Drive folder URL or None if unparseable.
+
+    RayCon's ``/v1/jobs`` validator on ``drive_folder_url`` is strict: it
+    rejects HTML anchor wrapping, leading/trailing text, and file URLs
+    (``/file/d/<id>``) with ``"drive_folder_url must be a Google Drive
+    folder URL or folder ID containing a 10-200 character folder ID"``.
+    Wrike's "Google Folder" custom field, however, sometimes stores an
+    HTML anchor (e.g. ``<a href="...folders/<id>">Site</a>``) or has
+    extra text appended by PMs. We normalize defensively here so a
+    sloppy Wrike entry doesn't burn a RayCon dispatch slot.
+
+    Reuses :func:`extract_folder_id_from_url` (which unwraps anchors and
+    matches both ``/folders/<id>`` and ``?id=<id>``) to pull the ID, then
+    rebuilds the canonical URL shape RayCon's validator accepts.
+    """
+    folder_id = extract_folder_id_from_url(value)
+    if not folder_id:
+        return None
+    return f"https://drive.google.com/drive/folders/{folder_id}"
+
+
+def _unwrap_html_anchor(value: str) -> str:
+    """Return the href content of an HTML anchor, or the value unchanged.
+
+    Wrike rich-text fields can wrap raw URLs in ``<a href="...">label</a>``
+    when a PM pastes via the rich-text editor. RayCon's validators are
+    strict about extraneous markup, so this small unwrapper keeps us
+    forward-safe across fields where the validator currently happens to
+    be lenient.
+    """
+    import re as _re
+
+    match = _re.search(r'href="([^"]+)"', value)
+    if match:
+        return match.group(1).replace("&amp;", "&")
+    return value
+
+
 @retry(**retry_config())  # type: ignore[untyped-decorator]
 def post_raycon_job(
     *,
@@ -165,6 +205,20 @@ def post_raycon_job(
         raise ValueError(
             "post_raycon_job missing required fields: " + ", ".join(missing_required)
         )
+
+    # Normalize Wrike-sourced URLs before they hit RayCon's strict
+    # validators. Live runs surfaced 400s from HTML-anchor-wrapped folder
+    # URLs in Wrike's Google Folder field (e.g. NYC 156 William, Dallas
+    # 4152 Cole on 2026-05-05).
+    normalized_folder = _normalize_drive_folder_url(drive_folder_url)
+    if not normalized_folder:
+        raise ValueError(
+            "post_raycon_job: drive_folder_url is not parseable as a Google "
+            f"Drive folder URL or ID (got {drive_folder_url!r}). Fix the "
+            "site's Google Folder custom field in Wrike."
+        )
+    drive_folder_url = normalized_folder
+    block_plan_url = _unwrap_html_anchor(block_plan_url)
 
     # RayCon's validator rejects 0 ("Number must be greater than 0") and
     # null ("Expected number, received null") on `total_building_sf`. When
@@ -313,6 +367,20 @@ def post_raycon_folder_ping(
             + ", ".join(missing_required)
         )
 
+    # Same defensive normalization as post_raycon_job: a Wrike folder field
+    # wrapped in an HTML anchor (or with extra text) makes RayCon's strict
+    # validator return 400 here too.
+    normalized_folder = _normalize_drive_folder_url(drive_folder_url)
+    if not normalized_folder:
+        raise ValueError(
+            "post_raycon_folder_ping: drive_folder_url is not parseable as a "
+            f"Google Drive folder URL or ID (got {drive_folder_url!r}). Fix "
+            "the site's Google Folder custom field in Wrike."
+        )
+    drive_folder_url = normalized_folder
+    if file_url:
+        file_url = _unwrap_html_anchor(file_url)
+
     body: dict[str, Any] = {
         "schema_version": "1.0",
         "site_id": site_id,
@@ -353,7 +421,23 @@ def post_raycon_folder_ping(
         headers=headers,
         timeout=60,
     )
-    response.raise_for_status()
+    if response.status_code >= 400:
+        body_text = (response.text or "").strip()
+        logger.error(
+            "RayCon folder ping failed: site=%s doc_type=%s status=%s body=%s",
+            site_name,
+            doc_type or "(unspecified)",
+            response.status_code,
+            body_text[:2000],
+        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            raise requests.HTTPError(
+                f"{exc} | RayCon response body: {body_text[:2000]}",
+                response=response,
+                request=getattr(exc, "request", None),
+            ) from exc
     try:
         return response.json()
     except ValueError:

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -15,6 +15,8 @@ from due_diligence_reporter.raycon_client import (
     RAYCON_SCENARIO_FILENAME,
     RayConSchemaError,
     _compute_hmac_signature,
+    _normalize_drive_folder_url,
+    _unwrap_html_anchor,
     post_raycon_folder_ping,
     post_raycon_job,
     raycon_payload_failed,
@@ -22,6 +24,69 @@ from due_diligence_reporter.raycon_client import (
     raycon_scenario_to_report_fields,
     read_raycon_scenario_from_m1,
 )
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDriveFolderUrl:
+    """RayCon /v1/jobs validators reject HTML-anchor-wrapped folder URLs.
+
+    Wrike's rich-text Google Folder field can store an anchor; we must
+    rebuild a canonical /drive/folders/<id> URL before dispatch.
+    """
+
+    def test_plain_folder_url_passes_through_canonicalized(self) -> None:
+        out = _normalize_drive_folder_url(
+            "https://drive.google.com/drive/folders/abc123abc123"
+        )
+        assert out == "https://drive.google.com/drive/folders/abc123abc123"
+
+    def test_u0_prefixed_folder_url_canonicalized(self) -> None:
+        out = _normalize_drive_folder_url(
+            "https://drive.google.com/drive/u/0/folders/abc123abc123"
+        )
+        assert out == "https://drive.google.com/drive/folders/abc123abc123"
+
+    def test_html_anchor_unwrapped(self) -> None:
+        out = _normalize_drive_folder_url(
+            '<a href="https://drive.google.com/drive/folders/abc123abc123">Site</a>'
+        )
+        assert out == "https://drive.google.com/drive/folders/abc123abc123"
+
+    def test_open_id_format_canonicalized(self) -> None:
+        out = _normalize_drive_folder_url(
+            "https://drive.google.com/open?id=abc123abc123"
+        )
+        assert out == "https://drive.google.com/drive/folders/abc123abc123"
+
+    def test_file_url_returns_none(self) -> None:
+        # /file/d/<id> is not a folder URL — caller will raise a clear
+        # "fix the Wrike field" error rather than dispatch a doomed POST.
+        out = _normalize_drive_folder_url(
+            "https://drive.google.com/file/d/abc123abc123/view"
+        )
+        assert out is None
+
+    def test_garbage_returns_none(self) -> None:
+        assert _normalize_drive_folder_url("") is None
+        assert _normalize_drive_folder_url("not a url") is None
+
+
+class TestUnwrapHtmlAnchor:
+    def test_anchor_unwrapped(self) -> None:
+        assert _unwrap_html_anchor(
+            '<a href="https://drive.google.com/file/d/xyz/view">BP</a>'
+        ) == "https://drive.google.com/file/d/xyz/view"
+
+    def test_amp_entities_decoded(self) -> None:
+        assert _unwrap_html_anchor('<a href="a?b=1&amp;c=2">x</a>') == "a?b=1&c=2"
+
+    def test_plain_url_passes_through(self) -> None:
+        url = "https://drive.google.com/file/d/xyz/view"
+        assert _unwrap_html_anchor(url) == url
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +282,71 @@ class TestPostRayConJob:
         keys = list(body.keys())
         assert keys.index("total_building_sf") == keys.index("block_plan_url") + 1
         assert keys.index("callback_marker") == keys.index("total_building_sf") + 1
+
+    def test_drive_folder_url_html_anchor_normalized(self) -> None:
+        # Live regression (2026-05-05): NYC 156 William and Dallas 4152 Cole
+        # had Wrike Google Folder fields stored as HTML anchors. RayCon's
+        # validator rejected the raw anchor with 400. We must unwrap to a
+        # canonical /drive/folders/<id> URL before sending.
+        kw = dict(_REQUIRED_KW)
+        kw["drive_folder_url"] = (
+            '<a href="https://drive.google.com/drive/folders/'
+            '13L4rDu9mW4UNPzBjLgZvadsrY8Cnl3zJ">Site Folder</a>'
+        )
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            post_raycon_job(total_building_sf=8400, **kw)
+        body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
+        assert body["drive_folder_url"] == (
+            "https://drive.google.com/drive/folders/"
+            "13L4rDu9mW4UNPzBjLgZvadsrY8Cnl3zJ"
+        )
+
+    def test_drive_folder_url_open_id_format_normalized(self) -> None:
+        # /open?id=<id> is a valid Drive folder URL shape; rebuild it as
+        # the canonical /drive/folders/<id> form for RayCon.
+        kw = dict(_REQUIRED_KW)
+        kw["drive_folder_url"] = (
+            "https://drive.google.com/open?id=13L4rDu9mW4UNPzBjLgZvadsrY8Cnl3zJ"
+        )
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            post_raycon_job(total_building_sf=8400, **kw)
+        body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
+        assert body["drive_folder_url"].endswith(
+            "/drive/folders/13L4rDu9mW4UNPzBjLgZvadsrY8Cnl3zJ"
+        )
+
+    def test_drive_folder_url_unparseable_raises_clear_error(self) -> None:
+        # When Wrike has a value with no recoverable folder ID (e.g. the PM
+        # pasted a /file/d/<id> URL by mistake), we must raise a clear
+        # message naming Wrike as the fix-it surface, *before* we burn a
+        # RayCon dispatch on a guaranteed-400.
+        kw = dict(_REQUIRED_KW)
+        kw["drive_folder_url"] = (
+            "https://drive.google.com/file/d/13L4rDu9mW4UNPzBjLgZvadsrY8Cnl3zJ/view"
+        )
+        with patch(
+            "due_diligence_reporter.raycon_client.get_settings",
+            return_value=self._fake_settings(),
+        ), patch(
+            "due_diligence_reporter.raycon_client.requests.post",
+            return_value=_ok_response(),
+        ) as mock_post:
+            with pytest.raises(ValueError, match="Google Folder custom field in Wrike"):
+                post_raycon_job(total_building_sf=8400, **kw)
+        # Critically: we never made the network call.
+        assert mock_post.call_count == 0
 
     def test_4xx_error_logs_response_body_and_includes_in_exception(self, caplog) -> None:
         # Regression: RayCon returns 400 with a JSON body explaining *why*


### PR DESCRIPTION
## Why

Manual run of `raycon-followup.yml` after PR #78 merged surfaced a *second* RayCon validator that the original cron failures masked. Three distinct outcomes from the run:

| Site | Result |
|---|---|
| Alpha Kirkland 620 5th Ave S | ✅ 200, run_id `rc_20260505212946_b475daf15d` (PR #78 fix worked) |
| Alpha Early NYC 156 William | ❌ 400 `drive_folder_url must be a Google Drive folder URL or folder ID containing a 10-200 character folder ID` |
| Alpha Dallas 4152 Cole | ❌ same 400 |
| Alpha Edmond 400 S Coltrane | ✅ alert: `raycon run failed: no_address_match` (correct designed behavior) |

The new error logging from PR #78 made this visible immediately — exactly what we wanted.

## Root cause

Probed RayCon `/v1/jobs` directly. Validator on `drive_folder_url` accepts:
- `https://drive.google.com/drive/folders/<id>`
- `https://drive.google.com/drive/u/0/folders/<id>`
- `https://drive.google.com/open?id=<id>`
- bare folder ID

But rejects (400):
- HTML-anchor-wrapped URLs (e.g. `<a href="...folders/<id>">Site</a>`)
- URLs with leading/trailing text
- `/file/d/<id>/view` (file URLs, not folder URLs)

Wrike's "Google Folder" custom field is rich-text and sometimes stores an HTML anchor when a PM pastes via the rich-text editor. That anchor flows untouched through the cron into RayCon and gets rejected. Compounding factor: `_resolve_m1_folder` already calls `extract_folder_id_from_url` (which unwraps anchors), so M1 resolution succeeded and we proceeded to dispatch — but the raw anchor flowed forward into the wire body.

## What

**`src/due_diligence_reporter/raycon_client.py`**
- New `_normalize_drive_folder_url`: reuses existing `extract_folder_id_from_url` (which already unwraps anchors and matches both `/folders/<id>` and `?id=<id>`) to extract the ID, then rebuilds canonical `https://drive.google.com/drive/folders/<id>`.
- New `_unwrap_html_anchor`: cheap insurance for `block_plan_url` / `file_url` (RayCon's validator on those is currently lenient, but those values flow from Drive API and are usually clean).
- Apply normalization at the top of both `post_raycon_job` and `post_raycon_folder_ping`. If the value is unrecoverable (e.g. PM pasted a `/file/d/<id>` URL), raise `ValueError` naming Wrike as the fix-it surface **before** making the doomed POST.
- Folder ping now also captures and re-raises response body on 4xx (parity with the job dispatch path from PR #78).

**`tests/test_raycon_client.py`**
- New `TestNormalizeDriveFolderUrl` (6 cases): plain, `/u/0/`, anchor, `/open?id`, file URL → `None`, garbage → `None`.
- New `TestUnwrapHtmlAnchor` (3 cases): anchor unwrapped, `&amp;` decoded, plain pass-through.
- New `post_raycon_job` cases: HTML anchor normalized, `/open?id` normalized, unparseable raises clear error and does NOT make the network call.

## Tests

`uv run pytest` — **1017 passing** (was 1005 after PR #78, +12).

## Recovery

Next 5-min cron after merge will succeed for NYC 156 William and Dallas 4152 Cole — RayCon is idempotent on `block_plan_file_id`, no manual cleanup needed. Kirkland already has its run. Edmond's `no_address_match` is RayCon-side data (separate, not in scope).

Future Wrike entries with unrecoverable folder values surface a clear "Fix the Google Folder custom field" error in the cron's per-site error row instead of silently burning a RayCon attempt.
