### PR TITLE
Recognize PFP and Preliminary Floor Plan as Block Plan aliases

### DIFF
--- a/docs/prompts/prompt_v3.md
+++ b/docs/prompts/prompt_v3.md
@@ -400,7 +400,7 @@ Before reading any documents, show the user what was found from `shared_folder_f
 Document Discovery for [site name]:
   SIR:                    found -- [filename]  OR  not found
   Building Inspection:    found -- [filename]  OR  not found
-  Block Plan:             found -- [filename]  OR  not found
+  Block Plan / PFP:       found -- [filename]  OR  not found
   E-Occupancy Report:     found -- [filename]  OR  not found
   School Approval Report: found -- [filename]  OR  not found
   RayCon Scenario:        found -- [filename]  OR  not found
@@ -413,7 +413,7 @@ If documents are missing, tell the user which ones and ask whether to proceed. T
 For **every** report-relevant document found in `shared_folder_files` and `site_folder_files`, call `read_drive_document(file_id, file_name)`:
 - Read the **SIR** â†’ extract Q1 fields (zoning, AHJ, permits, timeline, cost/schedule risks)
 - Read the **Building Inspection** â†’ extract structural, MEP, fire safety, ADA, deficiency chart (see "Building Inspection Data Extraction" section)
-- Read the **Block Plan** â†’ use as the raw floor-plan source artifact and set `sources.block_plan_link` to its Drive URL
+- Read the **Block Plan** (also known as **Preliminary Floor Plan / Preliminary Floor Plans / PFP** — these are all the same artifact) â†’ use as the raw floor-plan source artifact and set `sources.block_plan_link` to its Drive URL
 - Read the **E-Occupancy Report** â†’ extract score (0--100), zone (GREEN/YELLOW/RED), tier, timeline, IBC code summary. Compose `exec.c_occupancy` from these fields: `Has E-Occupancy` / `Change of use required, meets E-Occupancy` / `Change of use required, needs work` based on the zone and tier.
 - Read the **School Approval Report** â†’ extract state, approval_type, score, gating requirements, timeline. Compose `exec.c_edreg` from these fields: `Not required` / `Required and have done` / `Required have not done` based on the state requirements and current approval status.
   - Use this Alpha state-history reference when deciding the status:
@@ -427,10 +427,10 @@ For **every** report-relevant document found in `shared_folder_files` and `site_
 When present, also read this M1-generated scenario artifact:
 - **RayCon Scenario Report** -> authoritative source for scenario capacity, capex, cost breakdown rows, and scenario construction timeline/open-date fields. The Doc opens with a "RayCon Run" header (status, run_id, block plan file id, summary). On a successful run, the Doc contains the Scenario Summary and Detailed Cost Breakdown tables. On a failed run the Doc is **not published** -- if you ever see a Doc whose header reads `Status: failed` or contains a `Validation Errors` block, treat every cost/capacity row as gap-labeled and route the failure into `source_quality_notes`.
 
-**Do not skip reading a report-relevant document that was found.** Read the SIR, Building Inspection, Block Plan, E-Occupancy Report, School Approval Report, and RayCon Scenario Report when present. If an ISP is present, ignore it for this report.
+**Do not skip reading a report-relevant document that was found.** Read the SIR, Building Inspection, Block Plan (a.k.a. Preliminary Floor Plan / PFP), E-Occupancy Report, School Approval Report, and RayCon Scenario Report when present. If an ISP is present, ignore it for this report.
 
 Use the `doc_type` values from the Step 2 `list_drive_documents` output to decide which source and derived artifacts are already present:
