### PR TITLE
feat(reports): generalize republish to all authoritative doc arrivals

### DIFF
--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -61,8 +61,15 @@ load_dotenv(_project_root / ".env")
 
 import requests  # noqa: E402
 
-from due_diligence_reporter.classifier import classify_document_type  # noqa: E402
 from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.dd_republish import (  # noqa: E402
+    DD_REPUBLISH_STATE_PATH,
+    REASON_RAYCON,
+    find_existing_dd_report,
+    load_state as _load_dd_republish_state_shared,
+    maybe_republish_dd_report,
+    save_state as _save_dd_republish_state_shared,
+)
 from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
 from due_diligence_reporter.m1_lookup import _resolve_m1_folder  # noqa: E402
 from due_diligence_reporter.raycon_client import (  # noqa: E402
@@ -78,15 +85,12 @@ from due_diligence_reporter.report_pipeline import (  # noqa: E402
 )
 from due_diligence_reporter.server import save_skill_report  # noqa: E402
 from due_diligence_reporter.utils import (  # noqa: E402
-    build_site_match_terms,
     extract_folder_id_from_url,
 )
 from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
     build_site_summary,
-    extract_school_feasibility_from_record,
-    extract_timeline_confidence_from_record,
     filter_active_site_records,
     load_wrike_config,
 )
@@ -143,10 +147,16 @@ DISPATCH_DEDUP_PATH = _project_root / ".raycon_dispatch_state.json"
 
 # Persisted map of {f"{site_id}:{raycon_run_id}": ISO timestamp} so the
 # event-driven DD Report republish (Rec. 1) doesn't re-run the full
-# pipeline twice for the same RayCon scenario. A scenario that lacks a
-# raycon_run_id falls back to a synthetic key derived from the JSON's
-# Drive ``modifiedTime`` so we still dedup at run granularity.
-DD_REPUBLISH_DEDUP_PATH = _project_root / ".raycon_dd_republish_state.json"
+# pipeline twice for the same RayCon scenario.
+#
+# Pre-Rec.3, this file lived at ``.raycon_dd_republish_state.json`` and
+# was keyed only on ``site_id:run_id``. Post-Rec.3 the canonical state
+# file is the shared ``.dd_republish_state.json`` (see ``dd_republish``)
+# keyed on ``site_id:reason:fingerprint`` so vendor SIR + Building
+# Inspection arrivals dedup against the same store. The legacy path is
+# read once at startup for migration and never written again.
+LEGACY_DD_REPUBLISH_DEDUP_PATH = _project_root / ".raycon_dd_republish_state.json"
+DD_REPUBLISH_DEDUP_PATH = DD_REPUBLISH_STATE_PATH
 
 # Force-republish window: regenerate at least once per N hours for the same
 # (site, raycon_run_id) pair if conditions still hold. Mirrors the
