### PR TITLE
feat(reports): partial-on-purpose mode (completeness metadata + banner)

### DIFF
--- a/src/due_diligence_reporter/completeness.py
+++ b/src/due_diligence_reporter/completeness.py
@@ -1,0 +1,189 @@
+"""Partial-on-purpose completeness metadata for DD reports.
+
+Computes a structured ``completeness`` block that downstream consumers
+(the V3 Google Doc renderer, the dashboard, the ``check_site_readiness``
+MCP tool) use to decide whether a report is "complete" or
+"partial-on-purpose -- waiting on a known input".
+
+Today the only known reason a token can be pending is that
+``raycon_scenario.json`` has not yet landed in the site's M1 folder, but
+the schema is open-ended so other reasons (vendor SIR pending, etc.)
+can be added without a downstream contract change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .raycon_client import RAYCON_BREAKDOWN_ROWS
+
+# ---------------------------------------------------------------------------
+# Reason keys
+# ---------------------------------------------------------------------------
+
+RAYCON_PENDING_REASON = "raycon_scenario_pending"
+RAYCON_PENDING_TRIGGER_FILE = "raycon_scenario.json"
+
+# Human-readable label for each reason key. Consumed by the banner
+# renderer in the V3 doc builder. New reason keys must add an entry here
+# or the banner falls back to the raw key.
+REASON_DISPLAY_LABELS: dict[str, str] = {
+    RAYCON_PENDING_REASON: "RayCon cost & capacity",
+}
+
+# Trigger files keyed by reason — drives the ``auto_republish_on``
+# array on the completeness block.
+REASON_TRIGGER_FILES: dict[str, str] = {
+    RAYCON_PENDING_REASON: RAYCON_PENDING_TRIGGER_FILE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Token classification
+# ---------------------------------------------------------------------------
+
+
+def raycon_token_paths() -> list[str]:
+    """Return the canonical list of token paths sourced from RayCon.
+
+    These are the tokens that go pending when ``raycon_scenario.json``
+    has not yet landed.
+    """
+    paths: list[str] = []
+    for scenario in ("fastest_open", "max_capacity"):
+        paths.append(f"exec.{scenario}_capacity")
+        paths.append(f"exec.{scenario}_capex")
+        paths.append(f"exec.{scenario}_open_date")
+        for row_key, _ in RAYCON_BREAKDOWN_ROWS:
+            paths.append(f"exec.cost_{row_key}_{scenario}")
+    return paths
+
+
+_RAYCON_TOKEN_PATHS: frozenset[str] = frozenset(raycon_token_paths())
+
+
+# Placeholder strings produced by ``server._fill_scenario_placeholders``.
+# Anything that starts with one of these prefixes is a RayCon-pending
+# placeholder, regardless of suffix.
+_RAYCON_PENDING_PLACEHOLDER_PREFIXES: tuple[str, ...] = (
+    "[Not found - Fastest Open scenario not extracted",
+    "[Not found - Max Capacity scenario not extracted",
+)
+
+
+def is_raycon_pending_placeholder(value: Any) -> bool:
+    """Return True if *value* is the placeholder server.py installs when
+    a RayCon-derived field has no real data yet."""
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    return any(text.startswith(prefix) for prefix in _RAYCON_PENDING_PLACEHOLDER_PREFIXES)
+
+
+def _is_filled(value: Any) -> bool:
+    """Return True if *value* counts as a real value (not a placeholder)."""
+    if not isinstance(value, str):
+        return value is not None
+    text = value.strip()
+    if not text:
+        return False
+    if is_raycon_pending_placeholder(text):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Completeness block
+# ---------------------------------------------------------------------------
+
+
+def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
+    """Compute the ``report_metadata.completeness`` block for a report.
+
+    Walks the final populated token map and counts filled vs. pending
+    tokens, grouping pending tokens by the reason they're pending.
+
+    Args:
+        replacements: The normalized token -> value map that the V3
+            Google Doc renderer will consume.
+
+    Returns:
+        A dict matching the schema documented in the partial-on-purpose
+        plan (Rec. 5):
+
+            {
+              "stage": "partial" | "complete",
+              "filled_token_count": int,
+              "pending_token_count": int,
+              "pending_reasons": {reason_key: [token_paths...]},
+              "auto_republish_on": [trigger_file, ...]
+            }
+    """
+    pending_by_reason: dict[str, list[str]] = {}
+    filled = 0
+    pending = 0
+
+    for token, value in replacements.items():
+        if token in _RAYCON_TOKEN_PATHS and not _is_filled(value):
+            pending_by_reason.setdefault(RAYCON_PENDING_REASON, []).append(token)
+            pending += 1
+        elif _is_filled(value):
+            filled += 1
+
+    for reason in pending_by_reason:
+        pending_by_reason[reason].sort()
+
+    auto_republish_on = sorted({
+        REASON_TRIGGER_FILES[reason]
+        for reason in pending_by_reason
+        if reason in REASON_TRIGGER_FILES
+    })
+
+    stage = "partial" if pending > 0 else "complete"
+
+    return {
+        "stage": stage,
+        "filled_token_count": filled,
+        "pending_token_count": pending,
+        "pending_reasons": pending_by_reason,
+        "auto_republish_on": auto_republish_on,
+    }
+
+
+def project_completeness_from_readiness(
+    *,
+    raycon_scenario_found: bool,
+) -> dict[str, Any]:
+    """Project what the completeness block will look like *before* the
+    pipeline has run, based on which gating inputs are available.
+
+    Used by ``check_site_readiness`` to give the agent (and Greg) a
+    preview: ship partial now, or wait for the missing input?
+
+    Today RayCon is the only pending-input axis we model. When more
+    reasons are added to ``REASON_TRIGGER_FILES``, extend this function
+    to take their availability flags too.
+    """
+    pending_reasons: dict[str, list[str]] = {}
+    if not raycon_scenario_found:
+        pending_reasons[RAYCON_PENDING_REASON] = sorted(_RAYCON_TOKEN_PATHS)
+
+    auto_republish_on = sorted({
+        REASON_TRIGGER_FILES[reason]
+        for reason in pending_reasons
+        if reason in REASON_TRIGGER_FILES
+    })
+
+    pending_count = sum(len(paths) for paths in pending_reasons.values())
+    stage = "partial" if pending_count > 0 else "complete"
+
+    return {
+        "stage": stage,
+        # Filled count is unknown pre-generation — caller is asking what
+        # the *shape* would look like. Surface the projected pending
+        # count without inventing a filled count.
+        "filled_token_count": None,
+        "pending_token_count": pending_count,
+        "pending_reasons": pending_reasons,
+        "auto_republish_on": auto_republish_on,
+    }

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -682,6 +682,117 @@ def _reference_type_label(token: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Partial-on-purpose banner
+# ---------------------------------------------------------------------------
+
+
+# Local copy of the human-readable labels for pending reasons. Keeping a
+# small private map here (rather than importing from completeness.py)
+# avoids a layering dependency from the renderer onto the metadata
+# module — the doc builder should not depend on completeness logic. The
+# completeness module owns the canonical map; this is the rendering
+# fallback used when a key is unrecognized.
+_BANNER_REASON_LABELS: dict[str, str] = {
+    "raycon_scenario_pending": "RayCon cost & capacity",
+}
+
+
+def _format_pending_reason_label(reason_key: str) -> str:
+    """Map a ``pending_reasons`` key to the human-readable label used
+    in the banner ``Missing:`` line. Falls back to the raw key when no
+    label is registered, so a freshly-added reason still surfaces
+    visibly rather than silently dropping out of the banner."""
+    return _BANNER_REASON_LABELS.get(reason_key, reason_key)
+
+
+def format_partial_banner_text(
+    completeness: dict[str, Any] | None,
+    *,
+    block_plan_submitted_display: str | None = None,
+) -> str:
+    """Render the partial-banner text for ``completeness``.
+
+    Returns an empty string when the report is not partial (banner
+    must not render). When partial:
+
+    - Line 1: ``PARTIAL REPORT -- pending data``
+    - Line 2: ``Missing: <reason labels joined by ', '>`` plus the
+      Block Plan submitted timestamp when available, or
+      ``(Block Plan submitted at unknown time)`` when not.
+    - Line 3: ``This report will republish automatically when the
+      scenario lands.``
+
+    The reason labels are derived from ``pending_reasons.keys()`` so
+    new reasons surface in the banner without code changes here.
+    """
+    if not isinstance(completeness, dict):
+        return ""
+    if completeness.get("stage") != "partial":
+        return ""
+
+    reasons = completeness.get("pending_reasons") or {}
+    if isinstance(reasons, dict) and reasons:
+        labels = [_format_pending_reason_label(key) for key in reasons.keys()]
+    else:
+        labels = ["pending data"]
+    missing_str = ", ".join(labels)
+
+    if block_plan_submitted_display and block_plan_submitted_display.strip():
+        timestamp_clause = f"(Block Plan submitted {block_plan_submitted_display.strip()})"
+    else:
+        timestamp_clause = "(Block Plan submitted at unknown time)"
+
+    return (
+        "PARTIAL REPORT -- pending data\n"
+        f"Missing: {missing_str} {timestamp_clause}.\n"
+        "This report will republish automatically when the scenario lands.\n"
+    )
+
+
+def _insert_partial_banner(
+    b: _DocBuilder,
+    completeness: dict[str, Any] | None,
+) -> None:
+    """Insert the partial-on-purpose banner at the current builder index.
+
+    No-op when ``completeness`` is missing, ``stage != "partial"``, or
+    when the banner text resolves to empty. Styling matches the rest
+    of the executive header: bold first line, normal weight on the
+    follow-up lines, with a light-blue background so it reads as a
+    callout rather than body copy.
+    """
+    block_plan_submitted_display = None
+    if isinstance(completeness, dict):
+        block_plan_submitted_display = completeness.get("block_plan_submitted_display")
+
+    text = format_partial_banner_text(
+        completeness,
+        block_plan_submitted_display=block_plan_submitted_display,
+    )
+    if not text:
+        return
+
+    lines = text.split("\n")
+    headline = lines[0] + "\n"
+    body = "\n".join(line for line in lines[1:] if line) + "\n"
+
+    h_start, h_end = b.insert_text(headline)
+    b.style_text(
+        h_start, h_end - 1,
+        bold=True, font_size=11, font_family="Arial",
+        foreground_color=_DARK_BLUE,
+    )
+    b.style_paragraph(h_start, h_end, alignment="CENTER")
+
+    body_start, body_end = b.insert_text(body)
+    b.style_text(
+        body_start, body_end - 1,
+        bold=False, font_size=10, font_family="Arial",
+    )
+    b.style_paragraph(body_start, body_end, alignment="CENTER")
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -692,6 +803,7 @@ def build_dd_report_doc(
     doc_id: str,
     replacements: dict[str, str],
     site_title: str,
+    completeness: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Construct the full DD report document structure in a blank Google Doc.
 
@@ -711,6 +823,11 @@ def build_dd_report_doc(
         doc_id: The ID of the blank document to populate.
         replacements: Normalized token→value mapping.
         site_title: The site name for the report title.
+        completeness: Optional ``report_metadata.completeness`` block. When
+            ``stage == "partial"`` the renderer prepends a banner that
+            calls out the missing data and the trigger file the report
+            is waiting on. When ``stage == "complete"`` (or
+            ``completeness`` is None) the banner is omitted entirely.
 
     Returns:
         A dict summarizing the build: hyperlinks_applied, etc.
@@ -734,6 +851,12 @@ def build_dd_report_doc(
         foreground_color=_DARK_BLUE,
     )
     b.style_paragraph(title_start, title_end, alignment="CENTER")
+
+    # Partial-on-purpose banner: appears between the title and the
+    # header table when ``completeness.stage == "partial"``. Reports
+    # are in-house, so we render unconditionally — no separate
+    # internal/external paths.
+    _insert_partial_banner(b, completeness)
 
     # Empty line before header table
     b.insert_text("\n")

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 import zipfile
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
@@ -26,6 +26,10 @@ from .classifier import (
 )
 from .classifier import (
     classify_document_type as _classify_document_type,
+)
+from .completeness import (
+    compute_completeness_block,
+    project_completeness_from_readiness,
 )
 from .config import get_settings
 from .dashboard_publish import publish_site_record
@@ -2208,6 +2212,64 @@ async def get_permit_history(
 
 
 
+def _attach_block_plan_submitted_timestamp(
+    *,
+    gc: GoogleClient,
+    drive_folder_url: str,
+    completeness: dict[str, Any],
+) -> None:
+    """Look up the Block Plan ``modifiedTime`` from the site's M1 folder
+    and attach it to ``completeness`` so the V3 banner can name the
+    submission timestamp.
+
+    No-op when ``completeness.stage != "partial"`` (banner won't
+    render), when the M1 folder can't be resolved, or when no Block
+    Plan has been filed yet. All failures are logged and swallowed —
+    the banner falls back to "Block Plan submitted at unknown time"
+    rather than blocking the report.
+    """
+    if completeness.get("stage") != "partial":
+        return
+    if not drive_folder_url:
+        return
+    try:
+        m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+    except Exception as e:
+        logger.warning("Block Plan timestamp lookup: M1 resolve failed: %s", e)
+        return
+    if not m1_folder_id:
+        return
+    try:
+        m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
+    except Exception as e:
+        logger.warning("Block Plan timestamp lookup: M1 list failed: %s", e)
+        return
+    block_plan = m1_docs.get("block_plan")
+    if not block_plan:
+        return
+    iso = str(block_plan.get("modifiedTime") or "").strip()
+    if not iso:
+        return
+    completeness["block_plan_submitted_at"] = iso
+    completeness["block_plan_submitted_display"] = _format_block_plan_submitted_display(iso)
+
+
+def _format_block_plan_submitted_display(iso_ts: str) -> str:
+    """Format an ISO-8601 ``modifiedTime`` into the banner phrasing
+    ``YYYY-MM-DD HH:MM UTC``. Falls back to the raw string when the
+    timestamp can't be parsed."""
+    from datetime import datetime as _dt
+
+    candidate = iso_ts.strip()
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = _dt.fromisoformat(candidate)
+    except ValueError:
+        return iso_ts
+    return parsed.strftime("%Y-%m-%d %H:%M UTC")
+
+
 def _normalize_report_replacements(
     report_data: dict[str, Any],
     site_name: str,
@@ -2494,6 +2556,7 @@ def _build_report_trace_data(
     hyperlink_trace: dict[str, Any],
     token_evidence: dict[str, str] | None,
     rebl_resolution: ReblResolution,
+    completeness: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the report trace payload persisted beside the DD report."""
     evidence = token_evidence or {}
@@ -2524,6 +2587,7 @@ def _build_report_trace_data(
         "hyperlinks": hyperlink_trace,
         "rebl": rebl_resolution.to_dict(),
         **({"supplemental_evidence": supplemental_evidence} if supplemental_evidence else {}),
+        **({"report_metadata": {"completeness": completeness}} if completeness else {}),
     }
 
 
@@ -2729,6 +2793,23 @@ async def create_dd_report(
             if unmatched:
                 logger.warning("Unmatched agent keys (no template token): %s", unmatched)
 
+            # Compute the partial-on-purpose completeness metadata. Done
+            # before the doc builder runs so the renderer can prepend
+            # the "PARTIAL REPORT" banner when stage == "partial".
+            completeness = compute_completeness_block(replacements)
+            _attach_block_plan_submitted_timestamp(
+                gc=gc,
+                drive_folder_url=drive_folder_url,
+                completeness=completeness,
+            )
+            logger.info(
+                "Completeness: stage=%s filled=%d pending=%d auto_republish_on=%s",
+                completeness.get("stage"),
+                completeness.get("filled_token_count", 0),
+                completeness.get("pending_token_count", 0),
+                completeness.get("auto_republish_on"),
+            )
+
             # Build the document structure programmatically
             builder_result = build_dd_report_doc(
                 docs_service=gc.docs_service,
@@ -2736,6 +2817,7 @@ async def create_dd_report(
                 doc_id=doc_id,
                 replacements=replacements,
                 site_title=site_name.strip(),
+                completeness=completeness,
             )
 
             hyperlink_trace = {
@@ -2768,6 +2850,7 @@ async def create_dd_report(
                 hyperlink_trace=hyperlink_trace,
                 token_evidence=token_evidence,
                 rebl_resolution=rebl_resolution,
+                completeness=completeness,
             )
             try:
                 _upload_report_trace(
@@ -2798,6 +2881,7 @@ async def create_dd_report(
                     dd_report_url=doc_url or "",
                     rebl_resolution=rebl_resolution,
                     wrike_created_at=replacements.get("meta.wrike_created_at", ""),
+                    completeness=completeness,
                 )
                 dashboard_payload = publish_site_record(
                     gc=gc,
@@ -2823,6 +2907,7 @@ async def create_dd_report(
                 "unfilled_template_tokens": len(unfilled),
                 "hyperlinks_applied": hyperlink_trace["applied"],
                 "normalized_report_data": replacements,
+                "report_metadata": {"completeness": completeness},
                 "message": f"DD report built: {doc_url}",
             }
             if dashboard_payload is not None:
@@ -2915,6 +3000,34 @@ async def check_site_readiness(site_name_or_id: str) -> dict[str, Any]:
             inspection_found = files_by_type["building_inspection"] is not None
             report_exists = files_by_type["dd_report"] is not None
 
+            # Probe M1 for raycon_scenario.json so the projected
+            # completeness block tells callers whether a report
+            # generated *right now* would be partial-on-purpose.
+            raycon_scenario_found = False
+            try:
+                m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+            except Exception as e:
+                logger.warning(
+                    "check_site_readiness: M1 resolve failed for '%s': %s",
+                    site_title,
+                    e,
+                )
+                m1_folder_id = None
+            if m1_folder_id:
+                try:
+                    m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
+                    raycon_scenario_found = m1_docs.get("raycon_scenario_json") is not None
+                except Exception as e:
+                    logger.warning(
+                        "check_site_readiness: M1 list failed for '%s': %s",
+                        site_title,
+                        e,
+                    )
+
+            projected_completeness = project_completeness_from_readiness(
+                raycon_scenario_found=raycon_scenario_found,
+            )
+
             missing_docs: list[str] = []
             if not sir_found:
                 missing_docs.append("sir")
@@ -2935,18 +3048,26 @@ async def check_site_readiness(site_name_or_id: str) -> dict[str, Any]:
                 "isp_found": isp_found,
                 "inspection_found": inspection_found,
                 "report_exists": report_exists,
+                "raycon_scenario_found": raycon_scenario_found,
                 "missing_docs": missing_docs,
                 "ready_for_report": ready_for_report,
                 "files": files_by_type,
                 "drive_folder_url": drive_folder_url,
+                "report_metadata": {"completeness": projected_completeness},
                 "message": "\n".join([
                     f"Site '{site_title}' document readiness:",
                     f"  SIR: {'found - ' + (files_by_type.get('sir') or {}).get('name', '') if sir_found else 'not found'}",
                     f"  Building Inspection: {'found - ' + (files_by_type.get('building_inspection') or {}).get('name', '') if inspection_found else 'not found'}",
                     f"  DD Report: {'exists - ' + (files_by_type.get('dd_report') or {}).get('name', '') if report_exists else 'not yet created'}",
+                    f"  RayCon scenario: {'found' if raycon_scenario_found else 'not yet posted'}",
                     "",
                     "Ready for report generation." if ready_for_report else (
                         "Not ready - " + ", ".join(missing_docs) + " missing." if missing_docs else "Report already exists."
+                    ),
+                    (
+                        f"Projected report stage: {projected_completeness['stage']} "
+                        f"(pending tokens: {projected_completeness['pending_token_count']}, "
+                        f"auto-republish on: {', '.join(projected_completeness['auto_republish_on']) or '-'})."
                     ),
                 ]),
             }

--- a/src/due_diligence_reporter/site_record.py
+++ b/src/due_diligence_reporter/site_record.py
@@ -204,6 +204,11 @@ class SiteRecord:
     sources: SourceLinks = field(default_factory=SourceLinks)
     acquisition_conditions: str = ""
     tradeoffs_and_deficiencies: str = ""
+    # Partial-on-purpose metadata. ``completeness`` carries the
+    # ``stage`` ("partial" / "complete"), pending-token counts, and
+    # ``auto_republish_on`` triggers so the dashboard can render
+    # "waiting on RayCon" rows without re-deriving from the doc.
+    report_metadata: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_replacements(
@@ -218,6 +223,7 @@ class SiteRecord:
         classification_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
         rebl_resolution: ReblResolution | None = None,
         wrike_created_at: str = "",
+        completeness: dict[str, Any] | None = None,
     ) -> SiteRecord:
         """Build a SiteRecord from normalized DD replacements."""
 
@@ -267,6 +273,10 @@ class SiteRecord:
             url=g("sources.rebl_link"),
         )
 
+        report_metadata: dict[str, Any] = {}
+        if completeness is not None:
+            report_metadata["completeness"] = dict(completeness)
+
         return cls(
             slug=site_slug(site_name, suffix=slug_suffix),
             site_name=site_name.strip(),
@@ -291,6 +301,7 @@ class SiteRecord:
             sources=sources,
             acquisition_conditions=acquisition_conditions,
             tradeoffs_and_deficiencies=tradeoffs,
+            report_metadata=report_metadata,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,0 +1,186 @@
+"""Tests for the partial-on-purpose completeness metadata."""
+
+from __future__ import annotations
+
+from due_diligence_reporter.completeness import (
+    RAYCON_PENDING_REASON,
+    compute_completeness_block,
+    is_raycon_pending_placeholder,
+    project_completeness_from_readiness,
+    raycon_token_paths,
+)
+from due_diligence_reporter.google_doc_builder import format_partial_banner_text
+
+# ---------------------------------------------------------------------------
+# Token classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsRayconPendingPlaceholder:
+    def test_fastest_open_placeholder(self) -> None:
+        assert is_raycon_pending_placeholder(
+            "[Not found - Fastest Open scenario not extracted]"
+        )
+
+    def test_max_capacity_placeholder(self) -> None:
+        assert is_raycon_pending_placeholder(
+            "[Not found - Max Capacity scenario not extracted]"
+        )
+
+    def test_real_value_is_not_placeholder(self) -> None:
+        assert not is_raycon_pending_placeholder("$1,234,567")
+
+    def test_unrelated_not_found_is_not_placeholder(self) -> None:
+        assert not is_raycon_pending_placeholder("[Not found - SIR]")
+
+    def test_empty_is_not_placeholder(self) -> None:
+        assert not is_raycon_pending_placeholder("")
+
+
+class TestRayconTokenPaths:
+    def test_includes_summary_tokens(self) -> None:
+        paths = set(raycon_token_paths())
+        assert "exec.fastest_open_capacity" in paths
+        assert "exec.fastest_open_capex" in paths
+        assert "exec.fastest_open_open_date" in paths
+        assert "exec.max_capacity_capacity" in paths
+
+    def test_includes_cost_breakdown_tokens(self) -> None:
+        paths = set(raycon_token_paths())
+        assert "exec.cost_grand_total_fastest_open" in paths
+        assert "exec.cost_demolition_max_capacity" in paths
+
+    def test_total_count(self) -> None:
+        # 12 cost rows * 2 scenarios + 3 summary fields * 2 scenarios = 30
+        assert len(raycon_token_paths()) == 30
+
+
+# ---------------------------------------------------------------------------
+# compute_completeness_block — the unit-test contract called out in the
+# Rec. 5 plan.
+# ---------------------------------------------------------------------------
+
+
+def _all_raycon_pending() -> dict[str, str]:
+    """Every RayCon token holds the pending placeholder."""
+    return {
+        token: "[Not found - Fastest Open scenario not extracted]"
+        if "fastest_open" in token
+        else "[Not found - Max Capacity scenario not extracted]"
+        for token in raycon_token_paths()
+    }
+
+
+def _all_raycon_filled() -> dict[str, str]:
+    """Every RayCon token holds a real value."""
+    return dict.fromkeys(raycon_token_paths(), "$0")
+
+
+class TestComputeCompletenessBlock:
+    def test_all_pending_is_partial(self) -> None:
+        replacements = _all_raycon_pending()
+        block = compute_completeness_block(replacements)
+        assert block["stage"] == "partial"
+        assert block["pending_token_count"] == 30
+        assert block["filled_token_count"] == 0
+        assert block["auto_republish_on"] == ["raycon_scenario.json"]
+        assert RAYCON_PENDING_REASON in block["pending_reasons"]
+        assert len(block["pending_reasons"][RAYCON_PENDING_REASON]) == 30
+
+    def test_all_filled_is_complete(self) -> None:
+        replacements = _all_raycon_filled()
+        replacements.update({
+            "meta.site_name": "Tulsa-North",
+            "exec.c_answer": "Yes",
+        })
+        block = compute_completeness_block(replacements)
+        assert block["stage"] == "complete"
+        assert block["pending_token_count"] == 0
+        assert block["pending_reasons"] == {}
+        assert block["auto_republish_on"] == []
+        # filled_token_count counts every non-empty, non-placeholder
+        # entry in the map — the 30 RayCon tokens plus the 2 we added.
+        assert block["filled_token_count"] == 32
+
+    def test_partial_only_partially_filled_raycon(self) -> None:
+        replacements = _all_raycon_pending()
+        replacements["exec.fastest_open_capacity"] = "120 students"
+        block = compute_completeness_block(replacements)
+        assert block["stage"] == "partial"
+        assert block["pending_token_count"] == 29
+        # The one filled RayCon token contributes to filled_token_count.
+        assert block["filled_token_count"] == 1
+        pending_paths = block["pending_reasons"][RAYCON_PENDING_REASON]
+        assert "exec.fastest_open_capacity" not in pending_paths
+
+    def test_pending_reasons_open_ended_dict(self) -> None:
+        # The dict shape is {reason_key: [token_paths]} so future
+        # reasons can be added without a contract change.
+        block = compute_completeness_block(_all_raycon_pending())
+        assert isinstance(block["pending_reasons"], dict)
+        for paths in block["pending_reasons"].values():
+            assert isinstance(paths, list)
+
+
+class TestProjectCompletenessFromReadiness:
+    def test_raycon_missing_projects_partial(self) -> None:
+        block = project_completeness_from_readiness(raycon_scenario_found=False)
+        assert block["stage"] == "partial"
+        assert block["pending_token_count"] == 30
+        assert block["auto_republish_on"] == ["raycon_scenario.json"]
+        # Filled count is unknown pre-generation.
+        assert block["filled_token_count"] is None
+
+    def test_raycon_present_projects_complete(self) -> None:
+        block = project_completeness_from_readiness(raycon_scenario_found=True)
+        assert block["stage"] == "complete"
+        assert block["pending_token_count"] == 0
+        assert block["pending_reasons"] == {}
+        assert block["auto_republish_on"] == []
+
+
+# ---------------------------------------------------------------------------
+# Banner rendering — must render when partial, must be empty when complete.
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPartialBannerText:
+    def test_complete_renders_empty(self) -> None:
+        block = {"stage": "complete", "pending_reasons": {}}
+        assert format_partial_banner_text(block) == ""
+
+    def test_none_renders_empty(self) -> None:
+        assert format_partial_banner_text(None) == ""
+
+    def test_partial_with_known_reason(self) -> None:
+        block = {
+            "stage": "partial",
+            "pending_reasons": {RAYCON_PENDING_REASON: ["exec.fastest_open_capacity"]},
+        }
+        text = format_partial_banner_text(
+            block,
+            block_plan_submitted_display="2026-05-07 13:42 UTC",
+        )
+        assert "PARTIAL REPORT" in text
+        assert "RayCon cost & capacity" in text
+        assert "Block Plan submitted 2026-05-07 13:42 UTC" in text
+        assert "republish automatically" in text
+
+    def test_partial_falls_back_when_timestamp_missing(self) -> None:
+        block = {
+            "stage": "partial",
+            "pending_reasons": {RAYCON_PENDING_REASON: []},
+        }
+        text = format_partial_banner_text(block, block_plan_submitted_display=None)
+        assert "Block Plan submitted at unknown time" in text
+
+    def test_partial_unknown_reason_uses_raw_key(self) -> None:
+        block = {
+            "stage": "partial",
+            "pending_reasons": {"vendor_sir_pending": []},
+        }
+        text = format_partial_banner_text(block)
+        # New reason keys must surface in the banner even before a
+        # display label has been registered, so the fallback uses
+        # the raw key rather than dropping the line.
+        assert "vendor_sir_pending" in text

--- a/tests/test_google_doc_builder.py
+++ b/tests/test_google_doc_builder.py
@@ -622,6 +622,84 @@ class TestBuildDdReportDocRequestStructure:
 
         assert inserted_text.index("Source Quality Notes\n") < inserted_text.index("Lease Conditions\n")
 
+    def test_partial_banner_emitted_when_completeness_partial(self) -> None:
+        """build_dd_report_doc emits the PARTIAL REPORT banner when stage='partial'."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {"meta.site_name": "Test", "meta.report_date": "04/14/2026"}
+        completeness = {
+            "stage": "partial",
+            "filled_token_count": 0,
+            "pending_token_count": 30,
+            "pending_reasons": {"raycon_scenario_pending": ["exec.fastest_open_capacity"]},
+            "auto_republish_on": ["raycon_scenario.json"],
+            "block_plan_submitted_display": "2026-05-07 13:42 UTC",
+        }
+
+        build_dd_report_doc(
+            docs_svc, drive_svc, "doc123", repl, "Test",
+            completeness=completeness,
+        )
+
+        inserted_text = "\n".join(
+            request["insertText"]["text"]
+            for call_args in docs_svc.documents.return_value.batchUpdate.call_args_list
+            for request in call_args.kwargs["body"]["requests"]
+            if "insertText" in request
+        )
+
+        assert "PARTIAL REPORT" in inserted_text
+        assert "RayCon cost & capacity" in inserted_text
+        assert "Block Plan submitted 2026-05-07 13:42 UTC" in inserted_text
+        # Banner sits above the title's header table
+        assert inserted_text.index("PARTIAL REPORT") < inserted_text.index("Executive Summary")
+
+    def test_partial_banner_omitted_when_completeness_complete(self) -> None:
+        """No banner when stage='complete' — the republish path naturally
+        removes the banner when raycon_scenario.json arrives."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {"meta.site_name": "Test", "meta.report_date": "04/14/2026"}
+        completeness = {
+            "stage": "complete",
+            "filled_token_count": 30,
+            "pending_token_count": 0,
+            "pending_reasons": {},
+            "auto_republish_on": [],
+        }
+
+        build_dd_report_doc(
+            docs_svc, drive_svc, "doc123", repl, "Test",
+            completeness=completeness,
+        )
+
+        inserted_text = "\n".join(
+            request["insertText"]["text"]
+            for call_args in docs_svc.documents.return_value.batchUpdate.call_args_list
+            for request in call_args.kwargs["body"]["requests"]
+            if "insertText" in request
+        )
+
+        assert "PARTIAL REPORT" not in inserted_text
+
+    def test_partial_banner_omitted_when_completeness_none(self) -> None:
+        """Backwards compatibility: callers that don't pass completeness
+        get the legacy (no banner) rendering."""
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {"meta.site_name": "Test", "meta.report_date": "04/14/2026"}
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        inserted_text = "\n".join(
+            request["insertText"]["text"]
+            for call_args in docs_svc.documents.return_value.batchUpdate.call_args_list
+            for request in call_args.kwargs["body"]["requests"]
+            if "insertText" in request
+        )
+
+        assert "PARTIAL REPORT" not in inserted_text
+
     def test_direct_answer_renders_before_buildout_analysis(self) -> None:
         docs_svc = _make_mock_docs_service()
         drive_svc = MagicMock()


### PR DESCRIPTION
## Summary

Implements Recommendation 5 from the event-driven DDR plan: make
**partial-on-purpose** a first-class report mode. Today, "partial"
only manifests as ``[Not found -- RayCon scenario pending]``
placeholders in RayCon-derived fields. With this PR the report
itself, the dashboard, and the ``check_site_readiness`` MCP all
carry a structured ``report_metadata.completeness`` block, and the
V3 DD Report doc renders an explicit banner whenever a report is
partial-on-purpose.

The republish flow shipped in #82 already overwrites the doc when
``raycon_scenario.json`` lands. Because completeness is recomputed
from the new token map on every render, flipping ``stage`` from
``partial`` -> ``complete`` naturally removes the banner — no
separate "clear banner" code path required.

### `report_metadata.completeness` schema

```json
{
  "stage": "partial",
  "filled_token_count": 47,
  "pending_token_count": 23,
  "pending_reasons": {
    "raycon_scenario_pending": ["exec.fastest_open_capacity", "exec.cost_*"]
  },
  "auto_republish_on": ["raycon_scenario.json"]
}
```

- ``stage``: ``"complete"`` only when zero pending tokens; otherwise ``"partial"``.
- ``filled_token_count`` / ``pending_token_count``: derived by walking
  the final ``replacements`` map. Pending = ``[Not found - Fastest Open ...]``
  / ``[Not found - Max Capacity ...]`` placeholders installed by the
  existing ``_fill_scenario_placeholders`` path.
- ``pending_reasons``: open-ended ``{reason_key: [token_paths]}`` dict.
  RayCon is the only known reason today; new reasons (e.g.
  ``vendor_sir_pending``) drop in by adding a label + trigger file
  to ``REASON_DISPLAY_LABELS`` and ``REASON_TRIGGER_FILES``.
- ``auto_republish_on``: trigger files this report is waiting on.

### Banner

Rendered between the document title and the header table when
``stage == "partial"``. Reports stay in-house, so it renders
unconditionally (no internal/external split). Format:

> **PARTIAL REPORT -- pending data**
> Missing: RayCon cost & capacity (Block Plan submitted 2026-05-07 13:42 UTC).
> This report will republish automatically when the scenario lands.

The "Missing:" line is derived from ``pending_reasons.keys()``, so
new reasons surface in the banner without a code change in
``google_doc_builder``. The Block Plan submission timestamp is read
from the M1 Block Plan file's Drive ``modifiedTime`` (the same
metadata the existing republish flow consumes); when unavailable the
banner falls back to "Block Plan submitted at unknown time" rather
than blanking the line.

### `check_site_readiness` MCP

Probes M1 for ``raycon_scenario.json`` and returns
``report_metadata.completeness`` projected from currently-available
inputs. Lets the agent (and Greg) decide whether to ship partial now
or wait. The human-readable ``message`` field also gains a
"Projected report stage" line.

## Files changed

- ``src/due_diligence_reporter/completeness.py`` (new) — RayCon token
  classification, ``compute_completeness_block`` for the live token
  map, and ``project_completeness_from_readiness`` for the MCP
  pre-generation projection.
- ``src/due_diligence_reporter/google_doc_builder.py`` — new
  ``completeness`` parameter on ``build_dd_report_doc`` and a
  ``_insert_partial_banner`` helper that emits the banner between
  title and header table. ``format_partial_banner_text`` is exposed
  for unit testing.
- ``src/due_diligence_reporter/server.py`` — ``create_dd_report``
  computes completeness, looks up the Block Plan submission timestamp
  from M1, threads completeness into the doc builder / response /
  trace / SiteRecord. ``check_site_readiness`` probes for
  raycon_scenario.json and returns the projected block.
- ``src/due_diligence_reporter/site_record.py`` — adds a
  ``report_metadata`` field; ``from_replacements`` accepts
  ``completeness`` and stashes it in the dashboard payload.
- ``tests/test_completeness.py`` (new) — 19 unit tests covering token
  classification, the partial vs. complete contract, projected
  readiness, and the banner text fallbacks.
- ``tests/test_google_doc_builder.py`` — 3 integration tests that
  assert the banner is in / not in the batchUpdate request stream
  for partial / complete / no-completeness cases.

## Test plan

- [x] ``uv run pytest`` (1076 passing)
- [x] ``uv run ruff check`` on touched files (clean)
- [x] ``uv run mypy src/due_diligence_reporter/completeness.py`` (clean)
- [x] Unit tests: fully-RayCon-pending token map -> ``stage="partial"``;
  fully-populated -> ``stage="complete"``; banner renders/empties
  based on ``stage``.
- [ ] Manual smoke: trigger ``check_site_readiness`` against a site
  without ``raycon_scenario.json`` and confirm
  ``report_metadata.completeness.stage == "partial"`` and
  ``auto_republish_on == ["raycon_scenario.json"]``.
- [ ] Manual smoke: regenerate a partial report and verify the
  banner shows the M1 Block Plan ``modifiedTime``.
- [ ] Manual smoke: drop a real ``raycon_scenario.json`` and confirm
  the republish removes the banner (existing #82 / #83 flow).

## Manual follow-up

- **Template doc**: nothing to update by hand. The V3 DD Report Doc
  is constructed entirely by ``google_doc_builder.py`` (see the
  "programmatic Google Doc builder" docstring at the top of that
  file) — there is no Drive-side template to edit. The banner lives
  in the V3 template *code*, conditional on ``completeness.stage``.
- **Dashboard**: the dashboard now sees ``report_metadata.completeness``
  in each site's published JSON. No back-fill required — older
  records that don't carry the field continue to render as-is.
- **Env vars**: none.

## Reference

Implements Rec. 5 from the event-driven DDR plan referenced in the
task brief. See PR #82 (RayCon-event republish), #83
(P1/feasibility/timeline forwarding hotfix), #84 (vendor gate flip),
#85 (silent-fail observability) for the rest of the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)