-- If a Block Plan is found, set `sources.block_plan_link` to its Drive URL
+- If a Block Plan is found (file may be titled "Block Plan", "Preliminary Floor Plan(s)", or "PFP" — all three are the same doc_type `block_plan`), set `sources.block_plan_link` to its Drive URL
 - If an Opening Plan is found: set `sources.opening_plan_link` to its Drive URL and **skip Step 5.8** (plan already exists)
 - If a RayCon Scenario report is found: use it as the scenario capacity / cost / timeline source for all RayCon-derived rows
 

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -46,6 +46,7 @@ import argparse
 import asyncio
 import json
 import logging
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -87,7 +88,34 @@ logging.basicConfig(
 logger = logging.getLogger("raycon_followup")
 
 PUBLISHED_DOC_PREFIX = "RayCon Scenario Assessment"
-BLOCK_PLAN_FILENAME_HINTS = ("block plan", "block_plan", "blockplan")
+
+# Substrings that unambiguously identify a Block Plan filename. "PFP" and
+# "preliminary floor plan(s)" are partner-side aliases for the same artifact
+# and must match the Block Plan classifier in `classifier.py`.
+BLOCK_PLAN_FILENAME_HINTS = (
+    "block plan",
+    "block_plan",
+    "blockplan",
+    "preliminary floor plan",
+)
+# "pfp" is matched separately with word boundaries so we don't false-positive
+# on filenames that merely contain the letters p-f-p (e.g. "epfpro.pdf").
+BLOCK_PLAN_PFP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bpfp\b"),
+    re.compile(r"[-_]pfp(\.[^.]+)?$"),
+)
+
+
+def _filename_matches_block_plan(name: str) -> bool:
+    """Return True if ``name`` (already lowercased) looks like a Block Plan.
+
+    Recognized aliases: "Block Plan", "Preliminary Floor Plan(s)", and
+    "PFP". All three refer to the same artifact and must route to the
+    same downstream RayCon dispatch path.
+    """
+    if any(hint in name for hint in BLOCK_PLAN_FILENAME_HINTS):
+        return True
+    return any(pat.search(name) for pat in BLOCK_PLAN_PFP_PATTERNS)
 
 # Persisted map of {site_name: ISO8601 timestamp of last Chat alert}.
 # Prevents the 5-minute cron from spamming ~96 alerts/day for a stuck site.
@@ -199,7 +227,7 @@ def _find_block_plan(gc: GoogleClient, m1_folder_id: str) -> dict[str, Any] | No
     candidate: dict[str, Any] | None = None
     for f in gc.list_files_in_folder(m1_folder_id):
         name = str(f.get("name", "")).lower()
-        if not any(hint in name for hint in BLOCK_PLAN_FILENAME_HINTS):
+        if not _filename_matches_block_plan(name):
             continue
         if candidate is None or str(f.get("modifiedTime", "")) > str(
             candidate.get("modifiedTime", "")

--- a/src/due_diligence_reporter/classifier.py
+++ b/src/due_diligence_reporter/classifier.py
@@ -80,7 +80,18 @@ def classify_by_keywords(filename: str) -> tuple[str, float]:
         return "raycon_scenario_json", 1.0
     if "raycon scenario" in name or "raycon estimate" in name:
         return "raycon_scenario_report", 0.95
-    if "block plan" in name:
+    # Block Plan aliases: "block plan", "preliminary floor plan(s)" / "PFP".
+    # Vendors and partners use these terms interchangeably for the same
+    # artifact, so they all route to the `block_plan` doc_type and land in
+    # the site's M1 folder.
+    if (
+        "block plan" in name
+        or "blockplan" in name
+        or "block_plan" in name
+        or "preliminary floor plan" in name
+        or re.search(r"\bpfp\b", name)
+        or re.search(r"[-_]pfp(\.[^.]+)?$", name)
+    ):
         return "block_plan", 0.95
     if "report trace" in name and name.endswith(".json"):
         return "report_trace", 0.95
@@ -109,7 +120,7 @@ Given only a filename (and optionally a site name for context), determine the do
 Types:
 - sir: Site Investigation Report (also called Site Inspection Report)
 - isp: Internet Service Provider report / availability report
-- block_plan: Block Plan PDF for a specific school site
+- block_plan: Block Plan PDF for a specific school site (also called "Preliminary Floor Plan", "Preliminary Floor Plans", or "PFP" — these are all the same artifact)
 - building_inspection: Building Inspection Report or property condition report
 - dd_report: Due Diligence Report (the final compiled report)
 - matterport: Matterport 3D scan or virtual tour
@@ -187,7 +198,7 @@ You are given the first page text of a PDF and its filename. Determine the docum
 Types:
 - sir: Site Investigation Report — covers zoning, permits, AHJ info, building code
 - isp: Internet Service Provider report — lists ISPs, speeds, availability
-- block_plan: Block Plan PDF describing the school site layout and capacity assumptions
+- block_plan: Block Plan PDF describing the school site layout and capacity assumptions (also called "Preliminary Floor Plan", "Preliminary Floor Plans", or "PFP" — these are all the same artifact)
 - building_inspection: Building Inspection Report — covers building condition, systems, deficiencies
 - dd_report: Due Diligence Report — the final compiled report with executive summary
 - matterport: Matterport 3D scan documentation

--- a/tests/test_classifier_keywords.py
+++ b/tests/test_classifier_keywords.py
@@ -95,6 +95,53 @@ class TestClassifyByKeywordsBlockPlan:
             0.95,
         )
 