@@ -210,26 +220,48 @@ def _save_dispatch_state(
 
 def _load_republish_state(
     path: Path = DD_REPUBLISH_DEDUP_PATH,
+    *,
+    legacy_path: Path = LEGACY_DD_REPUBLISH_DEDUP_PATH,
 ) -> dict[str, str]:
-    """Load the {f'{site_id}:{run_id}': last_republish_iso} dedup map."""
+    """Load the shared DD republish dedup map.
+
+    Migrates legacy keys from the pre-Rec.3 ``.raycon_dd_republish_state.json``
+    (shape ``site_id:run_id``) into the new ``site_id:reason:fingerprint``
+    shape on first read. The new file wins on conflict; legacy entries are
+    only used to seed dedup on the first run after deploy.
+    """
+    state = _load_dd_republish_state_shared(path)
+
+    # One-shot migration: read the legacy file (if any) and rewrite each
+    # entry into the new key shape, but only when the new state doesn't
+    # already have an equivalent entry. We cannot delete the legacy file
+    # safely here (no write permissions in test sandboxes), so we just
+    # overlay it. Subsequent runs no-op once writes have been persisted to
+    # the new path because state already contains the migrated keys.
     try:
-        if not path.exists():
-            return {}
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return {k: str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+        if legacy_path.exists():
+            legacy = json.loads(legacy_path.read_text(encoding="utf-8"))
+            if isinstance(legacy, dict):
+                for old_key, ts in legacy.items():
+                    # Old key is "{site_id}:{run_id}". New key adds the
+                    # ``raycon_scenario`` reason in the middle.
+                    if not isinstance(old_key, str) or ":" not in old_key:
+                        continue
+                    site_id, run_id = old_key.split(":", 1)
+                    new_key = f"{site_id}:{REASON_RAYCON}:{run_id}"
+                    state.setdefault(new_key, str(ts))
     except Exception as e:
-        logger.warning("Failed to read DD republish dedup state at %s: %s", path, e)
-        return {}
+        logger.warning(
+            "Failed to migrate legacy DD republish state at %s: %s", legacy_path, e
+        )
+    return state
 
 
 def _save_republish_state(
     state: dict[str, str], path: Path = DD_REPUBLISH_DEDUP_PATH
 ) -> None:
     """Persist the DD republish dedup map. Best-effort; logs but does not raise."""
-    try:
-        path.write_text(json.dumps(state, sort_keys=True, indent=2), encoding="utf-8")
-    except Exception as e:
-        logger.warning("Failed to write DD republish dedup state at %s: %s", path, e)
+    _save_dd_republish_state_shared(state, path)
 
 
 def _filter_dedup_alerts(
@@ -434,31 +466,13 @@ def _dispatch_raycon_job(
 def _find_existing_dd_report(
     gc: GoogleClient, site_folder_id: str
 ) -> dict[str, Any] | None:
-    """Return the most recently modified DD Report Doc in the site folder, or None.
+    """Return the most recently modified DD Report Doc in the site folder.
 
-    DD Reports live at the site-folder root (not M1) and are named like
-    ``<site> DD Report - YYYY-MM-DD``. We classify by filename via the
-    shared classifier so we accept any historical naming scheme that
-    ``classify_document_type`` flags as ``dd_report``.
+    Thin wrapper over ``dd_republish.find_existing_dd_report``. Kept here
+    so existing tests that patch ``scripts.raycon_followup._find_existing_dd_report``
+    continue to work.
     """
-    candidate: dict[str, Any] | None = None
-    try:
-        files = gc.list_files_in_folder(site_folder_id)
-    except Exception as e:
-        logger.warning(
-            "Could not list site folder %s while looking for existing DD Report: %s",
-            site_folder_id,
-            e,
-        )
-        return None
-    for f in files:
-        if classify_document_type(str(f.get("name", ""))) != "dd_report":
-            continue
-        if candidate is None or str(f.get("modifiedTime", "")) > str(
-            candidate.get("modifiedTime", "")
-        ):
-            candidate = f
-    return candidate
+    return find_existing_dd_report(gc, site_folder_id)
 
 
 def _republish_dd_report_if_present(
@@ -476,120 +490,92 @@ def _republish_dd_report_if_present(
 ) -> dict[str, Any]:
     """Regenerate the DD Report on top of an existing one when RayCon answers.
 
-    Closes the gap where a partial DD Report (generated before RayCon
-    responded) stayed partial forever. Behaviors:
-
-    * No existing DD Report → no-op (the daily/inbox path will create it
-      the first time vendor inputs land).
-    * Existing DD Report + same ``(site_id, raycon_run_id)`` already
-      republished within ``force_after`` → no-op.
-    * Existing DD Report + this is a fresh ``(site_id, raycon_run_id)`` →
-      call ``process_site_pipeline(force_regenerate=True)``.
+    Thin RayCon-flavored wrapper over
+    :func:`due_diligence_reporter.dd_republish.maybe_republish_dd_report`
+    (Rec. 3). Preserves the legacy decision strings the existing tests
+    and on-call runbooks rely on (``republished``, ``deduped``, etc.)
+    while delegating the actual idempotence + pipeline call to the
+    shared helper so vendor SIR + Building Inspection arrivals dedup
+    against the same store.
 
     Failures here MUST NOT crash the caller — the RayCon Scenario Doc
     publish has already succeeded by the time we get here, and a
     republish error should not undo that.
     """
     now = now or datetime.now(timezone.utc)
-    site_name = str(site_summary.get("title", "")).strip() or "(unnamed)"
+
+    # Synthesize a stable fingerprint when RayCon doesn't supply a
+    # raycon_run_id, mirroring pre-refactor behavior so the same
+    # scenario JSON polled repeatedly within the day stays deduped.
+    run_key = raycon_run_id.strip() or f"unknown@{now.date().isoformat()}"
+
     site_id = str(site_summary.get("id", "")).strip()
+    site_name = str(site_summary.get("title", "")).strip() or "(unnamed)"
     drive_folder_url = str(site_summary.get("drive_folder_url", "")).strip()
 
+    # Pre-rec3 "skipped_no_drive_folder" / "skipped_bad_drive_url"
+    # branches surfaced as distinct decision strings; the shared helper
+    # collapses them into ``skip_bad_input``. Map back to the legacy
+    # strings so existing dashboards / log greps don't break.
     if not drive_folder_url:
         return {"dd_report_republish": "skipped_no_drive_folder"}
-
-    site_folder_id = extract_folder_id_from_url(drive_folder_url) or ""
-    if not site_folder_id:
+    if not extract_folder_id_from_url(drive_folder_url):
         return {"dd_report_republish": "skipped_bad_drive_url"}
 
-    existing = _find_existing_dd_report(gc, site_folder_id)
-    if existing is None:
-        logger.info(
-            "DD Report republish skipped for site=%s — no existing report; "
-            "daily/inbox path will create it.",
-            site_name,
-        )
-        return {"dd_report_republish": "skipped_no_existing_report"}
+    outcome = maybe_republish_dd_report(
+        gc,
+        site_summary=site_summary,
+        reason=REASON_RAYCON,
+        content_fingerprint=run_key,
+        settings=settings,
+        system_prompt=system_prompt,
+        shared_cache=shared_cache,
+        republish_state=republish_state,
+        dry_run=dry_run,
+        now=now,
+        force_after=force_after,
+        existing_report_finder=_find_existing_dd_report,
+        # Plumb the module-level ``process_site_pipeline`` reference so
+        # tests that patch ``scripts.raycon_followup.process_site_pipeline``
+        # still observe the call. Without this, the helper imports the
+        # symbol directly from ``due_diligence_reporter.report_pipeline``
+        # and bypasses the patch.
+        pipeline_runner=process_site_pipeline,
+    )
 
-    # Dedup key: synthesize a stable run identifier when RayCon doesn't
-    # supply one so we still get per-run dedup rather than per-poll.
-    run_key = raycon_run_id.strip() or f"unknown@{now.date().isoformat()}"
-    state_key = f"{site_id or site_name}:{run_key}"
-    last_iso = republish_state.get(state_key)
-    last_dt = _parse_iso(last_iso) if last_iso else None
-    if last_dt is not None and (now - last_dt) < force_after:
-        logger.info(
-            "DD Report republish deduped for site=%s run=%s (last %s ago)",
-            site_name,
-            run_key,
-            now - last_dt,
-        )
+    # Translate the helper's decision strings back to the legacy strings
+    # raycon_followup callers (and tests) expect. The ``raycon_run_id``
+    # field is preserved on every row so on-call grepping by run still
+    # works after the refactor.
+    if outcome.decision == "republish":
+        return {
+            "dd_report_republish": "republished",
+            "raycon_run_id": run_key,
+            "pipeline_status": outcome.pipeline_status,
+            "doc_url": outcome.doc_url,
+        }
+    if outcome.decision == "skip_no_prior_report":
+        return {"dd_report_republish": "skipped_no_existing_report"}
+    if outcome.decision == "skip_no_diff":
         return {
             "dd_report_republish": "deduped",
             "raycon_run_id": run_key,
-            "last_republish": last_iso,
+            "last_republish": outcome.last_republish or None,
         }
-
-    if dry_run:
+    if outcome.decision == "skip_dry_run":
+        existing = _find_existing_dd_report(
+            gc, extract_folder_id_from_url(drive_folder_url) or ""
+        )
         return {
             "dd_report_republish": "would_republish",
             "raycon_run_id": run_key,
-            "existing_dd_report_id": existing.get("id"),
+            "existing_dd_report_id": (existing or {}).get("id"),
         }
-
-    site_address = str(site_summary.get("address", "")).strip() or None
-    match_terms = build_site_match_terms(site_name, site_address)
-    # Thread the same Wrike-derived fields the daily/inbox callers pass —
-    # otherwise the regenerated DD Report email loses the P1 CC and the
-    # dashboard publish loses the W74/W81 ratings + Wrike createdDate.
-    record_for_extract = {"customFields": site_summary.get("custom_fields", [])}
-    try:
-        result = process_site_pipeline(
-            gc,
-            site_name,
-            drive_folder_url,
-            match_terms,
-            shared_cache,
-            system_prompt,
-            settings,
-            p1_email=site_summary.get("p1_assignee_email"),
-            site_address=site_address,
-            p1_name=site_summary.get("p1_assignee_name"),
-            school_feasibility=extract_school_feasibility_from_record(
-                record_for_extract
-            ),
-            timeline_confidence=extract_timeline_confidence_from_record(
-                record_for_extract
-            ),
-            wrike_created_at=site_summary.get("created_date") or None,
-            force_regenerate=True,
-        )
-    except Exception as e:
-        logger.error(
-            "DD Report republish failed for site=%s run=%s: %s",
-            site_name,
-            run_key,
-            e,
-        )
-        return {"dd_report_republish": "failed", "reason": str(e)}
-
-    # Record the attempt regardless of result.status so a permanently
-    # waiting_on_docs site doesn't re-enter the pipeline on every cron
-    # tick. A future scenario JSON (different run_id) will get a fresh
-    # state_key and try again.
-    republish_state[state_key] = now.isoformat()
-    logger.info(
-        "DD Report republish for site=%s run=%s status=%s",
-        site_name,
-        run_key,
-        result.status,
-    )
-    return {
-        "dd_report_republish": "republished",
-        "raycon_run_id": run_key,
-        "pipeline_status": result.status,
-        "doc_url": getattr(result, "doc_url", "") or "",
-    }
+    if outcome.decision == "failed":
+        return {"dd_report_republish": "failed", "reason": outcome.error}
+    # skip_bad_input fallback (e.g. unknown reason — shouldn't happen
+    # since we hard-code REASON_RAYCON above).
+    return {"dd_report_republish": outcome.decision, "reason": outcome.error}
 
 
 def _process_site(

--- a/scripts/scan_inbox.py
+++ b/scripts/scan_inbox.py
@@ -39,6 +39,11 @@ from dotenv import load_dotenv  # noqa: E402
 load_dotenv(_project_root / ".env")
 
 from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.dd_republish import (  # noqa: E402
+    load_state as _load_dd_republish_state,
+    maybe_republish_dd_report,
+    save_state as _save_dd_republish_state,
+)
 from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
 from due_diligence_reporter.inbox_scanner import (  # noqa: E402
     build_scan_summary,
@@ -144,8 +149,72 @@ def main(dry_run: bool = False, scan_only: bool = False) -> None:
     except Exception as e:
         logger.error("Wrike lookup failed; continuing with inbox scan only: %s", e)
 
+    # ── Rec. 3: event-driven DD Report republish callback ───────────────────
+    # When a vendor SIR or Building Inspection lands on a site that
+    # already has a DD Report, regenerate the report on top of it so
+    # the new authoritative input is reflected. We share state with
+    # the RayCon-followup republish via ``.dd_republish_state.json`` so
+    # all three authoritative-doc arrival paths dedup against one store.
+    #
+    # The callback is lazy: it only loads the agent system prompt and
+    # the Drive shared-folder cache when at least one SIR/BI actually
+    # arrives. A scan that produces no authoritative arrivals pays
+    # nothing.
+    _shared_cache: dict[str, list[dict[str, Any]]] | None = None
+    _system_prompt: str | None = None
+    _republish_state = _load_dd_republish_state()
+
+    def _dd_republish_callback(
+        *,
+        gc: GoogleClient,
+        site_summary: dict[str, Any],
+        reason: str,
+        fingerprint: str,
+        dry_run: bool,
+    ) -> dict[str, Any]:
+        nonlocal _shared_cache, _system_prompt
+        if _system_prompt is None:
+            prompt_path = _project_root / "docs" / "prompts" / "prompt_v3.md"
+            if not prompt_path.exists():
+                logger.error(
+                    "DD Report republish: system prompt missing at %s", prompt_path
+                )
+                return {"status": "failed", "error": f"prompt missing at {prompt_path}"}
+            _system_prompt = prompt_path.read_text(encoding="utf-8")
+        if _shared_cache is None:
+            _shared_cache = list_shared_folders_once(gc)
+        outcome = maybe_republish_dd_report(
+            gc,
+            site_summary=site_summary,
+            reason=reason,
+            content_fingerprint=fingerprint,
+            settings=settings,
+            system_prompt=_system_prompt,
+            shared_cache=_shared_cache,
+            republish_state=_republish_state,
+            dry_run=dry_run,
+            # Inject the script-local pipeline reference so future
+            # mocking parity matches the raycon_followup pattern.
+            pipeline_runner=process_site_pipeline,
+        )
+        return outcome.as_dict()
+
     # ── Phase 1: Inbox scan ──────────────────────────────────────────────────
-    results = scan_inbox(gc, site_records, settings, dry_run=dry_run)
+    results = scan_inbox(
+        gc,
+        site_records,
+        settings,
+        dry_run=dry_run,
+        dd_republish_callback=_dd_republish_callback,
+    )
+
+    # Persist republish dedup state once after the scan (mirrors how
+    # raycon_followup.py persists state at end-of-run rather than
+    # per-site, so a partial-run failure still records progress). Only
+    # write when there are entries to avoid leaving an empty {} file at
+    # repo root for runs that never fired the callback.
+    if not dry_run and _republish_state:
+        _save_dd_republish_state(_republish_state)
 
     # Build summary
     summary = build_scan_summary(results)

--- a/src/due_diligence_reporter/dd_republish.py
+++ b/src/due_diligence_reporter/dd_republish.py
@@ -1,0 +1,454 @@
+"""Shared helper for event-driven DD Report republish.
+
+Recommendation 3 from ``docs/event-driven-ddr-recommendations.md``:
+every authoritative-doc arrival fires a "republish if needed" check.
+
+The DDR has three authoritative documents that change report content:
+
+* ``vendor_sir`` — vendor-confirmed SIR PDF (CDS email path).
+* ``building_inspection`` — vendor Building Inspection PDF (Worksmith path).
+* ``raycon_scenario`` — RayCon's ``raycon_scenario.json`` written into M1.
+
+Pre-Rec.3, only RayCon's arrival regenerated an existing DD Report
+(the Rec. 1 hook in ``scripts/raycon_followup.py``). Post-Rec.3, all
+three call this single shared helper so we have ONE definition of
+"should we republish."
+
+Design choices:
+
+* The helper is **idempotent** across rapid retries. Dedup is keyed on
+  ``(site_id, reason, content_fingerprint)`` and persisted to a single
+  state file ``.dd_republish_state.json`` at repo root. The fingerprint
+  is caller-supplied (``raycon_run_id`` for RayCon; Drive
+  ``file_id:modifiedTime`` for SIR/BI), giving us per-token provenance
+  + value without inventing a new diff format on top of the existing
+  trace structure.
+* **No diff means no republish** (cost guard). A repeat call with the
+  same fingerprint is a no-op.
+* **First-generation** is not our concern: when no DD Report exists
+  yet, the helper returns ``skipped_no_existing_report`` so the daily/
+  inbox first-gen path keeps owning that case.
+* **Failures are non-fatal**: the caller's primary action (publishing
+  the RayCon Doc, filing the SIR/BI to Drive) has already succeeded by
+  the time we get here, and a republish error must not undo that.
+* **Force-after window** (12h, mirroring the RayCon path) ensures a
+  permanently-stuck site still re-enters the pipeline at most once per
+  half-day for the same fingerprint.
+
+Observability mirrors PR #85's silent-fail pattern: every decision
+emits a structured log line with ``reason``, ``site_id``, the
+``decision``, and on skip the rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .classifier import classify_document_type
+from .config import Settings
+from .google_client import GoogleClient
+from .report_pipeline import PipelineResult, process_site_pipeline
+from .utils import build_site_match_terms, extract_folder_id_from_url
+from .wrike import (
+    extract_school_feasibility_from_record,
+    extract_timeline_confidence_from_record,
+)
+
+logger = logging.getLogger("dd_republish")
+
+# Recognized reason codes. Kept narrow so callers can't smuggle in
+# arbitrary strings that would silently break dedup keying.
+REASON_RAYCON = "raycon_scenario"
+REASON_VENDOR_SIR = "vendor_sir"
+REASON_BUILDING_INSPECTION = "building_inspection"
+SUPPORTED_REASONS = frozenset(
+    {REASON_RAYCON, REASON_VENDOR_SIR, REASON_BUILDING_INSPECTION}
+)
+
+# Single shared state file for all three reasons. Keyed by
+# ``f"{site_id}:{reason}:{content_fingerprint}"``. Lives at repo root
+# next to ``.raycon_dispatch_state.json`` so on-call has a uniform
+# place to look at observability state.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DD_REPUBLISH_STATE_PATH = _PROJECT_ROOT / ".dd_republish_state.json"
+
+# Force-republish window: regenerate at least once per N hours for the
+# same ``(site_id, reason, fingerprint)`` triple if conditions still
+# hold. Mirrors ``DD_REPUBLISH_FORCE_AFTER`` in raycon_followup.py so
+# the RayCon path's behavior is unchanged after refactoring.
+DD_REPUBLISH_FORCE_AFTER = timedelta(hours=12)
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepublishOutcome:
+    """Structured result of ``maybe_republish_dd_report``.
+
+    ``decision`` is one of:
+      * ``"republish"`` — pipeline ran with ``force_regenerate=True``.
+      * ``"skip_no_prior_report"`` — first-generation case; not our job.
+      * ``"skip_no_diff"`` — same fingerprint within force-after window.
+      * ``"skip_dry_run"`` — dry run; no work performed.
+      * ``"skip_bad_input"`` — caller-supplied site fields incomplete.
+      * ``"failed"`` — pipeline raised; report unchanged. ``error`` set.
+
+    The dataclass also exposes ``as_dict()`` so callers can merge the
+    outcome into a per-site result row, mirroring the shape of the
+    RayCon-followup row.
+    """
+
+    decision: str
+    reason: str
+    site_id: str
+    fingerprint: str
+    error: str = ""
+    pipeline_status: str = ""
+    doc_url: str = ""
+    last_republish: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "dd_report_republish": self.decision,
+            "republish_reason": self.reason,
+            "site_id": self.site_id,
+            "content_fingerprint": self.fingerprint,
+            "error": self.error,
+            "pipeline_status": self.pipeline_status,
+            "doc_url": self.doc_url,
+            "last_republish": self.last_republish,
+        }
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def load_state(path: Path = DD_REPUBLISH_STATE_PATH) -> dict[str, str]:
+    """Load the ``{state_key: last_republish_iso}`` dedup map.
+
+    Returns ``{}`` on missing file or any read/parse error so a corrupt
+    state file never blocks a republish.
+    """
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return {k: str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.warning("Failed to read DD republish state at %s: %s", path, e)
+        return {}
+
+
+def save_state(state: dict[str, str], path: Path = DD_REPUBLISH_STATE_PATH) -> None:
+    """Persist the dedup map. Best-effort; logs but does not raise."""
+    try:
+        path.write_text(
+            json.dumps(state, sort_keys=True, indent=2), encoding="utf-8"
+        )
+    except Exception as e:
+        logger.warning("Failed to write DD republish state at %s: %s", path, e)
+
+
+def _state_key(site_id: str, reason: str, fingerprint: str) -> str:
+    return f"{site_id}:{reason}:{fingerprint}"
+
+
+def _parse_iso(s: str) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# DD Report discovery
+# ---------------------------------------------------------------------------
+
+
+def find_existing_dd_report(
+    gc: GoogleClient, site_folder_id: str
+) -> dict[str, Any] | None:
+    """Return the most recently modified DD Report Doc in the site folder.
+
+    DD Reports live at the site-folder root (not M1) and are named like
+    ``<site> DD Report - YYYY-MM-DD``. We classify by filename via the
+    shared classifier so we accept any historical naming scheme that
+    ``classify_document_type`` flags as ``dd_report``.
+    """
+    candidate: dict[str, Any] | None = None
+    try:
+        files = gc.list_files_in_folder(site_folder_id)
+    except Exception as e:
+        logger.warning(
+            "Could not list site folder %s while looking for existing DD Report: %s",
+            site_folder_id,
+            e,
+        )
+        return None
+    for f in files:
+        if classify_document_type(str(f.get("name", ""))) != "dd_report":
+            continue
+        if candidate is None or str(f.get("modifiedTime", "")) > str(
+            candidate.get("modifiedTime", "")
+        ):
+            candidate = f
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# The shared helper
+# ---------------------------------------------------------------------------
+
+
+def maybe_republish_dd_report(
+    gc: GoogleClient,
+    *,
+    site_summary: dict[str, Any],
+    reason: str,
+    content_fingerprint: str,
+    settings: Settings,
+    system_prompt: str,
+    shared_cache: dict[str, list[dict[str, Any]]],
+    republish_state: dict[str, str],
+    dry_run: bool = False,
+    force: bool = False,
+    force_after: timedelta = DD_REPUBLISH_FORCE_AFTER,
+    now: datetime | None = None,
+    pipeline_runner: Callable[..., PipelineResult] | None = None,
+    existing_report_finder: Callable[
+        [GoogleClient, str], dict[str, Any] | None
+    ]
+    | None = None,
+) -> RepublishOutcome:
+    """Idempotent "republish DD Report if a material input changed" hook.
+
+    Args:
+        gc: Authenticated Google client.
+        site_summary: Wrike-derived dict with at minimum ``id``,
+            ``title``, ``drive_folder_url``. Also forwards
+            ``p1_assignee_email``/``_name``, ``custom_fields``, and
+            ``created_date`` to ``process_site_pipeline`` so the
+            regenerated DD Report email keeps the P1 CC and the
+            dashboard publish keeps W74/W81 + Wrike createdDate.
+        reason: One of ``vendor_sir``, ``building_inspection``,
+            ``raycon_scenario``. Anything else is rejected as
+            ``skip_bad_input``.
+        content_fingerprint: Caller-supplied identifier of the new
+            authoritative input. RayCon: ``raycon_run_id`` (or a
+            synthetic fallback derived from JSON ``modifiedTime``).
+            SIR/BI: ``f"{drive_file_id}:{drive_modified_time}"``.
+            Empty string is rejected as ``skip_bad_input``.
+        settings: App settings (forwarded to pipeline).
+        system_prompt: DD Report agent system prompt text.
+        shared_cache: Pre-fetched Drive shared-folder listing.
+        republish_state: Mutated in place on republish for dedup.
+        dry_run: If True, returns ``skip_dry_run`` without invoking
+            the pipeline.
+        force: If True, bypass the same-fingerprint dedup. Reserved for
+            operator-driven recovery; default callers leave it off.
+        force_after: Force-republish window. Same fingerprint repeated
+            inside this window → no-op.
+        now: Injectable for tests.
+        pipeline_runner: Injectable ``process_site_pipeline`` for tests.
+        existing_report_finder: Injectable ``find_existing_dd_report``
+            for tests.
+
+    Returns: ``RepublishOutcome``. Never raises; failures are encoded
+    in the returned outcome.
+    """
+    now = now or datetime.now(timezone.utc)
+    runner = pipeline_runner or process_site_pipeline
+    finder = existing_report_finder or find_existing_dd_report
+
+    site_id = str(site_summary.get("id", "")).strip()
+    site_name = str(site_summary.get("title", "")).strip() or "(unnamed)"
+    drive_folder_url = str(site_summary.get("drive_folder_url", "")).strip()
+    fingerprint = (content_fingerprint or "").strip()
+
+    if reason not in SUPPORTED_REASONS:
+        logger.warning(
+            "DD republish rejected: unknown reason=%r site_id=%s",
+            reason,
+            site_id,
+        )
+        return RepublishOutcome(
+            decision="skip_bad_input",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+            error=f"unknown reason: {reason!r}",
+        )
+    if not fingerprint:
+        logger.warning(
+            "DD republish rejected: empty content_fingerprint reason=%s site_id=%s",
+            reason,
+            site_id,
+        )
+        return RepublishOutcome(
+            decision="skip_bad_input",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+            error="empty content_fingerprint",
+        )
+    if not drive_folder_url:
+        logger.warning(
+            "DD republish rejected: missing drive_folder_url reason=%s site_id=%s",
+            reason,
+            site_id,
+        )
+        return RepublishOutcome(
+            decision="skip_bad_input",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+            error="missing drive_folder_url",
+        )
+
+    site_folder_id = extract_folder_id_from_url(drive_folder_url) or ""
+    if not site_folder_id:
+        logger.warning(
+            "DD republish rejected: bad drive_folder_url reason=%s site_id=%s url=%s",
+            reason,
+            site_id,
+            drive_folder_url,
+        )
+        return RepublishOutcome(
+            decision="skip_bad_input",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+            error="could not extract folder id from drive_folder_url",
+        )
+
+    existing = finder(gc, site_folder_id)
+    if existing is None:
+        logger.info(
+            "DD republish skip: no_prior_report reason=%s site_id=%s site=%s "
+            "(daily/inbox path will create the first report)",
+            reason,
+            site_id or "?",
+            site_name,
+        )
+        return RepublishOutcome(
+            decision="skip_no_prior_report",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+        )
+
+    # Dedup key uses site_id when available so two sites with the same
+    # name don't share state. Falls back to title for legacy callers
+    # that don't plumb id (no live caller does today, but keep safe).
+    state_key = _state_key(site_id or site_name, reason, fingerprint)
+    last_iso = republish_state.get(state_key)
+    last_dt = _parse_iso(last_iso) if last_iso else None
+    if not force and last_dt is not None and (now - last_dt) < force_after:
+        logger.info(
+            "DD republish skip: no_diff reason=%s site_id=%s site=%s fingerprint=%s "
+            "(last republished %s ago)",
+            reason,
+            site_id or "?",
+            site_name,
+            fingerprint,
+            now - last_dt,
+        )
+        return RepublishOutcome(
+            decision="skip_no_diff",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+            last_republish=last_iso or "",
+        )
+
+    if dry_run:
+        logger.info(
+            "DD republish dry_run: would_republish reason=%s site_id=%s "
+            "site=%s fingerprint=%s",
+            reason,
+            site_id or "?",
+            site_name,
+            fingerprint,
+        )
+        return RepublishOutcome(
+            decision="skip_dry_run",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+        )
+
+    site_address = str(site_summary.get("address", "")).strip() or None
+    match_terms = build_site_match_terms(site_name, site_address)
+    record_for_extract = {"customFields": site_summary.get("custom_fields", [])}
+
+    try:
+        result = runner(
+            gc,
+            site_name,
+            drive_folder_url,
+            match_terms,
+            shared_cache,
+            system_prompt,
+            settings,
+            p1_email=site_summary.get("p1_assignee_email"),
+            site_address=site_address,
+            p1_name=site_summary.get("p1_assignee_name"),
+            school_feasibility=extract_school_feasibility_from_record(
+                record_for_extract
+            ),
+            timeline_confidence=extract_timeline_confidence_from_record(
+                record_for_extract
+            ),
+            wrike_created_at=site_summary.get("created_date") or None,
+            force_regenerate=True,
+        )
+    except Exception as e:
+        logger.error(
+            "DD republish failed: reason=%s site_id=%s site=%s fingerprint=%s err=%s",
+            reason,
+            site_id or "?",
+            site_name,
+            fingerprint,
+            e,
+        )
+        return RepublishOutcome(
+            decision="failed",
+            reason=reason,
+            site_id=site_id,
+            fingerprint=fingerprint,
+            error=str(e),
+        )
+
+    # Record the attempt regardless of result.status so a permanently
+    # waiting_on_docs site doesn't re-enter the pipeline on every cron
+    # tick. A future fingerprint will get a fresh state_key and try
+    # again. Matches the RayCon-followup pre-refactor behavior exactly.
+    republish_state[state_key] = now.isoformat()
+    logger.info(
+        "DD republish ran: reason=%s site_id=%s site=%s fingerprint=%s status=%s",
+        reason,
+        site_id or "?",
+        site_name,
+        fingerprint,
+        result.status,
+    )
+    return RepublishOutcome(
+        decision="republish",
+        reason=reason,
+        site_id=site_id,
+        fingerprint=fingerprint,
+        pipeline_status=result.status,
+        doc_url=getattr(result, "doc_url", "") or "",
+    )

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -224,6 +224,64 @@ def _run_doc_arrival_folder_ping(
     }
 
 
+# Map of inbox doc_type → shared-helper reason code. Keep this narrow:
+# ISP and Block Plan do NOT trigger a DD Report republish. ISP is not an
+# authoritative DD input for the report content; Block Plan triggers the
+# RayCon job dispatch which (when RayCon answers) routes through the
+# scripts/raycon_followup.py republish hook instead.
+_INBOX_DOC_TYPE_TO_REPUBLISH_REASON = {
+    "sir": "vendor_sir",
+    "building_inspection": "building_inspection",
+}
+
+
+def _maybe_fire_dd_republish(
+    *,
+    callback: Any,
+    gc: GoogleClient,
+    site_summary: dict[str, Any],
+    doc_type: str,
+    drive_file: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Fire the shared DD Report republish callback for a vendor doc arrival.
+
+    Builds the content fingerprint from the Drive file's
+    ``id:modifiedTime`` so a re-upload of the same SIR (same Drive file
+    id, refreshed modifiedTime) re-fires the republish, while a polled
+    re-walk of the same file ID + same modifiedTime is a no-op.
+
+    Failures inside the callback are swallowed and surfaced into the
+    returned dict so the inbox scan never breaks on a flaky republish.
+    """
+    reason = _INBOX_DOC_TYPE_TO_REPUBLISH_REASON.get(doc_type)
+    if not reason:
+        return {"status": "skipped", "reason": f"doc_type {doc_type} not authoritative"}
+
+    file_id = str(drive_file.get("id", "")).strip()
+    modified_time = str(drive_file.get("modifiedTime", "")).strip()
+    if not file_id:
+        return {"status": "skipped", "reason": "missing drive file id"}
+    fingerprint = f"{file_id}:{modified_time}" if modified_time else file_id
+
+    try:
+        return callback(
+            gc=gc,
+            site_summary=site_summary,
+            reason=reason,
+            fingerprint=fingerprint,
+            dry_run=dry_run,
+        )
+    except Exception as e:
+        logger.error(
+            "DD Report republish callback raised for site=%s doc_type=%s: %s",
+            site_summary.get("title"),
+            doc_type,
+            e,
+        )
+        return {"status": "failed", "error": str(e)}
+
+
 def _run_block_plan_downstream(
     gc: GoogleClient,
     *,
@@ -368,8 +426,21 @@ def scan_inbox(
     settings: Settings,
     *,
     dry_run: bool = False,
+    dd_republish_callback: Any = None,
 ) -> dict[str, Any]:
     """Top-level orchestrator: scan Gmail, classify, upload, mark processed.
+
+    ``dd_republish_callback`` (Rec. 3): when supplied, fires after each
+    classified vendor SIR or Building Inspection upload to republish the
+    DD Report if one already exists for the matched site. Signature:
+
+        callback(*, gc, site_summary, reason, fingerprint, dry_run) -> dict
+
+    The callback is responsible for loading the agent system prompt and
+    Drive shared-folder cache lazily so the cost is only paid when at
+    least one authoritative arrival actually fires republish. Failures
+    inside the callback are caught here and surfaced into the per-upload
+    row as ``dd_report_republish: failed``; they never break the scan.
 
     Returns a summary dict with counts and details.
     """
@@ -423,6 +494,7 @@ def scan_inbox(
                 site_records=site_records,
                 dry_run=dry_run,
                 internal_skip_label_id=internal_skip_label_id,
+                dd_republish_callback=dd_republish_callback,
             )
             if email_result.get("internal_skipped"):
                 results["internal_skipped"] += 1
@@ -476,8 +548,16 @@ def process_email(
     site_records: list[dict[str, Any]] | None = None,
     internal_skip_label_id: str | None = None,
     dry_run: bool = False,
+    dd_republish_callback: Any = None,
 ) -> dict[str, Any]:
     """Process a single email: classify attachments by filename, upload, mark done.
+
+    ``dd_republish_callback`` (Rec. 3): see :func:`scan_inbox` docstring.
+    Forwarded to the per-upload arrival path so vendor SIR + Building
+    Inspection arrivals on a site that already has a DD Report trigger a
+    republish. ``None`` (the default) means "don't fire republish" — the
+    legacy first-generation path keeps owning the case where no DD
+    Report exists yet.
 
     Returns a dict with keys: uploaded, skipped, low_confidence, errors, marked.
     """
@@ -729,6 +809,29 @@ def process_email(
                     drive_file=drive_file,
                 )
                 uploaded[-1]["raycon_folder_ping"] = folder_ping
+
+                # Rec. 3 — generalized event-driven DD Report republish.
+                # When a vendor SIR or Building Inspection lands on a
+                # site that already has a DD Report, fire the shared
+                # republish hook so the report picks up the new
+                # authoritative input. RayCon arrivals continue to be
+                # handled by scripts/raycon_followup.py since they fire
+                # only when the scenario JSON is published, not when the
+                # Block Plan is filed here.
+                if (
+                    dd_republish_callback is not None
+                    and doc_type in ("sir", "building_inspection")
+                ):
+                    republish_result = _maybe_fire_dd_republish(
+                        callback=dd_republish_callback,
+                        gc=gc,
+                        site_summary=site_summary,
+                        doc_type=doc_type,
+                        drive_file=drive_file,
+                        dry_run=dry_run,
+                    )
+                    if republish_result:
+                        uploaded[-1]["dd_report_republish"] = republish_result
 
             if doc_type == "block_plan" and drive_file is not None:
                 block_plan_content = extract_text_from_pdf_bytes(file_bytes)

--- a/tests/test_dd_republish.py
+++ b/tests/test_dd_republish.py
@@ -1,0 +1,398 @@
+"""Tests for the shared event-driven DD Report republish helper.
+
+Covers Recommendation 3 from
+``docs/event-driven-ddr-recommendations.md``: every authoritative-doc
+arrival fires a "republish if needed" check. Tests assert that:
+
+* Vendor SIR / Building Inspection arrival on a site WITH an existing
+  report → republish fires.
+* Vendor SIR / Building Inspection arrival on a site WITHOUT an
+  existing report → no-op (the daily/inbox first-gen path handles it).
+* Vendor SIR / Building Inspection arrival where the fingerprint
+  matches the prior trace → skip (no diff means no republish; cost
+  guard).
+* RayCon arrival (the original Rec. 1 hook) continues to behave
+  identically after the refactor.
+* Idempotence: two rapid calls with the same fingerprint → exactly
+  one republish.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from due_diligence_reporter.dd_republish import (
+    DD_REPUBLISH_FORCE_AFTER,
+    REASON_BUILDING_INSPECTION,
+    REASON_RAYCON,
+    REASON_VENDOR_SIR,
+    RepublishOutcome,
+    maybe_republish_dd_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _site(**overrides) -> dict:
+    base = {
+        "id": "site-123",
+        "title": "Alpha Keller",
+        "drive_folder_url": "https://drive.google.com/drive/folders/abc123",
+        "address": "123 Main St",
+    }
+    base.update(overrides)
+    return base
+
+
+def _existing_dd_report() -> dict:
+    return {
+        "id": "dd1",
+        "name": "Alpha Keller DD Report - 2026-05-01",
+        "modifiedTime": "2026-05-01T00:00:00Z",
+    }
+
+
+def _pipeline_runner_factory(status: str = "report_created", doc_url: str = "https://docs/x"):
+    """Return a MagicMock substitute for ``process_site_pipeline``."""
+    result = MagicMock()
+    result.status = status
+    result.doc_url = doc_url
+    return MagicMock(return_value=result)
+
+
+def _call_helper(
+    *,
+    site_summary=None,
+    reason=REASON_VENDOR_SIR,
+    fingerprint="file-1:2026-05-05T10:00:00Z",
+    state=None,
+    finder=None,
+    runner=None,
+    dry_run=False,
+    force=False,
+    now=None,
+):
+    """Driver helper to keep the test signatures terse."""
+    return maybe_republish_dd_report(
+        MagicMock(),
+        site_summary=site_summary or _site(),
+        reason=reason,
+        content_fingerprint=fingerprint,
+        settings=MagicMock(),
+        system_prompt="prompt",
+        shared_cache={},
+        republish_state=state if state is not None else {},
+        dry_run=dry_run,
+        force=force,
+        now=now,
+        existing_report_finder=finder
+        or MagicMock(return_value=_existing_dd_report()),
+        pipeline_runner=runner or _pipeline_runner_factory(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vendor SIR arrival
+# ---------------------------------------------------------------------------
+
+
+class TestVendorSIRArrival:
+    def test_existing_report_fires_republish(self):
+        """Vendor SIR arrival on a site WITH an existing report → republish."""
+        runner = _pipeline_runner_factory()
+        state: dict = {}
+        outcome = _call_helper(
+            reason=REASON_VENDOR_SIR,
+            fingerprint="sir-file-1:2026-05-05T10:00:00Z",
+            state=state,
+            runner=runner,
+        )
+        assert outcome.decision == "republish"
+        assert outcome.reason == REASON_VENDOR_SIR
+        # State updated for dedup on subsequent calls.
+        assert (
+            "site-123:vendor_sir:sir-file-1:2026-05-05T10:00:00Z" in state
+        )
+        runner.assert_called_once()
+        assert runner.call_args.kwargs["force_regenerate"] is True
+
+    def test_no_existing_report_is_noop(self):
+        """No prior DD Report → first-gen path handles it; we no-op."""
+        runner = _pipeline_runner_factory()
+        outcome = _call_helper(
+            reason=REASON_VENDOR_SIR,
+            finder=MagicMock(return_value=None),
+            runner=runner,
+        )
+        assert outcome.decision == "skip_no_prior_report"
+        runner.assert_not_called()
+
+    def test_same_fingerprint_inside_force_after_skips(self):
+        """Same SIR fingerprint repeated within 12h → no diff, no republish."""
+        runner = _pipeline_runner_factory()
+        recent = (
+            datetime.now(timezone.utc) - timedelta(hours=1)
+        ).isoformat()
+        state = {
+            "site-123:vendor_sir:sir-file-1:2026-05-05T10:00:00Z": recent,
+        }
+        outcome = _call_helper(
+            reason=REASON_VENDOR_SIR,
+            fingerprint="sir-file-1:2026-05-05T10:00:00Z",
+            state=state,
+            runner=runner,
+        )
+        assert outcome.decision == "skip_no_diff"
+        runner.assert_not_called()
+        # State unchanged.
+        assert state[
+            "site-123:vendor_sir:sir-file-1:2026-05-05T10:00:00Z"
+        ] == recent
+
+    def test_new_fingerprint_after_old_one_fires(self):
+        """A re-uploaded SIR (new modifiedTime) → fresh fingerprint → republish."""
+        runner = _pipeline_runner_factory()
+        old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        state = {
+            "site-123:vendor_sir:sir-file-1:2026-05-05T10:00:00Z": old,
+        }
+        outcome = _call_helper(
+            reason=REASON_VENDOR_SIR,
+            fingerprint="sir-file-1:2026-05-06T10:00:00Z",  # new modifiedTime
+            state=state,
+            runner=runner,
+        )
+        assert outcome.decision == "republish"
+        runner.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Building Inspection arrival
+# ---------------------------------------------------------------------------
+
+
+class TestBuildingInspectionArrival:
+    def test_existing_report_fires_republish(self):
+        runner = _pipeline_runner_factory()
+        outcome = _call_helper(
+            reason=REASON_BUILDING_INSPECTION,
+            fingerprint="bi-file-1:2026-05-05T10:00:00Z",
+            runner=runner,
+        )
+        assert outcome.decision == "republish"
+        assert outcome.reason == REASON_BUILDING_INSPECTION
+        runner.assert_called_once()
+        assert runner.call_args.kwargs["force_regenerate"] is True
+
+    def test_no_existing_report_is_noop(self):
+        runner = _pipeline_runner_factory()
+        outcome = _call_helper(
+            reason=REASON_BUILDING_INSPECTION,
+            finder=MagicMock(return_value=None),
+            runner=runner,
+        )
+        assert outcome.decision == "skip_no_prior_report"
+        runner.assert_not_called()
+
+    def test_same_fingerprint_skips(self):
+        runner = _pipeline_runner_factory()
+        recent = (
+            datetime.now(timezone.utc) - timedelta(minutes=15)
+        ).isoformat()
+        state = {
+            "site-123:building_inspection:bi-file-1:2026-05-05T10:00:00Z": recent,
+        }
+        outcome = _call_helper(
+            reason=REASON_BUILDING_INSPECTION,
+            fingerprint="bi-file-1:2026-05-05T10:00:00Z",
+            state=state,
+            runner=runner,
+        )
+        assert outcome.decision == "skip_no_diff"
+        runner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# RayCon regression — Rec. 1 behavior preserved
+# ---------------------------------------------------------------------------
+
+
+class TestRayConRegression:
+    """The RayCon path was the original Rec. 1 hook. After the refactor
+    its trigger conditions must still call ``process_site_pipeline``
+    with ``force_regenerate=True`` for a fresh raycon_run_id, and skip
+    on a repeat."""
+
+    def test_raycon_arrival_calls_force_regenerate(self):
+        runner = _pipeline_runner_factory()
+        outcome = _call_helper(
+            reason=REASON_RAYCON,
+            fingerprint="rc_run_abc",
+            runner=runner,
+        )
+        assert outcome.decision == "republish"
+        assert outcome.reason == REASON_RAYCON
+        runner.assert_called_once()
+        assert runner.call_args.kwargs["force_regenerate"] is True
+
+    def test_raycon_repeat_within_window_skips(self):
+        runner = _pipeline_runner_factory()
+        recent = (
+            datetime.now(timezone.utc) - timedelta(hours=1)
+        ).isoformat()
+        state = {"site-123:raycon_scenario:rc_run_abc": recent}
+        outcome = _call_helper(
+            reason=REASON_RAYCON,
+            fingerprint="rc_run_abc",
+            state=state,
+            runner=runner,
+        )
+        assert outcome.decision == "skip_no_diff"
+        runner.assert_not_called()
+
+    def test_raycon_after_force_after_window_re_fires(self):
+        """Past the 12h force-after, the same run_id republishes again."""
+        runner = _pipeline_runner_factory()
+        old = (
+            datetime.now(timezone.utc) - timedelta(hours=DD_REPUBLISH_FORCE_AFTER.total_seconds() / 3600 + 1)
+        ).isoformat()
+        state = {"site-123:raycon_scenario:rc_run_abc": old}
+        outcome = _call_helper(
+            reason=REASON_RAYCON,
+            fingerprint="rc_run_abc",
+            state=state,
+            runner=runner,
+        )
+        assert outcome.decision == "republish"
+        runner.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Idempotence — two rapid calls with same fingerprint → exactly one republish
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotence:
+    def test_two_rapid_calls_with_same_fingerprint_run_pipeline_once(self):
+        runner = _pipeline_runner_factory()
+        state: dict = {}
+        finder = MagicMock(return_value=_existing_dd_report())
+
+        for _ in range(2):
+            maybe_republish_dd_report(
+                MagicMock(),
+                site_summary=_site(),
+                reason=REASON_VENDOR_SIR,
+                content_fingerprint="sir-1:2026-05-05T10:00:00Z",
+                settings=MagicMock(),
+                system_prompt="prompt",
+                shared_cache={},
+                republish_state=state,
+                dry_run=False,
+                pipeline_runner=runner,
+                existing_report_finder=finder,
+            )
+        assert runner.call_count == 1
+        # State has exactly one entry for this (site, reason, fingerprint).
+        assert (
+            list(state.keys())
+            == ["site-123:vendor_sir:sir-1:2026-05-05T10:00:00Z"]
+        )
+
+    def test_idempotence_across_reasons_does_not_collide(self):
+        """SIR + BI fingerprints with the same Drive id must not dedup against
+        each other — they're orthogonal authoritative inputs.
+        """
+        runner = _pipeline_runner_factory()
+        state: dict = {}
+        finder = MagicMock(return_value=_existing_dd_report())
+        for reason in (REASON_VENDOR_SIR, REASON_BUILDING_INSPECTION):
+            maybe_republish_dd_report(
+                MagicMock(),
+                site_summary=_site(),
+                reason=reason,
+                content_fingerprint="file-1:2026-05-05T10:00:00Z",
+                settings=MagicMock(),
+                system_prompt="prompt",
+                shared_cache={},
+                republish_state=state,
+                dry_run=False,
+                pipeline_runner=runner,
+                existing_report_finder=finder,
+            )
+        assert runner.call_count == 2
+        assert (
+            "site-123:vendor_sir:file-1:2026-05-05T10:00:00Z" in state
+        )
+        assert (
+            "site-123:building_inspection:file-1:2026-05-05T10:00:00Z" in state
+        )
+
+
+# ---------------------------------------------------------------------------
+# Failure handling + edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_unknown_reason_returns_skip_bad_input(self):
+        outcome = _call_helper(reason="garbage_reason")
+        assert outcome.decision == "skip_bad_input"
+        assert "unknown reason" in outcome.error
+
+    def test_empty_fingerprint_returns_skip_bad_input(self):
+        outcome = _call_helper(fingerprint="")
+        assert outcome.decision == "skip_bad_input"
+        assert "fingerprint" in outcome.error
+
+    def test_missing_drive_folder_returns_skip_bad_input(self):
+        runner = _pipeline_runner_factory()
+        site = _site()
+        site["drive_folder_url"] = ""
+        outcome = _call_helper(site_summary=site, runner=runner)
+        assert outcome.decision == "skip_bad_input"
+        runner.assert_not_called()
+
+    def test_pipeline_exception_is_caught(self):
+        """A crashing pipeline must surface as ``failed``, not raise."""
+        runner = MagicMock(side_effect=RuntimeError("Anthropic 500"))
+        outcome = _call_helper(runner=runner)
+        assert outcome.decision == "failed"
+        assert "Anthropic 500" in outcome.error
+
+    def test_dry_run_returns_skip_dry_run(self):
+        runner = _pipeline_runner_factory()
+        outcome = _call_helper(runner=runner, dry_run=True)
+        assert outcome.decision == "skip_dry_run"
+        runner.assert_not_called()
+
+    def test_force_bypasses_dedup(self):
+        """``force=True`` bypasses the same-fingerprint dedup."""
+        runner = _pipeline_runner_factory()
+        recent = (
+            datetime.now(timezone.utc) - timedelta(minutes=5)
+        ).isoformat()
+        state = {"site-123:vendor_sir:sir-1:2026-05-05T10:00:00Z": recent}
+        outcome = _call_helper(
+            fingerprint="sir-1:2026-05-05T10:00:00Z",
+            state=state,
+            runner=runner,
+            force=True,
+        )
+        assert outcome.decision == "republish"
+        runner.assert_called_once()
+
+    def test_outcome_as_dict_has_expected_shape(self):
+        runner = _pipeline_runner_factory(
+            status="report_created", doc_url="https://docs/abc"
+        )
+        outcome = _call_helper(runner=runner)
+        d = outcome.as_dict()
+        assert d["dd_report_republish"] == "republish"
+        assert d["pipeline_status"] == "report_created"
+        assert d["doc_url"] == "https://docs/abc"
+        assert d["site_id"] == "site-123"

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -1310,3 +1310,303 @@ class TestDocArrivalFolderPing:
         mock_ping.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# Rec. 3 — vendor SIR / Building Inspection arrival fires DD republish
+# ---------------------------------------------------------------------------
+
+
+class TestDDRepublishCallbackWiring:
+    """When a vendor SIR or Building Inspection lands, the inbox scanner
+    must invoke the supplied ``dd_republish_callback`` with the right
+    fingerprint so the shared helper can decide whether to regenerate
+    the DD Report.
+
+    These tests assert the wiring (callback invoked at all, with the
+    right ``reason`` and ``fingerprint``); the helper's republish-vs-skip
+    decision is exercised end-to-end in ``tests/test_dd_republish.py``.
+    """
+
+    def _common_mocks(self, doc_type: str, filename: str):
+        """Set up the standard process_email mocks for a vendor doc upload."""
+        extract = MagicMock(
+            message_id=f"msg_{doc_type}",
+            subject=filename,
+            sender="vendor@external.com",
+            effective_sender="vendor@external.com",
+            body_snippet="",
+            attachments=[
+                {
+                    "filename": filename,
+                    "attachment_id": f"att_{doc_type}",
+                    "mime_type": "application/pdf",
+                }
+            ],
+        )
+        return extract
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_sir_arrival_fires_callback_with_vendor_sir_reason(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_ping,
+        mock_resolve_m1,
+        mock_build_summary,
+    ):
+        mock_extract.return_value = self._common_mocks(
+            "sir", "Alpha Keller SIR.pdf"
+        )
+        mock_classify.return_value = ("sir", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        mock_build_summary.return_value = {
+            "id": "site-1",
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {
+            "id": "sir_drive_id",
+            "webViewLink": "https://drive.google.com/file/d/sir_drive_id",
+            "modifiedTime": "2026-05-05T10:00:00Z",
+        }
+
+        site_records = [
+            {"id": "site-1", "title": "Alpha Keller", "customFields": []}
+        ]
+        callback = MagicMock(return_value={"dd_report_republish": "republish"})
+
+        result = process_email(
+            gc,
+            "msg_sir",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=site_records,
+            dd_republish_callback=callback,
+        )
+
+        assert len(result["uploaded"]) == 1
+        callback.assert_called_once()
+        kwargs = callback.call_args.kwargs
+        assert kwargs["reason"] == "vendor_sir"
+        # Fingerprint is "{drive_file_id}:{modifiedTime}".
+        assert kwargs["fingerprint"] == "sir_drive_id:2026-05-05T10:00:00Z"
+        assert kwargs["site_summary"]["title"] == "Alpha Keller"
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_building_inspection_arrival_fires_callback_with_bi_reason(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_ping,
+        mock_resolve_m1,
+        mock_build_summary,
+    ):
+        mock_extract.return_value = self._common_mocks(
+            "building_inspection",
+            "Alpha Keller Building Inspection Report.pdf",
+        )
+        mock_classify.return_value = ("building_inspection", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        mock_build_summary.return_value = {
+            "id": "site-1",
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {
+            "id": "bi_drive_id",
+            "webViewLink": "https://drive.google.com/file/d/bi_drive_id",
+            "modifiedTime": "2026-05-06T14:00:00Z",
+        }
+
+        site_records = [
+            {"id": "site-1", "title": "Alpha Keller", "customFields": []}
+        ]
+        callback = MagicMock(return_value={"dd_report_republish": "republish"})
+
+        result = process_email(
+            gc,
+            "msg_bi",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=site_records,
+            dd_republish_callback=callback,
+        )
+
+        assert len(result["uploaded"]) == 1
+        callback.assert_called_once()
+        kwargs = callback.call_args.kwargs
+        assert kwargs["reason"] == "building_inspection"
+        assert kwargs["fingerprint"] == "bi_drive_id:2026-05-06T14:00:00Z"
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_isp_arrival_does_not_fire_callback(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_ping,
+        mock_resolve_m1,
+        mock_build_summary,
+    ):
+        """ISP is not an authoritative DD input — no republish on arrival."""
+        mock_extract.return_value = self._common_mocks(
+            "isp", "Alpha Keller ISP.pdf"
+        )
+        mock_classify.return_value = ("isp", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        mock_build_summary.return_value = {
+            "id": "site-1",
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {
+            "id": "isp_drive_id",
+            "webViewLink": "https://drive.google.com/file/d/isp_drive_id",
+            "modifiedTime": "2026-05-05T10:00:00Z",
+        }
+        site_records = [
+            {"id": "site-1", "title": "Alpha Keller", "customFields": []}
+        ]
+        callback = MagicMock()
+        process_email(
+            gc,
+            "msg_isp",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=site_records,
+            dd_republish_callback=callback,
+        )
+        callback.assert_not_called()
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_sir_arrival_with_no_callback_is_noop(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_ping,
+        mock_resolve_m1,
+        mock_build_summary,
+    ):
+        """No callback supplied → upload still succeeds, no republish field."""
+        mock_extract.return_value = self._common_mocks(
+            "sir", "Alpha Keller SIR.pdf"
+        )
+        mock_classify.return_value = ("sir", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        mock_build_summary.return_value = {
+            "id": "site-1",
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+        }
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {
+            "id": "sir_drive_id",
+            "modifiedTime": "2026-05-05T10:00:00Z",
+        }
+
+        result = process_email(
+            gc,
+            "msg_sir",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=[
+                {"id": "site-1", "title": "Alpha Keller", "customFields": []}
+            ],
+            dd_republish_callback=None,
+        )
+        assert len(result["uploaded"]) == 1
+        assert "dd_report_republish" not in result["uploaded"][0]
+
+    @patch("due_diligence_reporter.inbox_scanner.build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_callback_exception_does_not_break_upload(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_ping,
+        mock_resolve_m1,
+        mock_build_summary,
+    ):
+        """Callback raising → upload still recorded, failure surfaced."""
+        mock_extract.return_value = self._common_mocks(
+            "sir", "Alpha Keller SIR.pdf"
+        )
+        mock_classify.return_value = ("sir", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "M1")
+        mock_ping.return_value = {"status": "accepted"}
+        mock_build_summary.return_value = {
+            "id": "site-1",
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"pdf"
+        gc.upload_file_to_folder.return_value = {
+            "id": "sir_drive_id",
+            "modifiedTime": "2026-05-05T10:00:00Z",
+        }
+        callback = MagicMock(side_effect=RuntimeError("pipeline blew up"))
+
+        result = process_email(
+            gc,
+            "msg_sir",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=[
+                {"id": "site-1", "title": "Alpha Keller", "customFields": []}
+            ],
+            dd_republish_callback=callback,
+        )
+        assert len(result["uploaded"]) == 1
+        republish = result["uploaded"][0].get("dd_report_republish") or {}
+        assert republish.get("status") == "failed"
+        assert "pipeline blew up" in republish.get("error", "")
+
+

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -734,7 +734,7 @@ class TestDDReportRepublish:
         assert out["dd_report_republish"] == "republished"
         assert out["raycon_run_id"] == "rc_run_abc"
         # State updated for dedup on the next cron tick.
-        assert republish_state.get("site-123:rc_run_abc")
+        assert republish_state.get("site-123:raycon_scenario:rc_run_abc")
         mock_pipeline.assert_called_once()
         kwargs = mock_pipeline.call_args.kwargs
         assert kwargs.get("force_regenerate") is True
@@ -769,7 +769,7 @@ class TestDDReportRepublish:
             "name": "Alpha Keller DD Report - 2026-05-01",
         }
         recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-        republish_state = {"site-123:rc_run_abc": recent}
+        republish_state = {"site-123:raycon_scenario:rc_run_abc": recent}
 
         gc = MagicMock()
         out = _republish_dd_report_if_present(
@@ -786,7 +786,7 @@ class TestDDReportRepublish:
         assert out["dd_report_republish"] == "deduped"
         mock_pipeline.assert_not_called()
         # State unchanged.
-        assert republish_state["site-123:rc_run_abc"] == recent
+        assert republish_state["site-123:raycon_scenario:rc_run_abc"] == recent
 
     @patch("scripts.raycon_followup.process_site_pipeline")
     @patch("scripts.raycon_followup._find_existing_dd_report")
@@ -810,8 +810,8 @@ class TestDDReportRepublish:
         assert out["dd_report_republish"] == "failed"
         assert "Anthropic 500" in out["reason"]
 
-    @patch("scripts.raycon_followup.extract_timeline_confidence_from_record")
-    @patch("scripts.raycon_followup.extract_school_feasibility_from_record")
+    @patch("due_diligence_reporter.dd_republish.extract_timeline_confidence_from_record")
+    @patch("due_diligence_reporter.dd_republish.extract_school_feasibility_from_record")
     @patch("scripts.raycon_followup.process_site_pipeline")
     @patch("scripts.raycon_followup._find_existing_dd_report")
     def test_republish_forwards_p1_and_feasibility_fields(


### PR DESCRIPTION
## Summary

Implements **Recommendation 3** from `docs/event-driven-ddr-recommendations.md`: every authoritative-doc arrival fires a "republish if needed" check.

Pre-Rec.3, only RayCon's `raycon_scenario.json` arrival regenerated an existing DD Report (the Rec. 1 hook in `scripts/raycon_followup.py`, shipped in PR #82). Vendor SIR and Building Inspection arrivals filed the document but left a stale DD Report in place — even when the new input materially changed scope.

This PR adds a **single idempotent helper**, `maybe_republish_dd_report`, that all three authoritative-doc arrival paths now route through. The DD Report's three authoritative inputs are now treated uniformly:

| Doc | Arrival path | Pre-PR | Post-PR |
|---|---|---|---|
| Vendor SIR | CDS email → `inbox_scanner` | filed; no republish | files; **republishes if DD Report exists** |
| Building Inspection | Worksmith → `inbox_scanner` | filed; no republish | files; **republishes if DD Report exists** |
| `raycon_scenario.json` | RayCon → `raycon_followup` | publishes RayCon Doc + republishes | unchanged behavior; refactored to share helper |

### Cost guard

Republish only fires when the diff is non-empty. The shared helper dedups on `(site_id, reason, content_fingerprint)` against a single state file `.dd_republish_state.json` at repo root. The fingerprint reuses Drive metadata — `file_id:modifiedTime` for SIR/BI, `raycon_run_id` for RayCon — instead of inventing a new diff format on top of the existing trace structure. Same fingerprint within the 12h force-after window is a no-op.

### What's changed

* **New module** `src/due_diligence_reporter/dd_republish.py` — `maybe_republish_dd_report()` + `RepublishOutcome` + shared state I/O. Single source of truth for "should we republish."
* **RayCon path refactored** — `_republish_dd_report_if_present` in `scripts/raycon_followup.py` is now a thin wrapper that translates `RepublishOutcome` decisions back to the legacy strings (`republished`, `deduped`, `failed`, `skipped_no_existing_report`) so existing dashboards and on-call greps still work. Behavior preserved (12h force-after, P1/feasibility/timeline forwarding from PR #83).
* **State migration** — legacy `.raycon_dd_republish_state.json` is read once at startup (`_load_republish_state`) and merged into the new key shape. Subsequent runs write to `.dd_republish_state.json`.
* **Vendor SIR + Building Inspection wiring** — `inbox_scanner.scan_inbox` and `process_email` accept an optional `dd_republish_callback`. After each classified vendor SIR / Building Inspection upload (right after the existing `_run_doc_arrival_folder_ping`), the callback fires with `reason=vendor_sir` or `reason=building_inspection`. ISP and Block Plan are intentionally excluded — Block Plan triggers RayCon's job dispatch which routes through the existing republish hook when the scenario JSON lands.
* **Callback wired in `scripts/scan_inbox.py`** — lazily loads the prompt + Drive shared-folder cache only when a SIR/BI actually arrives, and persists the shared dedup state at end-of-run.

### What's NOT changed

* The manual MCP override path (`create_dd_report` tool) — preserved untouched as an explicit user action.
* The vendor gate (`VENDOR_GATE_ENABLED`) — orthogonal to Rec. 3.
* RayCon path behavior — refactor only; trigger conditions and forwarding are identical to PR #82 + #83.

## Files changed

| File | Summary |
|---|---|
| `src/due_diligence_reporter/dd_republish.py` | NEW. `maybe_republish_dd_report` shared helper, `RepublishOutcome`, shared state I/O, `find_existing_dd_report`. |
| `scripts/raycon_followup.py` | Refactor `_republish_dd_report_if_present` to delegate to the shared helper; legacy state-file migration. |
| `scripts/scan_inbox.py` | Build the lazy DD republish callback; thread it into `scan_inbox`. |
| `src/due_diligence_reporter/inbox_scanner.py` | Plumb `dd_republish_callback` through `scan_inbox` → `process_email`; fire after SIR/BI uploads. |
| `tests/test_dd_republish.py` | NEW. Vendor SIR / Building Inspection / RayCon paths × {existing-report, no-existing-report, same-fingerprint, idempotence}. |
| `tests/test_inbox_scanner.py` | New `TestDDRepublishCallbackWiring` — vendor SIR, BI, ISP-no-fire, no-callback-noop, callback-exception-tolerated. |
| `tests/test_raycon_followup.py` | Update state-key shape (`site_id:raycon_scenario:run_id`) + redirect feasibility/timeline patches to the helper module. |

## Test plan

- [x] `uv run pytest tests/test_dd_republish.py` — 19 new tests, all passing
- [x] `uv run pytest tests/test_inbox_scanner.py` — 56 tests including 5 new wiring tests, all passing
- [x] `uv run pytest tests/test_raycon_followup.py` — 37 tests including the regression suite, all passing
- [x] `uv run pytest -q` — full suite, **1100 passed**

## Behavior change to the RayCon path

**None.** This is a pure refactor for the RayCon path:
- Same 12h force-after dedup window
- Same P1 / school_feasibility / timeline_confidence / wrike_created_at forwarding (PR #83)
- Same fail-soft behavior (republish failure cannot crash the RayCon Scenario Doc publish)
- Same legacy decision strings emitted (`republished`, `deduped`, `failed`, `skipped_no_existing_report`)
- Tests `TestDDReportRepublish` (PR #82 regression) all pass

Two surface-level shifts that are intentional and called out:
1. The state file moved from `.raycon_dd_republish_state.json` to the shared `.dd_republish_state.json`. Legacy entries are migrated on first read; the new file wins on conflict.
2. The state-key shape changed from `site_id:run_id` to `site_id:reason:run_id`. The migration step rewrites legacy keys with `reason=raycon_scenario`.

## Manual follow-up

- **No env vars** to configure.
- **No state migration script** required — `_load_republish_state` performs the legacy → shared migration automatically on first read.
- The legacy `.raycon_dd_republish_state.json` is left on disk after migration (we don't delete it from the helper; deletion is left to operators if they want to clean up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)