### PR TITLE
fix(observability): surface 3 silent failures (dashboard publish, provenance default, raycon schema)

### DIFF
--- a/src/due_diligence_reporter/provenance.py
+++ b/src/due_diligence_reporter/provenance.py
@@ -89,11 +89,22 @@ class ProvenanceVerdict:
 
     label: str  # "vendor" | "ai_generated" | "unknown"
     confidence: float
-    tier: str  # "filename" | "content" | "cached" | "trivial"
+    tier: str  # "filename" | "content" | "cached" | "trivial" | "error"
     reason: str = ""
+    # Set True only when classify_provenance itself raised and we fell
+    # through to the safe default. Lets callers distinguish "classifier
+    # said this isn't vendor" from "classifier crashed and we don't
+    # actually know" — the latter must NOT open the vendor gate.
+    provenance_classification_failed: bool = False
 
     @property
     def is_vendor(self) -> bool:
+        # On classifier error we deliberately return False (not vendor) so
+        # AI-generated SIRs cannot slip past the vendor gate when the
+        # classifier itself crashes. This is the Tulsa-class failure mode
+        # that the recommendations doc (Rec. 6) calls out.
+        if self.provenance_classification_failed:
+            return False
         # Default to vendor on UNKNOWN — better to surface a doc the gate
         # then rejects on completeness than to silently hide a real vendor doc.
         return self.label != _AI
