### PR TITLE
fix(raycon): forward P1 + feasibility + timeline fields on republish

### DIFF
--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -85,6 +85,8 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
     build_site_summary,
+    extract_school_feasibility_from_record,
+    extract_timeline_confidence_from_record,
     filter_active_site_records,
     load_wrike_config,
 )
@@ -537,6 +539,10 @@ def _republish_dd_report_if_present(
 
     site_address = str(site_summary.get("address", "")).strip() or None
     match_terms = build_site_match_terms(site_name, site_address)
+    # Thread the same Wrike-derived fields the daily/inbox callers pass —
+    # otherwise the regenerated DD Report email loses the P1 CC and the
+    # dashboard publish loses the W74/W81 ratings + Wrike createdDate.
+    record_for_extract = {"customFields": site_summary.get("custom_fields", [])}
     try:
         result = process_site_pipeline(
             gc,
@@ -546,7 +552,16 @@ def _republish_dd_report_if_present(
             shared_cache,
             system_prompt,
             settings,
+            p1_email=site_summary.get("p1_assignee_email"),
             site_address=site_address,
+            p1_name=site_summary.get("p1_assignee_name"),
+            school_feasibility=extract_school_feasibility_from_record(
+                record_for_extract
+            ),
+            timeline_confidence=extract_timeline_confidence_from_record(
+                record_for_extract
+            ),
+            wrike_created_at=site_summary.get("created_date") or None,
             force_regenerate=True,
         )
     except Exception as e:

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -810,6 +810,82 @@ class TestDDReportRepublish:
         assert out["dd_report_republish"] == "failed"
         assert "Anthropic 500" in out["reason"]
 
+    @patch("scripts.raycon_followup.extract_timeline_confidence_from_record")
+    @patch("scripts.raycon_followup.extract_school_feasibility_from_record")
+    @patch("scripts.raycon_followup.process_site_pipeline")
+    @patch("scripts.raycon_followup._find_existing_dd_report")
+    def test_republish_forwards_p1_and_feasibility_fields(
+        self,
+        mock_find_dd,
+        mock_pipeline,
+        mock_feasibility,
+        mock_timeline,
+    ):
+        """Regression for #82: republish must thread p1/feasibility/timeline/
+        wrike_created_at into ``process_site_pipeline`` so the regenerated DD
+        Report email still CC's the P1 owner and the dashboard publish keeps
+        the W74/W81 ratings + Wrike createdDate.
+
+        Covers two paths:
+          1. all fields present on site_summary → all forwarded.
+          2. fields missing on site_summary → forwarded as None (no crash).
+        """
+        mock_find_dd.return_value = {"id": "dd1", "name": "Alpha Keller DD Report"}
+        result_obj = MagicMock()
+        result_obj.status = "report_created"
+        result_obj.doc_url = "https://docs.google.com/document/d/dd1"
+        mock_pipeline.return_value = result_obj
+        mock_feasibility.return_value = "high"
+        mock_timeline.return_value = "medium"
+
+        gc = MagicMock()
+        full_site = {
+            **_site(),
+            "p1_assignee_email": "owner@example.com",
+            "p1_assignee_name": "Alex Owner",
+            "created_date": "2026-01-15T12:00:00Z",
+            "custom_fields": [{"id": "f1", "value": "high"}],
+        }
+        _republish_dd_report_if_present(
+            gc,
+            full_site,
+            "rc_run_abc",
+            settings=self._settings(),
+            system_prompt="prompt",
+            shared_cache={},
+            republish_state={},
+            dry_run=False,
+        )
+
+        kwargs = mock_pipeline.call_args.kwargs
+        assert kwargs.get("force_regenerate") is True
+        assert kwargs.get("p1_email") == "owner@example.com"
+        assert kwargs.get("p1_name") == "Alex Owner"
+        assert kwargs.get("school_feasibility") == "high"
+        assert kwargs.get("timeline_confidence") == "medium"
+        assert kwargs.get("wrike_created_at") == "2026-01-15T12:00:00Z"
+
+        # Graceful-default path: site_summary missing the optional fields.
+        mock_pipeline.reset_mock()
+        mock_feasibility.return_value = None
+        mock_timeline.return_value = None
+        _republish_dd_report_if_present(
+            gc,
+            _site(),  # no p1_*, no created_date, no custom_fields
+            "rc_run_def",
+            settings=self._settings(),
+            system_prompt="prompt",
+            shared_cache={},
+            republish_state={},
+            dry_run=False,
+        )
+        kwargs = mock_pipeline.call_args.kwargs
+        assert kwargs.get("p1_email") is None
+        assert kwargs.get("p1_name") is None
+        assert kwargs.get("school_feasibility") is None
+        assert kwargs.get("timeline_confidence") is None
+        assert kwargs.get("wrike_created_at") is None
+
     @patch("scripts.raycon_followup.save_skill_report")
     @patch("scripts.raycon_followup._find_published_doc")
     @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced in #82.

The new `_republish_dd_report_if_present` helper in `scripts/raycon_followup.py` called `process_site_pipeline` with only `site_address` and `force_regenerate=True`, dropping `p1_email` / `p1_name` / `school_feasibility` / `timeline_confidence` / `wrike_created_at` — fields the other production callers (`scripts/scan_inbox.py`, `scripts/daily_dd_check.py`) thread through. `_email_pipeline_report` (`src/due_diligence_reporter/report_pipeline.py:1145-1146`) only adds the P1 owner to the recipient list when `p1_email` is non-`None`, so regenerated DD Reports silently stopped CC'ing the P1 owner. The dashboard publish payload also lost the W74/W81 ratings and the Wrike `createdDate`.

## What's now passed

The republish call now forwards the same fields the daily/inbox callers do, all sourced from the existing `site_summary` populated by `wrike.build_site_summary`:

| kwarg | source |
| --- | --- |
| `p1_email` | `site_summary["p1_assignee_email"]` |
| `p1_name` | `site_summary["p1_assignee_name"]` |
| `school_feasibility` | `extract_school_feasibility_from_record({"customFields": site_summary["custom_fields"]})` |
| `timeline_confidence` | `extract_timeline_confidence_from_record({"customFields": site_summary["custom_fields"]})` |
| `wrike_created_at` | `site_summary["created_date"]` |

Missing keys yield `None` via `.get(...)` — no crash on partial summaries, matching the other callers' behavior.

## Tests

New `TestDDReportRepublish::test_republish_forwards_p1_and_feasibility_fields` asserts the kwargs are forwarded into a mocked `process_site_pipeline`. It covers both the happy path (all fields present on `site_summary`) and the graceful-default path (all optional fields missing → `None`).

## Test plan

- [x] `uv run pytest tests/test_raycon_followup.py tests/test_report_pipeline.py` — 63 passed
- [x] Confirmed the new test fails when the source fix is reverted (catches the regression)

---
🤖 *Generated by Computer*