### PR TITLE
fix(reports): RayCon fingerprint + persistent state + atomic writes

### DIFF
--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -32,6 +32,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Restore DD republish dedup state
+        # Persists .dd_republish_state.json across cron ticks so the 12h
+        # DD_REPUBLISH_FORCE_AFTER window is honored. Save key is
+        # run-id-scoped so each run writes a fresh entry; restore-keys
+        # falls back to the latest entry that matches the prefix.
+        # Workflow-scoped key so inbox-scan doesn't trample
+        # raycon-followup's cache (and vice versa).
+        id: restore-dd-republish-state
+        uses: actions/cache/restore@v4
+        with:
+          path: .dd_republish_state.json
+          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
+          restore-keys: |
+            dd-republish-state-${{ github.workflow }}-
+            dd-republish-state-
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -160,6 +176,16 @@ jobs:
           else
             uv run python scripts/scan_inbox.py
           fi
+
+      - name: Save DD republish dedup state
+        # Always run so state persists even when the script step exits
+        # non-zero. Run-id-scoped save key avoids the in-place-update
+        # restriction of actions/cache.
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .dd_republish_state.json
+          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
 
       - name: Done
         run: echo "Inbox scan completed"

--- a/.github/workflows/raycon-followup.yml
+++ b/.github/workflows/raycon-followup.yml
@@ -51,6 +51,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Restore DD republish dedup state
+        # Persists .dd_republish_state.json across cron ticks so the 12h
+        # DD_REPUBLISH_FORCE_AFTER window is honored. Without this the
+        # state file is born empty every run and dedup degrades to
+        # intra-run only.
+        #
+        # Save key includes ${{ github.run_id }} so each run writes a
+        # fresh cache entry (actions/cache only writes when the exact
+        # key is new); restore-keys falls back to the latest entry that
+        # matches the prefix, giving us cross-run continuity without
+        # ever overwriting a key in place.
+        id: restore-dd-republish-state
+        uses: actions/cache/restore@v4
+        with:
+          path: .dd_republish_state.json
+          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
+          restore-keys: |
+            dd-republish-state-${{ github.workflow }}-
+            dd-republish-state-
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -154,6 +174,17 @@ jobs:
             ARGS+=(--alert-after-minutes "$INPUT_ALERT_AFTER_MINUTES")
           fi
           uv run python scripts/raycon_followup.py "${ARGS[@]}"
+
+      - name: Save DD republish dedup state
+        # Always run so we persist state even when the script step
+        # exits non-zero — partial dedup beats no dedup. The save key
+        # is run-id-scoped so we never collide with an existing entry;
+        # the next run picks us up via the restore-keys prefix fallback.
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .dd_republish_state.json
+          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
 
       - name: Done
         run: echo "RayCon follow-up completed"

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -225,36 +225,13 @@ def _load_republish_state(
 ) -> dict[str, str]:
     """Load the shared DD republish dedup map.
 
-    Migrates legacy keys from the pre-Rec.3 ``.raycon_dd_republish_state.json``
-    (shape ``site_id:run_id``) into the new ``site_id:reason:fingerprint``
-    shape on first read. The new file wins on conflict; legacy entries are
-    only used to seed dedup on the first run after deploy.
+    Delegates to ``dd_republish.load_state``, which now owns the
+    one-shot legacy migration so both raycon_followup and scan_inbox
+    pick it up. Kept as a thin wrapper so existing tests that patch
+    ``scripts.raycon_followup._load_republish_state`` still observe
+    the call.
     """