@@ -241,8 +252,45 @@ def classify_provenance(
             the doc_type is exclusively AI-produced (e.g. ``dd_report``),
             short-circuit before any I/O.
 
-    Returns a ``ProvenanceVerdict``.
+    Returns a ``ProvenanceVerdict``. On any internal exception, returns a
+    verdict with ``provenance_classification_failed=True`` and
+    ``is_vendor=False`` so the vendor gate fails closed instead of letting
+    AI-generated SIRs through (Rec. 6).
     """
+    try:
+        return _classify_provenance_inner(
+            file_info, gc, m1_folder_id=m1_folder_id, doc_type=doc_type
+        )
+    except Exception as e:
+        name = ""
+        try:
+            if isinstance(file_info, dict):
+                name = str(file_info.get("name", ""))
+        except Exception:
+            name = ""
+        logger.error(
+            "Provenance classification failed for %s (%s): %s",
+            name or "<unknown>",
+            type(e).__name__,
+            e,
+        )
+        return ProvenanceVerdict(
+            label=_UNKNOWN,
+            confidence=0.0,
+            tier="error",
+            reason=f"classifier raised {type(e).__name__}: {e}"[:200],
+            provenance_classification_failed=True,
+        )
+
+
+def _classify_provenance_inner(
+    file_info: dict[str, Any],
+    gc: Any | None = None,
+    *,
+    m1_folder_id: str | None = None,
+    doc_type: str | None = None,
+) -> ProvenanceVerdict:
+    """Real classify_provenance body. Wrapped by ``classify_provenance``."""
     if not isinstance(file_info, dict):
         return ProvenanceVerdict(_UNKNOWN, 0.0, "trivial", "no file_info")
 

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -12,6 +12,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import anthropic
@@ -1061,13 +1062,75 @@ def _run_pipeline_agent(
     )
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Best-effort observability state files
+#
+# Mirror the ``.raycon_dispatch_state.json`` shape used by ``raycon_followup``
+# so on-call has a single style of failure-state file to look at when a
+# best-effort path silently degraded.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DASHBOARD_PUBLISH_FAILURES_PATH = _PROJECT_ROOT / ".dashboard_publish_failures.json"
+PIPELINE_TRACE_FAILURES_PATH = _PROJECT_ROOT / ".pipeline_trace_failures.json"
+
+
+def _load_failure_state(path: Path) -> dict[str, dict[str, Any]]:
+    """Load a best-effort failure-state map. Returns ``{}`` on any error."""
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return {}
+        return {k: v for k, v in data.items() if isinstance(v, dict)}
+    except Exception as e:
+        logger.warning("Failed to read failure state at %s: %s", path, e)
+        return {}
+
+
+def _save_failure_state(state: dict[str, dict[str, Any]], path: Path) -> None:
+    """Persist a best-effort failure-state map. Logs but does not raise."""
+    try:
+        path.write_text(json.dumps(state, sort_keys=True, indent=2), encoding="utf-8")
+    except Exception as e:
+        logger.warning("Failed to write failure state at %s: %s", path, e)
+
+
+def _record_best_effort_failure(
+    path: Path,
+    key: str,
+    *,
+    site_title: str,
+    error_type: str,
+    error_message: str,
+) -> None:
+    """Append/update a failure record so silent degradations stay observable."""
+    state = _load_failure_state(path)
+    prior = state.get(key, {}) if isinstance(state.get(key), dict) else {}
+    attempts = int(prior.get("attempts", 0)) + 1
+    state[key] = {
+        "site_title": site_title,
+        "error_type": error_type,
+        "error_message": error_message[:500],
+        "failed_at": datetime.now(UTC).isoformat(),
+        "attempts": attempts,
+    }
+    _save_failure_state(state, path)
+
+
 def _save_pipeline_trace(
     gc: GoogleClient,
     drive_folder_url: str,
     site_title: str,
     trace: ReportTrace | None,
 ) -> str | None:
-    """Persist a report trace JSON beside the generated report."""
+    """Persist a report trace JSON beside the generated report.
+
+    Best-effort: on upload failure, log AND append a structured record to
+    ``.pipeline_trace_failures.json`` so a wedged trace upload doesn't go
+    unnoticed for days. Never raises.
+    """
     if not trace:
         return None
 
@@ -1089,6 +1152,20 @@ def _save_pipeline_trace(
         return trace_file.get("webViewLink")
     except Exception as e:
         logger.warning("Failed to save report trace: %s", e)
+        try:
+            _record_best_effort_failure(
+                PIPELINE_TRACE_FAILURES_PATH,
+                key=site_title,
+                site_title=site_title,
+                error_type=type(e).__name__,
+                error_message=str(e),
+            )
+        except Exception as record_err:  # pragma: no cover — defensive
+            logger.warning(
+                "Failed to record pipeline-trace failure for '%s': %s",
+                site_title,
+                record_err,
+            )
         return None
 
 
@@ -1406,7 +1483,31 @@ def _publish_to_dashboard_best_effort(
     except Exception as e:
         # publish_to_dashboard already swallows requests errors; this is a
         # belt-and-suspenders guard against anything truly unexpected.
-        logger.warning("Dashboard publish raised for %s: %s", site_title, e)
+        # We had a recent incident where a wedged dashboard publish went
+        # unnoticed for days because this branch silently swallowed the
+        # error. Surface every failure now: log AND append a structured
+        # record to ``.dashboard_publish_failures.json`` so on-call can
+        # see what's wedged without grepping cron logs.
+        logger.error(
+            "Dashboard publish raised for %s (%s): %s",
+            site_title,
+            type(e).__name__,
+            e,
+        )
+        try:
+            _record_best_effort_failure(
+                DASHBOARD_PUBLISH_FAILURES_PATH,
+                key=site_title,
+                site_title=site_title,
+                error_type=type(e).__name__,
+                error_message=str(e),
+            )
+        except Exception as record_err:  # pragma: no cover — defensive
+            logger.warning(
+                "Failed to record dashboard-publish failure for '%s': %s",
+                site_title,
+                record_err,
+            )
 
 
 # Google Chat notification per pipeline result

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -156,6 +156,57 @@ class TestContentTier:
             # is_vendor should be False
             assert v.is_vendor is False
 
+    def test_classifier_internal_raise_fails_closed(self):
+        """When classify_provenance itself raises, fall through to a verdict
+        with ``provenance_classification_failed=True`` and ``is_vendor=False``.
+
+        This is the Tulsa-class failure mode (Rec. 6): an exception in the
+        classifier used to default ``is_vendor=True`` and let AI-generated
+        SIRs through the vendor gate. The fix flips the default to False
+        so the gate fails closed on classifier errors.
+        """
+        with patch(
+            "due_diligence_reporter.provenance._classify_provenance_inner",
+            side_effect=RuntimeError("OpenAI client blew up"),
+        ):
+            v = classify_provenance(
+                {"name": "Vendor SIR.pdf", "id": "abc"}, gc=None
+            )
+
+        assert v.provenance_classification_failed is True
+        assert v.is_vendor is False
+        assert v.tier == "error"
+        assert "RuntimeError" in v.reason
+
+    def test_classifier_raise_helper_returns_false(self):
+        """``is_vendor_sourced`` must surface the closed-gate default."""
+        with patch(
+            "due_diligence_reporter.provenance._classify_provenance_inner",
+            side_effect=ValueError("malformed input"),
+        ):
+            assert (
+                is_vendor_sourced({"name": "Vendor SIR.pdf", "id": "x"}, gc=None)
+                is False
+            )
+
+    def test_failed_flag_default_false_for_normal_verdicts(self):
+        """The new flag stays False on every normal classification path."""
+        # Filename hit
+        v = classify_provenance(
+            {"name": "addr_2026-04-29_SIR.docx", "id": "abc"}, gc=None
+        )
+        assert v.provenance_classification_failed is False
+
+        # doc_type short-circuit
+        v = classify_provenance(
+            {"name": "x.docx", "id": "x"}, gc=None, doc_type="dd_report"
+        )
+        assert v.provenance_classification_failed is False
+
+        # bad input → unknown verdict, but classifier did NOT raise
+        v = classify_provenance(None, gc=None)  # type: ignore[arg-type]
+        assert v.provenance_classification_failed is False
+
     def test_cache_hit(self):
         cache_blob = (
             '{"abc": {"modifiedTime": "t1", "label": "vendor", '

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -1091,3 +1091,86 @@ class TestFilenameMatchesBlockPlan:
     def test_unrelated_filename_does_not_match(self):
         from scripts.raycon_followup import _filename_matches_block_plan
         assert not _filename_matches_block_plan("alpha keller sir.pdf")
+
+
+# ---------------------------------------------------------------------------
+# Schema-fail handling (Rec. 6 — raise must not crash the cron)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaFailHandling:
+    """Verify ``_process_site`` handles ``RayConSchemaError`` gracefully.
+
+    ``read_raycon_scenario_from_m1`` raises ``RayConSchemaError`` when the
+    JSON is present but malformed (vs returning ``None`` for the normal
+    "still polling" case). The caller must surface this as an error row
+    so the end-of-run errors batch posts a Google Chat alert — without
+    crashing the 5-minute cron.
+    """
+
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_schema_error_yields_error_row_not_crash(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+    ):
+        from due_diligence_reporter.raycon_client import RayConSchemaError
+
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        mock_read_scenario.side_effect = RayConSchemaError(
+            "Unsupported RayCon schema_version '9.9' in folder m1_folder_id"
+        )
+
+        gc = MagicMock()
+        # No try/except in the test — the cron itself must not crash.
+        row = _process_site(
+            gc,
+            _site(),
+            dry_run=False,
+            alert_after=timedelta(minutes=60),
+            dispatch_state={},
+        )
+
+        assert row["site"] == "Alpha Keller"
+        assert "error" in row
+        assert "schema" in row["error"].lower()
+        assert "9.9" in row["error"]
+        # No crash, no alert row (errors are surfaced via the errors batch).
+        assert "alert" not in row
+
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_schema_error_logged_at_error_level(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+        caplog,
+    ):
+        import logging
+
+        from due_diligence_reporter.raycon_client import RayConSchemaError
+
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        mock_read_scenario.side_effect = RayConSchemaError(
+            "raycon_scenario.json in folder m1_folder_id is not valid JSON"
+        )
+
+        with caplog.at_level(logging.ERROR, logger="raycon_followup"):
+            _process_site(
+                MagicMock(),
+                _site(),
+                dry_run=False,
+                alert_after=timedelta(minutes=60),
+                dispatch_state={},
+            )
+
+        assert any(
+            "not valid JSON" in record.getMessage() for record in caplog.records
+        )

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from due_diligence_reporter.report_pipeline import (
@@ -10,6 +12,8 @@ from due_diligence_reporter.report_pipeline import (
     TraceEvent,
     _extract_source_read_issues,
     _merge_cached_report_fields,
+    _publish_to_dashboard_best_effort,
+    _save_pipeline_trace,
     check_site_readiness_direct,
     match_site_in_shared_cache,
     process_site_pipeline,
@@ -807,4 +811,150 @@ class TestSourceReadAlerts:
         assert "DD Source Review Needed -- Alpha Keller" in message
         assert "SIR" in message
         assert "Failed to read document" in message
+
+
+# ---------------------------------------------------------------------------
+# Best-effort silent-failure observability (Rec. 6)
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingTrace:
+    """ReportTrace stand-in whose ``to_dict`` raises mid-upload."""
+
+    final_report_data = {"q1.site_owner": "x"}
+
+    def to_dict(self) -> dict:
+        raise RuntimeError("trace serialization exploded")
+
+
+def _redirect_failure_state(monkeypatch, tmp_path) -> tuple[Path, Path]:
+    """Point both failure-state files at tmp_path so tests don't touch repo root."""
+    from due_diligence_reporter import report_pipeline as rp
+
+    pub_path = tmp_path / ".dashboard_publish_failures.json"
+    trace_path = tmp_path / ".pipeline_trace_failures.json"
+    monkeypatch.setattr(rp, "DASHBOARD_PUBLISH_FAILURES_PATH", pub_path)
+    monkeypatch.setattr(rp, "PIPELINE_TRACE_FAILURES_PATH", trace_path)
+    return pub_path, trace_path
+
+
+class TestDashboardPublishObservability:
+    """``_publish_to_dashboard_best_effort`` must surface failures, not swallow."""
+
+    def test_publish_failure_is_recorded_and_not_raised(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        pub_path, _ = _redirect_failure_state(monkeypatch, tmp_path)
+
+        trace = MagicMock()
+        trace.final_report_data = {"q1.site_owner": "P1"}
+
+        with patch(
+            "due_diligence_reporter.report_pipeline.publish_to_dashboard",
+            side_effect=RuntimeError("kaboom"),
+        ):
+            # Must not raise — fail-open behavior preserved.
+            _publish_to_dashboard_best_effort(
+                site_title="Alpha Keller",
+                trace=trace,
+                drive_folder_url="https://drive.google.com/drive/folders/x",
+                dd_report_url="https://docs/x",
+                site_address="123 Main",
+            )
+
+        # Failure must be persisted for on-call to discover.
+        assert pub_path.exists()
+        recorded = json.loads(pub_path.read_text())
+        assert "Alpha Keller" in recorded
+        entry = recorded["Alpha Keller"]
+        assert entry["site_title"] == "Alpha Keller"
+        assert entry["error_type"] == "RuntimeError"
+        assert "kaboom" in entry["error_message"]
+        assert entry["attempts"] == 1
+        assert "failed_at" in entry
+
+    def test_repeated_failures_increment_attempts(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        pub_path, _ = _redirect_failure_state(monkeypatch, tmp_path)
+        trace = MagicMock()
+        trace.final_report_data = {"q1.site_owner": "P1"}
+
+        with patch(
+            "due_diligence_reporter.report_pipeline.publish_to_dashboard",
+            side_effect=RuntimeError("kaboom"),
+        ):
+            for _ in range(3):
+                _publish_to_dashboard_best_effort(
+                    site_title="Alpha Keller",
+                    trace=trace,
+                    drive_folder_url="https://drive.google.com/drive/folders/x",
+                    dd_report_url="https://docs/x",
+                    site_address="123 Main",
+                )
+
+        recorded = json.loads(pub_path.read_text())
+        assert recorded["Alpha Keller"]["attempts"] == 3
+
+    def test_publish_success_does_not_record_failure(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        pub_path, _ = _redirect_failure_state(monkeypatch, tmp_path)
+        trace = MagicMock()
+        trace.final_report_data = {"q1.site_owner": "P1"}
+
+        with patch(
+            "due_diligence_reporter.report_pipeline.publish_to_dashboard",
+            return_value=None,
+        ):
+            _publish_to_dashboard_best_effort(
+                site_title="Alpha Keller",
+                trace=trace,
+                drive_folder_url="https://drive.google.com/drive/folders/x",
+                dd_report_url="https://docs/x",
+                site_address="123 Main",
+            )
+
+        assert not pub_path.exists()
+
+
+class TestPipelineTraceObservability:
+    """``_save_pipeline_trace`` failures land in ``.pipeline_trace_failures.json``."""
+
+    def test_upload_failure_is_recorded_and_returns_none(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        _, trace_path = _redirect_failure_state(monkeypatch, tmp_path)
+
+        gc = MagicMock()
+        gc.upload_file_to_folder.side_effect = RuntimeError("drive upload wedged")
+
+        trace = MagicMock()
+        trace.to_dict.return_value = {"events": []}
+
+        result = _save_pipeline_trace(
+            gc,
+            "https://drive.google.com/drive/folders/abc123",
+            "Alpha Keller",
+            trace,
+        )
+
+        assert result is None
+        assert trace_path.exists()
+        recorded = json.loads(trace_path.read_text())
+        entry = recorded["Alpha Keller"]
+        assert entry["error_type"] == "RuntimeError"
+        assert "drive upload wedged" in entry["error_message"]
+        assert entry["attempts"] == 1
+
+    def test_no_trace_does_not_record(self, monkeypatch, tmp_path) -> None:
+        _, trace_path = _redirect_failure_state(monkeypatch, tmp_path)
+        result = _save_pipeline_trace(
+            MagicMock(),
+            "https://drive.google.com/drive/folders/abc",
+            "Alpha Keller",
+            None,
+        )
+        assert result is None
+        assert not trace_path.exists()
 


### PR DESCRIPTION
## Summary

Implements **Rec. 6** from `event-driven-ddr-recommendations.md`. Three places in the DDR pipeline silently swallowed exceptions or routed them to defaults that hid problems. Each is now logged and observable, without changing fail-open behavior where it's intentional.

### Fix 1 — `_publish_to_dashboard_best_effort` (and `_save_pipeline_trace`)

Both helpers used a bare `except` that turned dashboard outages and trace-upload wedges into silent no-ops. We had a recent incident where a wedged dashboard publish went unnoticed for several days because the error path was a `logger.warning` lost in the cron stream.

Now each failure path:
1. Logs at `logger.error` with the site title, exception type, and message.
2. Appends a structured record to `.dashboard_publish_failures.json` / `.pipeline_trace_failures.json` (mirroring the `.raycon_dispatch_state.json` shape: `{site_title: {error_type, error_message, failed_at, attempts}}`).

**Fail-open behavior preserved on dashboard publish + pipeline trace — observability only.** A dashboard outage still does not block report generation.

### Fix 2 — `provenance.classify_provenance` default flip

When `classify_provenance` raised internally (malformed input, unexpected mime type, OpenAI client crash), the implicit fallthrough produced a verdict whose `is_vendor` property defaulted to **True** (label `_UNKNOWN` ≠ `_AI`). That let AI-generated SIRs through the vendor gate exactly the way the Tulsa-class empty reports did.

Changes:
- New field on `ProvenanceVerdict`: `provenance_classification_failed: bool = False`.
- `is_vendor` returns `False` when this flag is set, so the vendor gate fails **closed** on classifier crashes.
- Top-level `try/except` in `classify_provenance` logs at `logger.error` and returns the safe-default verdict.

**Provenance default flip closes a Tulsa-class failure mode where the gate let AI-SIRs through on classifier errors.**

### Fix 3 — `read_raycon_scenario_from_m1` schema-fail vs. polling

Verified every schema-failure branch (invalid JSON, non-object payload, unsupported `schema_version`) already raises `RayConSchemaError` rather than returning `None`. The polling-case (file missing) still returns `None` as expected. Caller in `scripts/raycon_followup.py::_process_site` already catches the exception, logs at error, and feeds the row into the end-of-run errors batch (which posts a Google Chat alert). Added an explicit test that the cron does not crash and the error message reaches the row.

## Test plan

- `tests/test_report_pipeline.py` — added `TestDashboardPublishObservability` and `TestPipelineTraceObservability` covering: failure path persists a structured record, repeat failures increment `attempts`, success path does not write the file, no-trace short-circuit.
- `tests/test_provenance.py` — added classifier-raise tests asserting `provenance_classification_failed=True` and `is_vendor=False`. Confirmed existing tests for normal paths still hold and the new flag stays `False` on filename / doc_type / bad-input verdicts.
- `tests/test_raycon_followup.py` — added `TestSchemaFailHandling` confirming `_process_site` returns an error row (rather than crashing) when `read_raycon_scenario_from_m1` raises, and that the error is logged at error level.
- `uv run pytest`: **1054 passed**.

## Out of scope

Other silent-fail sites identified in the recommendations doc (SMTP failures in `_email_pipeline_report`, `dashboard_readiness.mark_readiness_complete`, etc.) are deliberately not touched in this PR.

---
🤖 *Generated by Computer*