+    def test_blockplan_concatenated(self):
+        assert classify_by_keywords("AlphaKeller_BlockPlan.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_block_plan_underscore(self):
+        assert classify_by_keywords("alpha_keller_block_plan.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_preliminary_floor_plan(self):
+        assert classify_by_keywords("Alpha Keller Preliminary Floor Plan.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_preliminary_floor_plans_plural(self):
+        """\"Preliminary Floor Plans\" (plural) is the same artifact."""
+        assert classify_by_keywords("Preliminary Floor Plans - Alpha Tampa.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_pfp_acronym_uppercase(self):
+        assert classify_by_keywords("Alpha Keller PFP.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_pfp_acronym_lowercase_hyphenated(self):
+        assert classify_by_keywords("alpha-keller-pfp.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_pfp_acronym_with_extension_only(self):
+        assert classify_by_keywords("PFP.pdf") == (
+            "block_plan",
+            0.95,
+        )
+
+    def test_pfp_substring_does_not_false_positive(self):
+        """PFP word boundary: must not match inside a longer word."""
+        assert classify_by_keywords("epfpro_brochure.pdf") == ("unknown", 0.0)
+
 
 class TestClassifyByKeywordsCapacityBrainlift:
     def test_capacity_brainlift(self):

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -684,3 +684,52 @@ class TestFilterDedupAlerts:
 
         assert len(fresh) == 1
         assert new_state["Alpha Keller"] == now.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Block Plan filename detection (PFP / Preliminary Floor Plan aliases)
+# ---------------------------------------------------------------------------
+
+
+class TestFilenameMatchesBlockPlan:
+    """Verify that ``_filename_matches_block_plan`` recognizes all three
+    partner-side aliases: \"Block Plan\", \"Preliminary Floor Plan(s)\", and
+    \"PFP\". These are interchangeable terms for the same artifact.
+    """
+
+    def test_block_plan_phrase(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("alpha keller block plan.pdf")
+
+    def test_blockplan_concatenated(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("alphakeller_blockplan.pdf")
+
+    def test_block_plan_underscore(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("keller_block_plan_v3.pdf")
+
+    def test_preliminary_floor_plan(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("alpha keller preliminary floor plan.pdf")
+
+    def test_preliminary_floor_plans_plural(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("preliminary floor plans - tampa.pdf")
+
+    def test_pfp_word_boundary_match(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("alpha keller pfp.pdf")
+
+    def test_pfp_hyphenated_match(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert _filename_matches_block_plan("alpha-keller-pfp.pdf")
+
+    def test_pfp_substring_does_not_match(self):
+        """Word boundary required: 'pfp' inside 'epfpro' must NOT match."""
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert not _filename_matches_block_plan("epfpro_brochure.pdf")
+
+    def test_unrelated_filename_does_not_match(self):
+        from scripts.raycon_followup import _filename_matches_block_plan
+        assert not _filename_matches_block_plan("alpha keller sir.pdf")


### PR DESCRIPTION
## Summary

Vendors and partners use "Block Plan", "Preliminary Floor Plan(s)", and "PFP" interchangeably for the same artifact. This PR teaches the document classifier and the RayCon follow-up scanner to treat all three labels as `doc_type=block_plan` so the file routes into the site's M1 folder and triggers the RayCon dispatch path.

## Changes

**Classifier (`src/due_diligence_reporter/classifier.py`)**
- Tier 1 `classify_by_keywords` now matches `block plan`, `blockplan`, `block_plan`, `preliminary floor plan`, and `\bpfp\b` / `[-_]pfp(\.ext)?$`.
- The `pfp` regex uses word boundaries so it does not false-positive on filenames like `epfpro.pdf`.
- Tier 2 and Tier 3 LLM prompts now document the aliases so filename- and content-based classification stay in sync.

**RayCon follow-up (`scripts/raycon_followup.py`)**
- Extracted `_filename_matches_block_plan()` helper that applies the same alias rules when scanning M1 for the most recent Block Plan PDF.
- `BLOCK_PLAN_FILENAME_HINTS` now includes `preliminary floor plan`; PFP is matched with a separate compiled regex via word boundaries.

**Prompt (`docs/prompts/prompt_v3.md`)**
- Discovery summary line, Step 4 read list, and the doc_type lookup all note that "Block Plan", "Preliminary Floor Plan(s)", and "PFP" are interchangeable terms for the same artifact.

## Tests

- `tests/test_classifier_keywords.py`: 8 new cases (block plan / blockplan / block_plan / Preliminary Floor Plan / Preliminary Floor Plans plural / PFP uppercase / PFP hyphenated / PFP-only filename, plus an `epfpro` negative case).
- `tests/test_raycon_followup.py`: 9 new cases for `_filename_matches_block_plan` covering the same alias matrix and word-boundary negative case.
- Full suite: **1034 passed**.