### PR TITLE
fix(reports): consolidate reason labels + drop capacity from RayCon-pending tokens

### DIFF
--- a/src/due_diligence_reporter/completeness.py
+++ b/src/due_diligence_reporter/completeness.py
@@ -47,11 +47,12 @@ def raycon_token_paths() -> list[str]:
     """Return the canonical list of token paths sourced from RayCon.
 
     These are the tokens that go pending when ``raycon_scenario.json``
-    has not yet landed.
+    has not yet landed. Per ``report_schema.TOKEN_SOURCES``, capacity
+    summary tokens are sourced from the Capacity Brainlift (the agent),
+    not RayCon, so they're excluded here.
     """
     paths: list[str] = []
     for scenario in ("fastest_open", "max_capacity"):
-        paths.append(f"exec.{scenario}_capacity")
         paths.append(f"exec.{scenario}_capex")
         paths.append(f"exec.{scenario}_open_date")
         for row_key, _ in RAYCON_BREAKDOWN_ROWS:
@@ -133,9 +134,14 @@ def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
     for reason in pending_by_reason:
         pending_by_reason[reason].sort()
 
+    pending_reasons_sorted = {
+        reason: pending_by_reason[reason]
+        for reason in sorted(pending_by_reason)
+    }
+
     auto_republish_on = sorted({
         REASON_TRIGGER_FILES[reason]
-        for reason in pending_by_reason
+        for reason in pending_reasons_sorted
         if reason in REASON_TRIGGER_FILES
     })
 
@@ -145,7 +151,7 @@ def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
         "stage": stage,
         "filled_token_count": filled,
         "pending_token_count": pending,
-        "pending_reasons": pending_by_reason,
+        "pending_reasons": pending_reasons_sorted,
         "auto_republish_on": auto_republish_on,
     }
 