-    state = _load_dd_republish_state_shared(path)
-
-    # One-shot migration: read the legacy file (if any) and rewrite each
-    # entry into the new key shape, but only when the new state doesn't
-    # already have an equivalent entry. We cannot delete the legacy file
-    # safely here (no write permissions in test sandboxes), so we just
-    # overlay it. Subsequent runs no-op once writes have been persisted to
-    # the new path because state already contains the migrated keys.
-    try:
-        if legacy_path.exists():
-            legacy = json.loads(legacy_path.read_text(encoding="utf-8"))
-            if isinstance(legacy, dict):
-                for old_key, ts in legacy.items():
-                    # Old key is "{site_id}:{run_id}". New key adds the
-                    # ``raycon_scenario`` reason in the middle.
-                    if not isinstance(old_key, str) or ":" not in old_key:
-                        continue
-                    site_id, run_id = old_key.split(":", 1)
-                    new_key = f"{site_id}:{REASON_RAYCON}:{run_id}"
-                    state.setdefault(new_key, str(ts))
-    except Exception as e:
-        logger.warning(
-            "Failed to migrate legacy DD republish state at %s: %s", legacy_path, e
-        )
-    return state
+    return _load_dd_republish_state_shared(path, legacy_path=legacy_path)
 
 
 def _save_republish_state(
@@ -485,6 +462,7 @@ def _republish_dd_report_if_present(
     shared_cache: dict[str, list[dict[str, Any]]],
     republish_state: dict[str, str],
     dry_run: bool,
+    drive_modified_time: str = "",
     now: datetime | None = None,
     force_after: timedelta = DD_REPUBLISH_FORCE_AFTER,
 ) -> dict[str, Any]:
@@ -504,10 +482,15 @@ def _republish_dd_report_if_present(
     """
     now = now or datetime.now(timezone.utc)
 
-    # Synthesize a stable fingerprint when RayCon doesn't supply a
-    # raycon_run_id, mirroring pre-refactor behavior so the same
-    # scenario JSON polled repeatedly within the day stays deduped.
-    run_key = raycon_run_id.strip() or f"unknown@{now.date().isoformat()}"
+    # Composite fingerprint mirrors the SIR/BI shape (file_id:modifiedTime).
+    # If RayCon recomputes the same run_id but writes fresh content (new
+    # _drive_modified_time), the modifiedTime suffix changes and we
+    # republish; otherwise dedup holds. Without this suffix a real content
+    # change gets silently skipped for up to DD_REPUBLISH_FORCE_AFTER.
+    raycon_run_id = raycon_run_id.strip()
+    drive_modified_time = (drive_modified_time or "").strip()
+    base_key = raycon_run_id or f"unknown@{now.date().isoformat()}"
+    run_key = f"{base_key}:{drive_modified_time}" if drive_modified_time else base_key
 
     site_id = str(site_summary.get("id", "")).strip()
     site_name = str(site_summary.get("title", "")).strip() or "(unnamed)"
@@ -545,12 +528,14 @@ def _republish_dd_report_if_present(
 
     # Translate the helper's decision strings back to the legacy strings
     # raycon_followup callers (and tests) expect. The ``raycon_run_id``
-    # field is preserved on every row so on-call grepping by run still
-    # works after the refactor.
+    # field on the row is the bare run id (without the modifiedTime
+    # suffix) so on-call grepping by run still works after the
+    # composite-fingerprint fix.
+    legacy_run_id = base_key
     if outcome.decision == "republish":
         return {
             "dd_report_republish": "republished",
-            "raycon_run_id": run_key,
+            "raycon_run_id": legacy_run_id,
             "pipeline_status": outcome.pipeline_status,
             "doc_url": outcome.doc_url,
         }
@@ -559,7 +544,7 @@ def _republish_dd_report_if_present(
     if outcome.decision == "skip_no_diff":
         return {
             "dd_report_republish": "deduped",
-            "raycon_run_id": run_key,
+            "raycon_run_id": legacy_run_id,
             "last_republish": outcome.last_republish or None,
         }
     if outcome.decision == "skip_dry_run":
@@ -568,7 +553,7 @@ def _republish_dd_report_if_present(
         )
         return {
             "dd_report_republish": "would_republish",
-            "raycon_run_id": run_key,
+            "raycon_run_id": legacy_run_id,
             "existing_dd_report_id": (existing or {}).get("id"),
         }
     if outcome.decision == "failed":
@@ -747,10 +732,14 @@ def _process_site(
                 )
                 or scenario.get("raycon_run_id", "")
             ).strip()
+            drive_modified_time = str(
+                scenario.get("_drive_modified_time", "")
+            ).strip()
             republish_result = dd_republish_callback(
                 gc=gc,
                 site_summary=site_summary,
                 raycon_run_id=raycon_run_id,
+                drive_modified_time=drive_modified_time,
                 dry_run=dry_run,
             )
         except Exception as e:
@@ -843,6 +832,7 @@ def main(argv: list[str] | None = None) -> int:
         site_summary: dict[str, Any],
         raycon_run_id: str,
         dry_run: bool,
+        drive_modified_time: str = "",
     ) -> dict[str, Any]:
         nonlocal _shared_cache, _system_prompt
         if _system_prompt is None:
@@ -867,6 +857,7 @@ def main(argv: list[str] | None = None) -> int:
             shared_cache=_shared_cache,
             republish_state=republish_state,
             dry_run=dry_run,
+            drive_modified_time=drive_modified_time,
         )
 
     results: list[dict[str, Any]] = []

--- a/src/due_diligence_reporter/dd_republish.py
+++ b/src/due_diligence_reporter/dd_republish.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -76,6 +78,16 @@ SUPPORTED_REASONS = frozenset(
 # place to look at observability state.
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 DD_REPUBLISH_STATE_PATH = _PROJECT_ROOT / ".dd_republish_state.json"
+
+# Pre-Rec.3 path: the old RayCon-only file at
+# ``.raycon_dd_republish_state.json`` keyed on ``site_id:run_id``.
+# ``load_state`` migrates entries from this file into the shared
+# ``site_id:reason:fingerprint`` shape on first read so RayCon dedup
+# survives the cutover. The legacy file is left in place; subsequent
+# runs no-op once the new file holds the migrated keys.
+LEGACY_DD_REPUBLISH_STATE_PATH = (
+    _PROJECT_ROOT / ".raycon_dd_republish_state.json"
+)
 
 # Force-republish window: regenerate at least once per N hours for the
 # same ``(site_id, reason, fingerprint)`` triple if conditions still
@@ -133,28 +145,91 @@ class RepublishOutcome:
 # ---------------------------------------------------------------------------
 
 
-def load_state(path: Path = DD_REPUBLISH_STATE_PATH) -> dict[str, str]:
+def load_state(
+    path: Path = DD_REPUBLISH_STATE_PATH,
+    *,
+    legacy_path: Path = LEGACY_DD_REPUBLISH_STATE_PATH,
+) -> dict[str, str]:
     """Load the ``{state_key: last_republish_iso}`` dedup map.
 
     Returns ``{}`` on missing file or any read/parse error so a corrupt
     state file never blocks a republish.
+
+    Also runs the one-shot legacy migration: pre-Rec.3 the file lived
+    at ``.raycon_dd_republish_state.json`` and was keyed
+    ``site_id:run_id``. We rewrite each legacy entry into the new
+    ``site_id:raycon_scenario:run_id`` shape, but only when the new
+    state doesn't already have the key (new wins on conflict). Lives
+    here (in the shared loader) so both ``raycon_followup`` and
+    ``scan_inbox`` get the migration; otherwise scan_inbox would
+    silently drop the legacy state.
     """
+    state: dict[str, str] = {}
     try:
-        if not path.exists():
-            return {}
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return {k: str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                state = {k: str(v) for k, v in data.items()}
     except Exception as e:
         logger.warning("Failed to read DD republish state at %s: %s", path, e)
-        return {}
+        state = {}
+
+    # Legacy migration. Fail-closed: malformed legacy file → ignored,
+    # not crash. We never delete the legacy file; once the new file
+    # holds the migrated keys, this branch becomes a no-op overlay.
+    try:
+        if legacy_path.exists():
+            legacy = json.loads(legacy_path.read_text(encoding="utf-8"))
+            if isinstance(legacy, dict):
+                for old_key, ts in legacy.items():
+                    if not isinstance(old_key, str) or ":" not in old_key:
+                        continue
+                    site_id, run_id = old_key.split(":", 1)
+                    new_key = f"{site_id}:{REASON_RAYCON}:{run_id}"
+                    state.setdefault(new_key, str(ts))
+    except Exception as e:
+        logger.warning(
+            "Failed to migrate legacy DD republish state at %s: %s",
+            legacy_path,
+            e,
+        )
+    return state
 
 
 def save_state(state: dict[str, str], path: Path = DD_REPUBLISH_STATE_PATH) -> None:
-    """Persist the dedup map. Best-effort; logs but does not raise."""
+    """Persist the dedup map atomically.
+
+    Writes to a sibling tempfile in the same directory then ``os.replace``
+    onto the target path so concurrent readers never see a half-written
+    file. Tempfile lives in the same directory to keep ``os.replace``
+    atomic on a single filesystem. Best-effort; logs but does not raise.
+    """
     try:
-        path.write_text(
-            json.dumps(state, sort_keys=True, indent=2), encoding="utf-8"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(state, sort_keys=True, indent=2)
+        # delete=False so we control the rename; we explicitly clean up
+        # on failure. Using NamedTemporaryFile so the temp name is
+        # collision-safe across racing writers.
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(path.parent),
+            prefix=path.name + ".",
+            suffix=".tmp",
+            delete=False,
         )
+        try:
+            tmp.write(payload)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.replace(tmp.name, path)
+        except Exception:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+            raise
     except Exception as e:
         logger.warning("Failed to write DD republish state at %s: %s", path, e)
 

--- a/tests/test_dd_republish.py
+++ b/tests/test_dd_republish.py
@@ -22,13 +22,17 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
+import json
+
 from due_diligence_reporter.dd_republish import (
     DD_REPUBLISH_FORCE_AFTER,
     REASON_BUILDING_INSPECTION,
     REASON_RAYCON,
     REASON_VENDOR_SIR,
     RepublishOutcome,
+    load_state,
     maybe_republish_dd_report,
+    save_state,
 )
 
 
@@ -396,3 +400,288 @@ class TestEdgeCases:
         assert d["pipeline_status"] == "report_created"
         assert d["doc_url"] == "https://docs/abc"
         assert d["site_id"] == "site-123"
+
+
+# ---------------------------------------------------------------------------
+# Legacy state migration (PR #88 → follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRepublishStateMigration:
+    """One-shot migration from the pre-Rec.3 ``.raycon_dd_republish_state.json``
+    (keyed ``site_id:run_id``) into the shared ``.dd_republish_state.json``
+    (keyed ``site_id:reason:fingerprint``).
+
+    Lives in ``dd_republish.load_state`` so both raycon_followup and
+    scan_inbox pick it up — otherwise scan_inbox would silently skip
+    the migration and lose dedup on the cutover run.
+    """
+
+    def test_legacy_present_new_absent_keys_rewritten(self, tmp_path):
+        legacy = tmp_path / ".raycon_dd_republish_state.json"
+        new = tmp_path / ".dd_republish_state.json"
+        legacy.write_text(
+            json.dumps(
+                {
+                    "site-123:rc_run_abc": "2026-05-05T10:00:00+00:00",
+                    "site-456:rc_run_def": "2026-05-06T10:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = load_state(new, legacy_path=legacy)
+
+        assert state == {
+            "site-123:raycon_scenario:rc_run_abc": "2026-05-05T10:00:00+00:00",
+            "site-456:raycon_scenario:rc_run_def": "2026-05-06T10:00:00+00:00",
+        }
+
+    def test_both_present_new_wins_on_conflict(self, tmp_path):
+        """If the new file already has the migrated key, don't clobber it
+        with the legacy timestamp — the new file is post-migration truth.
+        """
+        legacy = tmp_path / ".raycon_dd_republish_state.json"
+        new = tmp_path / ".dd_republish_state.json"
+        legacy.write_text(
+            json.dumps({"site-123:rc_run_abc": "2026-01-01T00:00:00+00:00"}),
+            encoding="utf-8",
+        )
+        new.write_text(
+            json.dumps(
+                {
+                    "site-123:raycon_scenario:rc_run_abc": "2026-05-05T10:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = load_state(new, legacy_path=legacy)
+
+        assert (
+            state["site-123:raycon_scenario:rc_run_abc"]
+            == "2026-05-05T10:00:00+00:00"
+        )
+
+    def test_legacy_malformed_json_fails_closed(self, tmp_path):
+        """Malformed legacy file → treated as no prior state, no crash."""
+        legacy = tmp_path / ".raycon_dd_republish_state.json"
+        new = tmp_path / ".dd_republish_state.json"
+        legacy.write_text("{not valid json", encoding="utf-8")
+
+        state = load_state(new, legacy_path=legacy)
+
+        assert state == {}
+
+    def test_legacy_left_in_place_after_migration(self, tmp_path):
+        """Migration overlays the legacy file; we never delete it.
+
+        Subsequent runs no-op once the new file has been written with
+        the migrated keys (asserted by the new-wins test above). This
+        test pins the actual behavior so future refactors that add a
+        delete are caught here.
+        """
+        legacy = tmp_path / ".raycon_dd_republish_state.json"
+        new = tmp_path / ".dd_republish_state.json"
+        legacy.write_text(
+            json.dumps({"site-123:rc_run_abc": "2026-05-05T10:00:00+00:00"}),
+            encoding="utf-8",
+        )
+
+        load_state(new, legacy_path=legacy)
+
+        assert legacy.exists()
+        assert json.loads(legacy.read_text(encoding="utf-8")) == {
+            "site-123:rc_run_abc": "2026-05-05T10:00:00+00:00"
+        }
+
+    def test_legacy_absent_returns_new_state_only(self, tmp_path):
+        legacy = tmp_path / ".raycon_dd_republish_state.json"
+        new = tmp_path / ".dd_republish_state.json"
+        new.write_text(
+            json.dumps(
+                {"site-1:vendor_sir:f1:2026-05-05T10:00:00Z": "2026-05-05T11:00:00Z"}
+            ),
+            encoding="utf-8",
+        )
+
+        state = load_state(new, legacy_path=legacy)
+
+        assert state == {
+            "site-1:vendor_sir:f1:2026-05-05T10:00:00Z": "2026-05-05T11:00:00Z"
+        }
+
+    def test_legacy_skips_malformed_keys(self, tmp_path):
+        """Legacy entries without a ':' separator are skipped, not crashed."""
+        legacy = tmp_path / ".raycon_dd_republish_state.json"
+        new = tmp_path / ".dd_republish_state.json"
+        legacy.write_text(
+            json.dumps(
+                {
+                    "no_colon_key": "2026-05-05T10:00:00+00:00",
+                    "site-1:rc_ok": "2026-05-05T11:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = load_state(new, legacy_path=legacy)
+
+        assert "site-1:raycon_scenario:rc_ok" in state
+        assert all(":" in k for k in state)
+
+
+# ---------------------------------------------------------------------------
+# save_state — atomic write
+# ---------------------------------------------------------------------------
+
+
+class TestSaveStateAtomic:
+    def test_save_then_load_roundtrip(self, tmp_path):
+        path = tmp_path / ".dd_republish_state.json"
+        payload = {
+            "site-1:vendor_sir:f1:2026-05-05T10:00:00Z": "2026-05-05T11:00:00Z",
+            "site-2:raycon_scenario:rc_xyz": "2026-05-05T12:00:00Z",
+        }
+        save_state(payload, path)
+        # Read back via load_state with no legacy file present.
+        loaded = load_state(path, legacy_path=tmp_path / ".no_such_legacy.json")
+        assert loaded == payload
+
+    def test_save_does_not_leave_tmp_files(self, tmp_path):
+        path = tmp_path / ".dd_republish_state.json"
+        save_state({"k": "v"}, path)
+        # Atomic write → temp file should be renamed away. Only the
+        # final state file should remain in the directory.
+        leftovers = [
+            p.name for p in tmp_path.iterdir() if p.name != path.name
+        ]
+        assert leftovers == [], f"unexpected leftovers: {leftovers}"
+
+    def test_save_overwrites_existing(self, tmp_path):
+        path = tmp_path / ".dd_republish_state.json"
+        path.write_text(json.dumps({"old": "v"}), encoding="utf-8")
+        save_state({"new": "v2"}, path)
+        assert json.loads(path.read_text(encoding="utf-8")) == {"new": "v2"}
+
+    def test_save_to_nested_directory_creates_parents(self, tmp_path):
+        path = tmp_path / "nested" / "subdir" / ".dd_republish_state.json"
+        save_state({"k": "v"}, path)
+        assert path.exists()
+        assert json.loads(path.read_text(encoding="utf-8")) == {"k": "v"}
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 regression — RayCon fingerprint includes _drive_modified_time
+# ---------------------------------------------------------------------------
+
+
+class TestRayConCompositeFingerprint:
+    """When RayCon recomputes the same ``run_id`` but writes fresh content
+    (different ``_drive_modified_time``), the helper must republish — not
+    silently skip for up to 12h. The fingerprint plumbed by
+    ``_republish_dd_report_if_present`` is composite
+    (``run_id:drive_modified_time``) so a content change always changes
+    the dedup key.
+    """
+
+    def test_same_run_id_different_modified_time_republishes(self):
+        from scripts.raycon_followup import _republish_dd_report_if_present
+
+        runner = MagicMock()
+        runner.return_value = MagicMock(
+            status="report_created", doc_url="https://docs/x"
+        )
+
+        # Patch the pipeline + finder via the dd_republish helper so we
+        # don't touch real Drive.
+        from unittest.mock import patch
+
+        existing = {"id": "dd1", "name": "Alpha Keller DD Report"}
+        # Pre-seed state as if a prior run with the same run_id but an
+        # older modifiedTime fingerprint had completed 1 hour ago — well
+        # inside the 12h force-after window. Without the modifiedTime
+        # suffix this would be a "deduped" no-op.
+        recent = (
+            datetime.now(timezone.utc) - timedelta(hours=1)
+        ).isoformat()
+        state = {
+            "site-123:raycon_scenario:rc_run_abc:2026-05-05T10:00:00Z": recent,
+        }
+
+        with patch(
+            "scripts.raycon_followup._find_existing_dd_report",
+            return_value=existing,
+        ), patch(
+            "scripts.raycon_followup.process_site_pipeline", runner
+        ):
+            out = _republish_dd_report_if_present(
+                MagicMock(),
+                _site(),
+                "rc_run_abc",
+                settings=MagicMock(),
+                system_prompt="prompt",
+                shared_cache={},
+                republish_state=state,
+                dry_run=False,
+                drive_modified_time="2026-05-05T20:00:00Z",  # newer content
+            )
+
+        assert out["dd_report_republish"] == "republished", out
+        runner.assert_called_once()
+        # New composite key recorded; old one still present (not relevant).
+        assert (
+            "site-123:raycon_scenario:rc_run_abc:2026-05-05T20:00:00Z" in state
+        )
+
+    def test_unknown_run_id_fallback_includes_modified_time(self):
+        """The ``unknown@<date>`` fallback (when run_id is empty) must
+        also include the modifiedTime so we don't dedup all empty-run-id
+        events on a given day. Review finding #10.
+        """
+        from scripts.raycon_followup import _republish_dd_report_if_present
+        from unittest.mock import patch
+
+        runner = MagicMock(
+            return_value=MagicMock(
+                status="report_created", doc_url="https://docs/x"
+            )
+        )
+        existing = {"id": "dd1", "name": "Alpha Keller DD Report"}
+        state: dict = {}
+
+        with patch(
+            "scripts.raycon_followup._find_existing_dd_report",
+            return_value=existing,
+        ), patch(
+            "scripts.raycon_followup.process_site_pipeline", runner
+        ):
+            # First arrival — empty run_id, modifiedTime A.
+            _republish_dd_report_if_present(
+                MagicMock(),
+                _site(),
+                "",
+                settings=MagicMock(),
+                system_prompt="prompt",
+                shared_cache={},
+                republish_state=state,
+                dry_run=False,
+                drive_modified_time="2026-05-05T10:00:00Z",
+            )
+            # Second arrival — still empty run_id, but newer modifiedTime.
+            # Must republish (different fingerprint), not dedup.
+            _republish_dd_report_if_present(
+                MagicMock(),
+                _site(),
+                "",
+                settings=MagicMock(),
+                system_prompt="prompt",
+                shared_cache={},
+                republish_state=state,
+                dry_run=False,
+                drive_modified_time="2026-05-05T20:00:00Z",
+            )
+
+        assert runner.call_count == 2
+        # Two distinct keys recorded — one per arrival.
+        assert len(state) == 2


### PR DESCRIPTION
## Summary

Follow-up to #88 addressing review findings #1, #2, #3, and #8. Single PR, no drive-by refactors. Manual MCP \`create_dd_report\` path is untouched.

### Fix 1 (#1, BLOCKING) — RayCon fingerprint includes \`_drive_modified_time\`

`scripts/raycon_followup.py` previously fingerprinted RayCon dedup on \`raycon_run_id\` only (with \`unknown@<date>\` fallback). If RayCon recomputed the same \`run_id\` and wrote a fresh \`raycon_scenario.json\` (different \`_drive_modified_time\`), the helper saw a recent timestamp inside \`DD_REPUBLISH_FORCE_AFTER\` and silently returned \`skip_no_diff\` for up to 12h.

Now \`_process_site\` plumbs \`scenario["_drive_modified_time"]\` through the callback into \`_republish_dd_report_if_present\`, which builds a composite fingerprint \`f"{run_id}:{drive_modified_time}"\` (mirroring the SIR/BI shape). The \`unknown@<date>\` fallback gets the same suffix so distinct empty-run-id events on the same day no longer collide.

The legacy \`raycon_run_id\` row field stays the bare run id (no suffix) so on-call runbooks/dashboards keep working.

### Fix 2 (#2) — Persistent state across cron runs

Both \`inbox-scan.yml\` and \`raycon-followup.yml\` now restore + save \`.dd_republish_state.json\` via \`actions/cache/restore\` + \`actions/cache/save\`. Save key is run-id-scoped so each run writes a fresh entry; restore-keys falls back to the most recent prefix match.

| Workflow | Cache path | Save key | Restore-keys |
|---|---|---|---|
| \`raycon-followup\` | \`.dd_republish_state.json\` | \`dd-republish-state-${{ github.workflow }}-${{ github.run_id }}\` | \`dd-republish-state-${{ github.workflow }}-\` then \`dd-republish-state-\` |
| \`inbox-scan\` | \`.dd_republish_state.json\` | \`dd-republish-state-${{ github.workflow }}-${{ github.run_id }}\` | \`dd-republish-state-${{ github.workflow }}-\` then \`dd-republish-state-\` |

Workflow-scoped key so the two workflows don't trample each other's caches; \`restore-keys\` ladder still allows cross-workflow seeding on cold start.

### Fix 3 (#3) — Atomic state-file writes

\`dd_republish.save_state\` now writes to a sibling \`NamedTemporaryFile\` in the same directory, \`flush\` + \`fsync\`, then \`os.replace\` onto the target. Tempfile lives in the same directory so \`os.replace\` is atomic on a single filesystem. Cleans up the tempfile on failure.

\`inbox-scan.yml\` already had a \`concurrency:\` group at HEAD (matches \`raycon-followup.yml\` pattern) so no change there.

### Fix 4 (#8) — Legacy state migration: tests + consolidation

The migration helper in \`raycon_followup._load_republish_state\` only fired when \`raycon_followup\` was the loader. \`scan_inbox\` called \`dd_republish.load_state\` directly and silently skipped migration. Migration is now owned by \`dd_republish.load_state\` so both callers pick it up; the \`raycon_followup\` wrapper is a thin shim that forwards to it.

New \`TestLoadRepublishStateMigration\` covers:
- legacy present, new absent → keys correctly rewritten;
- both present → new file wins on conflict;
- malformed legacy JSON → fail closed (no crash, returns \`{}\`);
- migration overlays the legacy file (does NOT delete it — pinned via test);
- malformed legacy keys (no \`:\`) skipped, not crashed.

Plus \`TestSaveStateAtomic\` (roundtrip, no temp leftovers, overwrite, parent dir creation) and \`TestRayConCompositeFingerprint\` (Fix 1 regression).

## Out of scope

Per spec: NOT addressing review findings #6, #7, #9, #10 (other than the #10 root cause fixed by Fix 1's fallback handling).

## Test plan
- [x] \`uv run pytest\` — full suite passes (1112 passed)
- [ ] Confirm in CI that \`actions/cache/restore\` + \`actions/cache/save\` round-trips state across two consecutive cron runs (visible in workflow logs as \`Cache restored from key: ...\` then \`Cache saved with key: ...\`)
- [ ] Spot-check a real RayCon recompute event in logs to confirm the composite fingerprint produces a distinct dedup key