### PR TITLE
chore(vendor-gate): enable VENDOR_GATE_ENABLED=1 in cron workflows

### DIFF
--- a/.github/workflows/daily-dd-check.yml
+++ b/.github/workflows/daily-dd-check.yml
@@ -17,6 +17,8 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Vendor gate ON: requires vendor-sourced SIR + BI + raycon_scenario.json. Greg's call (Rec. 8). Manual MCP path is unaffected.
+  VENDOR_GATE_ENABLED: "1"
 
 jobs:
   daily-check:

--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -21,6 +21,8 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Vendor gate ON: requires vendor-sourced SIR + BI + raycon_scenario.json. Greg's call (Rec. 8). Manual MCP path is unaffected.
+  VENDOR_GATE_ENABLED: "1"
 
 jobs:
   inbox-scan:

--- a/.github/workflows/raycon-followup.yml
+++ b/.github/workflows/raycon-followup.yml
@@ -40,6 +40,8 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Vendor gate ON: requires vendor-sourced SIR + BI + raycon_scenario.json. Greg's call (Rec. 8). Manual MCP path is unaffected.
+  VENDOR_GATE_ENABLED: "1"
 
 jobs:
   raycon-followup:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ changes do not get an entry.
 
 ## [Unreleased]
 
+### Changed
+
+- **Vendor gate flipped on for cron paths (daily sweep, inbox scanner, raycon
+  followup republish).** `VENDOR_GATE_ENABLED=1` is now set in the workflow
+  `env` block of `daily-dd-check.yml`, `inbox-scan.yml`, and
+  `raycon-followup.yml`. With the gate on, `_missing_required_docs` requires a
+  vendor-sourced SIR (CDS, not AI-generated), a vendor-sourced Building
+  Inspection (Worksmith, not AI-generated), and `raycon_scenario.json`. Manual
+  MCP `create_dd_report` path is unaffected (it goes through
+  `server.py::check_site_readiness`). Closes pre-vendor-gate Tulsa-class false
+  positives. Revert is a single env-var change per workflow file (or set
+  `VENDOR_GATE_ENABLED=0`); no code revert needed.
+
 ### Fixed
 
 - **MCP Hive cold-start tool-list timeout (502 / 60s `tools/list` timeouts on


### PR DESCRIPTION
## Summary

Flips the vendor gate ON for cron-driven report generation (daily sweep, inbox scanner, raycon followup republish). The gate requires vendor-sourced SIR + vendor-sourced Building Inspection + `raycon_scenario.json`. The manual MCP `create_dd_report` path uses a separate readiness check (`server.py::check_site_readiness`) that is unaffected, so Greg can still manually invoke generation with whatever inputs are on hand.

Implements **Rec. 8** from the recommendations doc.

## Files modified

- `.github/workflows/daily-dd-check.yml` — added `VENDOR_GATE_ENABLED: "1"` to top-level `env` block
- `.github/workflows/inbox-scan.yml` — same
- `.github/workflows/raycon-followup.yml` — same (covers PR #82's republish path that runs `process_site_pipeline(force_regenerate=True)`)
- `CHANGELOG.md` — `[Unreleased] / Changed` entry

## Notes

- Skipping the `cleanup_premature_dd_reports.py` dry-run per Greg — existing bogus reports stay in place but no new ones get generated.
- Revert is a single env-var change in each workflow file (or set `VENDOR_GATE_ENABLED=0`); no code revert needed.
- `report_pipeline._vendor_gate_enabled` default stays OFF in code by design — the workflow env vars do the lift, which makes revert a one-line YAML change.
- `scripts/cleanup_premature_dd_reports.py` uses `os.environ.setdefault("VENDOR_GATE_ENABLED", "1")`, which won't conflict with workflow-level env (setdefault doesn't overwrite).

## Test plan

- [x] `uv run pytest tests/test_vendor_gate.py tests/test_report_pipeline.py tests/test_raycon_followup.py` — 77 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)