@@ -164,9 +170,14 @@ def project_completeness_from_readiness(
     reasons are added to ``REASON_TRIGGER_FILES``, extend this function
     to take their availability flags too.
     """
-    pending_reasons: dict[str, list[str]] = {}
+    pending_reasons_unsorted: dict[str, list[str]] = {}
     if not raycon_scenario_found:
-        pending_reasons[RAYCON_PENDING_REASON] = sorted(_RAYCON_TOKEN_PATHS)
+        pending_reasons_unsorted[RAYCON_PENDING_REASON] = sorted(_RAYCON_TOKEN_PATHS)
+
+    pending_reasons = {
+        reason: pending_reasons_unsorted[reason]
+        for reason in sorted(pending_reasons_unsorted)
+    }
 
     auto_republish_on = sorted({
         REASON_TRIGGER_FILES[reason]

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -11,6 +11,7 @@ import logging
 import re
 from typing import Any
 
+from .completeness import REASON_DISPLAY_LABELS
 from .report_schema import LINK_DISPLAY_LABELS, LINK_TOKENS
 
 logger = logging.getLogger(__name__)
@@ -686,23 +687,12 @@ def _reference_type_label(token: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-# Local copy of the human-readable labels for pending reasons. Keeping a
-# small private map here (rather than importing from completeness.py)
-# avoids a layering dependency from the renderer onto the metadata
-# module — the doc builder should not depend on completeness logic. The
-# completeness module owns the canonical map; this is the rendering
-# fallback used when a key is unrecognized.
-_BANNER_REASON_LABELS: dict[str, str] = {
-    "raycon_scenario_pending": "RayCon cost & capacity",
-}
-
-
 def _format_pending_reason_label(reason_key: str) -> str:
     """Map a ``pending_reasons`` key to the human-readable label used
     in the banner ``Missing:`` line. Falls back to the raw key when no
     label is registered, so a freshly-added reason still surfaces
     visibly rather than silently dropping out of the banner."""
-    return _BANNER_REASON_LABELS.get(reason_key, reason_key)
+    return REASON_DISPLAY_LABELS.get(reason_key, reason_key)
 
 
 def format_partial_banner_text(
@@ -732,7 +722,7 @@ def format_partial_banner_text(
 
     reasons = completeness.get("pending_reasons") or {}
     if isinstance(reasons, dict) and reasons:
-        labels = [_format_pending_reason_label(key) for key in reasons.keys()]
+        labels = [_format_pending_reason_label(key) for key in sorted(reasons.keys())]
     else:
         labels = ["pending data"]
     missing_str = ", ".join(labels)

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from due_diligence_reporter import completeness as completeness_module
 from due_diligence_reporter.completeness import (
     RAYCON_PENDING_REASON,
+    REASON_DISPLAY_LABELS,
     compute_completeness_block,
     is_raycon_pending_placeholder,
     project_completeness_from_readiness,
@@ -40,10 +42,17 @@ class TestIsRayconPendingPlaceholder:
 class TestRayconTokenPaths:
     def test_includes_summary_tokens(self) -> None:
         paths = set(raycon_token_paths())
-        assert "exec.fastest_open_capacity" in paths
         assert "exec.fastest_open_capex" in paths
         assert "exec.fastest_open_open_date" in paths
-        assert "exec.max_capacity_capacity" in paths
+        assert "exec.max_capacity_capex" in paths
+        assert "exec.max_capacity_open_date" in paths
+
+    def test_excludes_capacity_tokens(self) -> None:
+        # Capacity is sourced from the Capacity Brainlift (the agent),
+        # not RayCon — see report_schema.TOKEN_SOURCES.
+        paths = set(raycon_token_paths())
+        assert "exec.fastest_open_capacity" not in paths
+        assert "exec.max_capacity_capacity" not in paths
 
     def test_includes_cost_breakdown_tokens(self) -> None:
         paths = set(raycon_token_paths())
@@ -51,8 +60,8 @@ class TestRayconTokenPaths:
         assert "exec.cost_demolition_max_capacity" in paths
 
     def test_total_count(self) -> None:
-        # 12 cost rows * 2 scenarios + 3 summary fields * 2 scenarios = 30
-        assert len(raycon_token_paths()) == 30
+        # 12 cost rows * 2 scenarios + 2 RayCon summary fields * 2 scenarios = 28
+        assert len(raycon_token_paths()) == 28
 
 
 # ---------------------------------------------------------------------------
@@ -81,11 +90,11 @@ class TestComputeCompletenessBlock:
         replacements = _all_raycon_pending()
         block = compute_completeness_block(replacements)
         assert block["stage"] == "partial"
-        assert block["pending_token_count"] == 30
+        assert block["pending_token_count"] == 28
         assert block["filled_token_count"] == 0
         assert block["auto_republish_on"] == ["raycon_scenario.json"]
         assert RAYCON_PENDING_REASON in block["pending_reasons"]
-        assert len(block["pending_reasons"][RAYCON_PENDING_REASON]) == 30
+        assert len(block["pending_reasons"][RAYCON_PENDING_REASON]) == 28
 
     def test_all_filled_is_complete(self) -> None:
         replacements = _all_raycon_filled()
@@ -99,19 +108,19 @@ class TestComputeCompletenessBlock:
         assert block["pending_reasons"] == {}
         assert block["auto_republish_on"] == []
         # filled_token_count counts every non-empty, non-placeholder
-        # entry in the map — the 30 RayCon tokens plus the 2 we added.
-        assert block["filled_token_count"] == 32
+        # entry in the map — the 28 RayCon tokens plus the 2 we added.
+        assert block["filled_token_count"] == 30
 
     def test_partial_only_partially_filled_raycon(self) -> None:
         replacements = _all_raycon_pending()
-        replacements["exec.fastest_open_capacity"] = "120 students"
+        replacements["exec.fastest_open_capex"] = "$1,234,567"
         block = compute_completeness_block(replacements)
         assert block["stage"] == "partial"
-        assert block["pending_token_count"] == 29
+        assert block["pending_token_count"] == 27
         # The one filled RayCon token contributes to filled_token_count.
         assert block["filled_token_count"] == 1
         pending_paths = block["pending_reasons"][RAYCON_PENDING_REASON]
-        assert "exec.fastest_open_capacity" not in pending_paths
+        assert "exec.fastest_open_capex" not in pending_paths
 
     def test_pending_reasons_open_ended_dict(self) -> None:
         # The dict shape is {reason_key: [token_paths]} so future
@@ -126,7 +135,7 @@ class TestProjectCompletenessFromReadiness:
     def test_raycon_missing_projects_partial(self) -> None:
         block = project_completeness_from_readiness(raycon_scenario_found=False)
         assert block["stage"] == "partial"
-        assert block["pending_token_count"] == 30
+        assert block["pending_token_count"] == 28
         assert block["auto_republish_on"] == ["raycon_scenario.json"]
         # Filled count is unknown pre-generation.
         assert block["filled_token_count"] is None
@@ -184,3 +193,77 @@ class TestFormatPartialBannerText:
         # display label has been registered, so the fallback uses
         # the raw key rather than dropping the line.
         assert "vendor_sir_pending" in text
+
+    def test_banner_uses_canonical_reason_display_labels(
+        self, monkeypatch
+    ) -> None:
+        # Adding a label to the canonical map in completeness.py must
+        # surface in the banner without touching google_doc_builder.py.
+        # This guards against a parallel, drifting label map in the
+        # renderer (the bug PR #86 review surfaced).
+        new_reason_key = "vendor_sir_pending"
+        new_label = "Vendor SIR (Acme Co.)"
+        patched = dict(REASON_DISPLAY_LABELS)
+        patched[new_reason_key] = new_label
+        monkeypatch.setattr(completeness_module, "REASON_DISPLAY_LABELS", patched)
+        # google_doc_builder reads REASON_DISPLAY_LABELS from the
+        # completeness module via a top-level import, so patching the
+        # binding there too keeps the test honest.
+        from due_diligence_reporter import google_doc_builder
+
+        monkeypatch.setattr(google_doc_builder, "REASON_DISPLAY_LABELS", patched)
+
+        block = {
+            "stage": "partial",
+            "pending_reasons": {new_reason_key: []},
+        }
+        text = format_partial_banner_text(block)
+        assert new_label in text
+        assert new_reason_key not in text
+
+    def test_banner_orders_multiple_reasons_deterministically(self) -> None:
+        # When multiple reasons coexist, the banner must list them in
+        # a stable order (alphabetical by reason key) so the output is
+        # deterministic across runs and dict-iteration orderings.
+        block = {
+            "stage": "partial",
+            "pending_reasons": {
+                "zeta_reason": [],
+                "alpha_reason": [],
+                RAYCON_PENDING_REASON: [],
+            },
+        }
+        text = format_partial_banner_text(block)
+        # alpha < raycon_scenario_pending < zeta
+        assert text.index("alpha_reason") < text.index("RayCon cost & capacity")
+        assert text.index("RayCon cost & capacity") < text.index("zeta_reason")
+
+
+# ---------------------------------------------------------------------------
+# Projection-vs-actual consistency: project_completeness_from_readiness must
+# agree with compute_completeness_block on the partially-populated token map
+# the report pipeline actually produces. This is the contract that would have
+# caught the capacity-tokens-in-RayCon-paths bug surfaced in PR #86 review.
+# ---------------------------------------------------------------------------
+
+
+class TestProjectionVsActualConsistency:
+    def test_raycon_missing_matches_actual(self) -> None:
+        projected = project_completeness_from_readiness(raycon_scenario_found=False)
+        actual = compute_completeness_block(_all_raycon_pending())
+
+        assert projected["pending_token_count"] == actual["pending_token_count"]
+        assert set(projected["pending_reasons"].keys()) == set(
+            actual["pending_reasons"].keys()
+        )
+        assert projected["auto_republish_on"] == actual["auto_republish_on"]
+        assert projected["stage"] == actual["stage"]
+
+    def test_raycon_present_matches_actual(self) -> None:
+        projected = project_completeness_from_readiness(raycon_scenario_found=True)
+        actual = compute_completeness_block(_all_raycon_filled())
+
+        assert projected["pending_token_count"] == actual["pending_token_count"]
+        assert projected["pending_reasons"] == actual["pending_reasons"]
+        assert projected["auto_republish_on"] == actual["auto_republish_on"]
+        assert projected["stage"] == actual["stage"]


### PR DESCRIPTION
## Summary

Small follow-up to #86 (already merged) addressing two findings from the PR #86 review.

### Fix 1 — Consolidate reason-label maps

`google_doc_builder.py` kept a private `_BANNER_REASON_LABELS` map that duplicated `REASON_DISPLAY_LABELS` in `completeness.py`. New reason keys added to the canonical map would have rendered as raw snake_case in the banner. Now imports `REASON_DISPLAY_LABELS` directly and deletes the duplicate. The raw-key fallback for unregistered reasons is preserved.

### Fix 2 — Drop `*_capacity` tokens from `_RAYCON_TOKEN_PATHS`

`_RAYCON_TOKEN_PATHS` listed `exec.fastest_open_capacity` and `exec.max_capacity_capacity` as RayCon-pending, but per `report_schema.TOKEN_SOURCES` (and `SUMMARY_TOKEN_BASES`) the `capacity` metric is sourced from `"Capacity Brainlift"` (the agent), not `raycon_scenario.json`. This bug:
- overstated `pending_token_count` by up to 2 when only RayCon was missing,
- mis-attributed capacity gaps to RayCon in placeholder text and reason keys.

Capacity tokens are dropped from the canonical RayCon path list. `capex`, `open_date`, and the 12 RayCon cost rows for both scenarios remain. New count: 28 (was 30).

`server._fill_scenario_placeholders` was deliberately left untouched — the prompt's guidance was "only edit if the change in `_RAYCON_TOKEN_PATHS` requires it." Capacity tokens still get the agent-sourced placeholder there if missing, which is unchanged behavior. (If we want capacity placeholders to read differently, that's a separate, label-only follow-up.)

### Fix 3 (small, included) — Deterministic ordering

`pending_reasons` keys are now sorted before serialization in both `compute_completeness_block` and `project_completeness_from_readiness`, and the banner's `Missing:` line iterates `sorted(pending_reasons.keys())`. Output is deterministic when multiple reasons coexist. ~6 lines of net change across both files.

## Files changed

| File | What changed |
| --- | --- |
| `src/due_diligence_reporter/completeness.py` | Drop capacity tokens from `raycon_token_paths()`. Sort `pending_reasons` keys before returning, in both `compute_completeness_block` and `project_completeness_from_readiness`. |
| `src/due_diligence_reporter/google_doc_builder.py` | Import canonical `REASON_DISPLAY_LABELS` from `completeness`; delete duplicate `_BANNER_REASON_LABELS`. Iterate `sorted(pending_reasons.keys())` in the banner. |
| `tests/test_completeness.py` | Update token-count expectations (30 → 28) and the partial-fill case to use a non-capacity token. Add `test_excludes_capacity_tokens`. Add `TestProjectionVsActualConsistency` (the test that would have caught Fix 2). Add `test_banner_uses_canonical_reason_display_labels` (the test that would have caught Fix 1). Add `test_banner_orders_multiple_reasons_deterministically`. |

## Test plan

- [x] `uv run pytest tests/test_completeness.py tests/test_google_doc_builder.py` — 89 passed
- [x] `uv run pytest` (full suite) — 1081 passed
- [x] `uv run ruff check` on changed files — clean

## Notes for review

- No circular-import risk: `completeness.py` doesn't import from `google_doc_builder.py`. Top-level import is fine.
- The label string `"RayCon cost & capacity"` itself is unchanged (it's a user-facing description of the scenario report; capacity is part of the *output* even if the number originates upstream). Renaming would be a separate UX call.

---
🤖 *Generated by Computer*