### PR TITLE
feat(mcp): diagnose_site_readiness tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ changes do not get an entry.
 
 ## [Unreleased]
 
+### Added
+
+- **`diagnose_site_readiness` MCP tool** (Recommendation 4B). Read-only "should
+  I run now or wait?" diagnostic that surfaces, for one site: per-doc
+  blocking status (`vendor_sir` / `building_inspection` / `raycon_scenario`)
+  using the cron-path readiness view; for pending RayCon entries the
+  `block_plan_present`, `last_dispatch`, and `minutes_since` derived from
+  `.raycon_dispatch_state.json` (with the Block Plan `modifiedTime` as a
+  documented fallback when the dispatch state file has no entry); the
+  projected `would_be_filled_now` / `would_be_pending` token paths;
+  `partial_report_possible`; and `vendor_gate_enabled` so the caller knows
+  which view they're seeing. Never triggers generation, republish, or any
+  other side effect. `check_site_readiness` is unchanged and remains the
+  pre-generation projection used internally by `create_dd_report`.
+
 ### Changed
 
 - **Vendor gate flipped on for cron paths (daily sweep, inbox scanner, raycon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,19 @@ changes do not get an entry.
   `.raycon_dispatch_state.json` (with the Block Plan `modifiedTime` as a
   documented fallback when the dispatch state file has no entry); the
   projected `would_be_filled_now` / `would_be_pending` token paths;
-  `partial_report_possible`; and `vendor_gate_enabled` so the caller knows
-  which view they're seeing. Never triggers generation, republish, or any
-  other side effect. `check_site_readiness` is unchanged and remains the
-  pre-generation projection used internally by `create_dd_report`.
+  `partial_report_possible`; `vendor_gate_enabled` so the caller knows
+  which view they're seeing; and `m1_folder_missing` (with
+  `drive_folder_url=null`) when the per-site M1 folder hasn't been
+  created yet. Strictly read-only: passes `read_only=True` /
+  `create_if_missing=False` through `check_site_readiness_direct` so
+  neither the M1 folder nor the provenance cache is ever written, and
+  `ready_for_full_report` mirrors `_missing_required_docs` exactly so
+  RayCon scenario absence does not block readiness when
+  `VENDOR_GATE_ENABLED=0` (the diagnostic `blocking[]` view still
+  reports its actual status). Never triggers generation, republish, or
+  any other side effect. `check_site_readiness` is unchanged and
+  remains the pre-generation projection used internally by
+  `create_dd_report`.
 
 ### Changed
 

--- a/src/due_diligence_reporter/m1_lookup.py
+++ b/src/due_diligence_reporter/m1_lookup.py
@@ -19,7 +19,6 @@ from .classifier import classify_document
 from .google_client import GoogleClient
 from .utils import extract_folder_id_from_url
 
-
 # Doc types the scanner now persists into per-site M1 folders, plus the
 # downstream reports the Block Plan pipeline derives. ``_list_m1_documents_by_type``
 # returns any of these keyed by doc_type so dedup, readiness backfill, and
@@ -37,9 +36,17 @@ M1_RECOGNIZED_DOC_TYPES = {
 
 
 def _resolve_m1_folder(
-    gc: GoogleClient, drive_folder_url: str
+    gc: GoogleClient,
+    drive_folder_url: str,
+    *,
+    create_if_missing: bool = True,
 ) -> tuple[str | None, str | None]:
-    """Return the site's M1 folder ID, creating a plain ``M1`` folder when absent."""
+    """Return the site's M1 folder ID, creating a plain ``M1`` folder when absent.
+
+    Pass ``create_if_missing=False`` from read-only callers (e.g. the
+    diagnose tool) to skip the ``gc.create_folder`` side effect; this
+    returns ``(None, None)`` instead when M1 doesn't yet exist.
+    """
     folder_id = extract_folder_id_from_url(drive_folder_url)
     if not folder_id:
         return None, None
@@ -47,6 +54,8 @@ def _resolve_m1_folder(
     for subfolder in subfolders:
         if subfolder.get("name", "").lower().startswith("m1"):
             return subfolder.get("id"), subfolder.get("webViewLink")
+    if not create_if_missing:
+        return None, None
     created = gc.create_folder(folder_id, "M1")
     return created.get("id"), created.get("webViewLink")
 

--- a/src/due_diligence_reporter/provenance.py
+++ b/src/due_diligence_reporter/provenance.py
@@ -238,6 +238,7 @@ def classify_provenance(
     *,
     m1_folder_id: str | None = None,
     doc_type: str | None = None,
+    read_only: bool = False,
 ) -> ProvenanceVerdict:
     """Classify a Drive file as vendor- or AI-sourced.
 
@@ -251,6 +252,10 @@ def classify_provenance(
         doc_type: optional pre-computed classifier result. When passed and
             the doc_type is exclusively AI-produced (e.g. ``dd_report``),
             short-circuit before any I/O.
+        read_only: when True, never write the provenance cache back to
+            Drive even on a Tier 2 miss. Used by read-only callers (e.g.
+            the diagnose tool). The cache is still *read* — only the
+            ``_save_cache`` side effect is suppressed.
 
     Returns a ``ProvenanceVerdict``. On any internal exception, returns a
     verdict with ``provenance_classification_failed=True`` and
@@ -259,7 +264,11 @@ def classify_provenance(
     """
     try:
         return _classify_provenance_inner(
-            file_info, gc, m1_folder_id=m1_folder_id, doc_type=doc_type
+            file_info,
+            gc,
+            m1_folder_id=m1_folder_id,
+            doc_type=doc_type,
+            read_only=read_only,
         )
     except Exception as e:
         name = ""
@@ -289,6 +298,7 @@ def _classify_provenance_inner(
     *,
     m1_folder_id: str | None = None,
     doc_type: str | None = None,
+    read_only: bool = False,
 ) -> ProvenanceVerdict:
     """Real classify_provenance body. Wrapped by ``classify_provenance``."""
     if not isinstance(file_info, dict):
@@ -350,8 +360,8 @@ def _classify_provenance_inner(
     if verdict.label == _UNKNOWN:
         verdict = ProvenanceVerdict(_VENDOR, 0.5, verdict.tier, "default-to-vendor")
 
-    # Persist.
-    if gc and m1_folder_id and file_id:
+    # Persist. Skipped for read-only callers (e.g. the diagnose tool).
+    if gc and m1_folder_id and file_id and not read_only:
         cache[file_id] = {
             "modifiedTime": modified,
             "label": verdict.label,

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -343,8 +343,16 @@ def check_site_readiness_direct(
     *,
     site_title: str | None = None,
     site_address: str | None = None,
+    read_only: bool = False,
 ) -> dict[str, Any]:
-    """Check site document readiness directly without going through MCP."""
+    """Check site document readiness directly without going through MCP.
+
+    Pass ``read_only=True`` from read-only callers (e.g. the diagnose
+    tool) to suppress two write side effects: creating the per-site M1
+    folder when it's missing and writing the provenance cache to Drive
+    on a Tier 2 miss. Defaults to ``False`` to preserve existing
+    cron-path behavior for ``check_site_readiness`` / ``create_dd_report``.
+    """
     folder_id = extract_folder_id_from_url(drive_folder_url)
     if not folder_id:
         return {
@@ -406,7 +414,9 @@ def check_site_readiness_direct(
     # CDS overlays into the M1 folder. Run a per-file provenance check (cheap
     # filename heuristic + cached LLM content fallback) so the readiness gate
     # only opens on *vendor-sourced* SIR + BI.
-    m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+    m1_folder_id, _ = _resolve_m1_folder(
+        gc, drive_folder_url, create_if_missing=not read_only
+    )
 
     def _vendor_check(doc_type: str) -> bool:
         f = files_by_type.get(doc_type)
@@ -414,7 +424,11 @@ def check_site_readiness_direct(
             return False
         try:
             verdict = classify_provenance(
-                f, gc, m1_folder_id=m1_folder_id, doc_type=doc_type
+                f,
+                gc,
+                m1_folder_id=m1_folder_id,
+                doc_type=doc_type,
+                read_only=read_only,
             )
         except Exception as e:  # pragma: no cover
             logger.warning(

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 import zipfile
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
@@ -28,8 +28,10 @@ from .classifier import (
     classify_document_type as _classify_document_type,
 )
 from .completeness import (
+    REASON_DISPLAY_LABELS,
     compute_completeness_block,
     project_completeness_from_readiness,
+    raycon_token_paths,
 )
 from .config import get_settings
 from .dashboard_publish import publish_site_record
@@ -3077,6 +3079,369 @@ async def check_site_readiness(site_name_or_id: str) -> dict[str, Any]:
                 "status": "error",
                 "error": "check_site_readiness failed",
                 "message": str(e),
+            }
+
+    return await asyncio.to_thread(_work)
+
+
+# ---------------------------------------------------------------------------
+# diagnose_site_readiness — richer "should I run now or wait?" diagnostic.
+# Read-only; never triggers generation, republish, or any side effect.
+# ---------------------------------------------------------------------------
+
+# Path to the dispatch dedup map written by ``scripts/raycon_followup.py``.
+# Keyed by ``block_plan_file_id`` with values
+# ``{"last_dispatch": ISO, "count": int, "site": str, "raycon_run_id": str|None}``.
+# We read it best-effort so the diagnose tool never raises if the cron has
+# never run yet on this checkout.
+_RAYCON_DISPATCH_STATE_PATH = (
+    Path(__file__).resolve().parent.parent.parent / ".raycon_dispatch_state.json"
+)
+
+
+def _load_raycon_dispatch_state(
+    path: Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Best-effort read of the RayCon dispatch dedup map.
+
+    Returns ``{}`` on missing file, parse error, or unexpected shape so a
+    corrupt state file never breaks the diagnose tool. The default path
+    is resolved at call time (not at function-definition time) so tests
+    can monkeypatch ``_RAYCON_DISPATCH_STATE_PATH``.
+    """
+    if path is None:
+        path = _RAYCON_DISPATCH_STATE_PATH
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return {}
+        return {k: v for k, v in data.items() if isinstance(v, dict)}
+    except Exception as e:
+        logger.warning("diagnose_site_readiness: dispatch state read failed (%s): %s", path, e)
+        return {}
+
+
+def _latest_dispatch_for_site(
+    state: dict[str, dict[str, Any]],
+    site_title: str,
+    *,
+    block_plan_file_id: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Return ``(last_dispatch_iso, block_plan_file_id)`` for *site_title*.
+
+    Prefers the entry whose key matches the *block_plan_file_id* we
+    actually see in M1 today. Falls back to the most recent entry whose
+    ``site`` field matches *site_title* so we still surface a dispatch
+    even when the Block Plan was rotated and the prior file ID is now
+    stale.
+    """
+    if block_plan_file_id and block_plan_file_id in state:
+        entry = state[block_plan_file_id]
+        last = entry.get("last_dispatch")
+        if isinstance(last, str) and last:
+            return last, block_plan_file_id
+
+    best_iso: str | None = None
+    best_file_id: str | None = None
+    needle = site_title.strip().lower()
+    for file_id, entry in state.items():
+        site_val = str(entry.get("site", "")).strip().lower()
+        if site_val != needle:
+            continue
+        last = entry.get("last_dispatch")
+        if not isinstance(last, str) or not last:
+            continue
+        if best_iso is None or last > best_iso:
+            best_iso = last
+            best_file_id = file_id
+    return best_iso, best_file_id
+
+
+def _minutes_since_iso(iso: str | None, *, now: datetime | None = None) -> int | None:
+    """Integer minutes between *iso* and *now* (UTC). ``None`` if unparseable."""
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    current = now or datetime.now(tz=UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    delta = current - dt
+    return int(delta.total_seconds() // 60)
+
+
+def _build_blocking_entries(
+    *,
+    readiness: dict[str, Any],
+    vendor_gate_enabled: bool,
+    block_plan_present: bool,
+    raycon_last_dispatch: str | None,
+    raycon_minutes_since: int | None,
+) -> list[dict[str, Any]]:
+    """Build the ``blocking`` list in the response.
+
+    Mirrors ``_missing_required_docs`` semantics so the diagnose tool
+    reports the same view the cron path uses. The vendor gate state is
+    surfaced explicitly so the caller can see what view they're getting.
+    """
+    if vendor_gate_enabled:
+        sir_present = bool(readiness.get("sir_vendor"))
+        bi_present = bool(readiness.get("inspection_vendor"))
+    else:
+        sir_present = bool(readiness.get("sir_found"))
+        bi_present = bool(readiness.get("inspection_found"))
+
+    raycon_present = bool(readiness.get("raycon_scenario_found"))
+
+    raycon_entry: dict[str, Any] = {
+        "doc": "raycon_scenario",
+        "status": "present" if raycon_present else "pending",
+    }
+    if not raycon_present:
+        raycon_entry["block_plan_present"] = block_plan_present
+        raycon_entry["last_dispatch"] = raycon_last_dispatch
+        raycon_entry["minutes_since"] = raycon_minutes_since
+
+    return [
+        {
+            "doc": "vendor_sir",
+            "status": "present" if sir_present else "missing",
+        },
+        {
+            "doc": "building_inspection",
+            "status": "present" if bi_present else "missing",
+        },
+        raycon_entry,
+    ]
+
+
+@mcp.tool()
+async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
+    """Read-only "should I run now or wait?" diagnostic for a site.
+
+    Surfaces the cron-path readiness view for a site:
+
+    * ``blocking`` — per-doc status (``vendor_sir`` / ``building_inspection``
+      / ``raycon_scenario``). For the RayCon entry, when the scenario JSON
+      hasn't landed yet, also reports ``block_plan_present``,
+      ``last_dispatch`` (most recent ``/v1/jobs`` POST timestamp from the
+      dispatch state file written by ``scripts/raycon_followup.py``), and
+      ``minutes_since`` (integer minutes since that dispatch).
+    * ``ready_for_full_report`` — true iff every entry in ``blocking`` is
+      ``present``.
+    * ``partial_report_possible`` — true iff the floor for "we have
+      something to write about" is met (vendor SIR present, or — with the
+      legacy gate — bare SIR presence). A partial report is possible even
+      if BI is missing or RayCon is pending.
+    * ``would_be_filled_now`` / ``would_be_pending`` — token paths the
+      report would fill or leave pending if it ran right now.
+    * ``vendor_gate_enabled`` — which view (vendor-strict vs. legacy) is
+      being reported.
+
+    Use this BEFORE ``create_dd_report`` to decide whether to run now
+    (accept partial) or wait.
+
+    Differs from ``check_site_readiness``: that tool is the
+    pre-generation projection used internally by ``create_dd_report``;
+    ``diagnose_site_readiness`` is the user/agent-facing diagnostic that
+    composes the cron-path readiness view, RayCon dispatch state, and
+    full token projection into one structured payload. Reports the
+    cron-path view (vendor gate enforced) by default; never bypass.
+
+    This tool is strictly read-only — it must never trigger generation,
+    republish, or any other side effect.
+    """
+    logger.info("Tool called: diagnose_site_readiness - %s", site_name)
+
+    if not site_name or not site_name.strip():
+        return {
+            "status": "error",
+            "error": "Missing parameter",
+            "message": "site_name must be a non-empty string",
+        }
+
+    def _work() -> dict[str, Any]:
+        # Local imports to avoid pulling anthropic et al. into the
+        # top-level server import path.
+        from .report_pipeline import (
+            _vendor_gate_enabled,
+            check_site_readiness_direct,
+            list_shared_folders_once,
+        )
+
+        try:
+            record = find_site_record(site_name_or_id=site_name)
+            if not record:
+                return {
+                    "status": "error",
+                    "error": "Site record not found",
+                    "message": (
+                        f"Could not find a Wrike Site Record matching '{site_name}'."
+                    ),
+                    "site": site_name,
+                }
+
+            summary = build_site_summary(record)
+            site_title = summary.get("title", site_name)
+            address = summary.get("address")
+            drive_folder_url = summary.get("drive_folder_url")
+            if not drive_folder_url:
+                return {
+                    "status": "error",
+                    "error": "No Drive folder",
+                    "message": (
+                        f"Site record '{site_title}' has no Google Drive folder URL in Wrike."
+                    ),
+                    "site": site_title,
+                }
+
+            gc = _make_google_client()
+            match_terms = _build_site_match_terms(site_title, address)
+            shared_cache = list_shared_folders_once(gc)
+
+            readiness = check_site_readiness_direct(
+                gc,
+                drive_folder_url,
+                match_terms,
+                shared_cache,
+                site_title=site_title,
+                site_address=address,
+            )
+
+            # Resolve M1 to find the Block Plan file ID and its
+            # modifiedTime. The Block Plan ID is the lookup key into the
+            # dispatch state map; its modifiedTime is the proxy for
+            # ``last_dispatch`` if the dispatch state file is missing
+            # (e.g. the cron has never run on this checkout).
+            block_plan_file_id: str | None = None
+            block_plan_modified: str | None = None
+            try:
+                m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+            except Exception as e:
+                logger.warning(
+                    "diagnose_site_readiness: M1 resolve failed for '%s': %s",
+                    site_title,
+                    e,
+                )
+                m1_folder_id = None
+            if m1_folder_id:
+                try:
+                    m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
+                    bp = m1_docs.get("block_plan")
+                    if bp:
+                        block_plan_file_id = str(bp.get("id") or "") or None
+                        mt = bp.get("modifiedTime")
+                        if isinstance(mt, str):
+                            block_plan_modified = mt
+                except Exception as e:
+                    logger.warning(
+                        "diagnose_site_readiness: M1 list failed for '%s': %s",
+                        site_title,
+                        e,
+                    )
+
+            block_plan_present = block_plan_file_id is not None
+            raycon_present = bool(readiness.get("raycon_scenario_found"))
+
+            # Resolve last_dispatch:
+            #   1. If RayCon scenario is present, the dispatch already
+            #      succeeded — surface its modifiedTime as the run
+            #      timestamp.
+            #   2. Otherwise, look up the dispatch state map for this
+            #      site / block_plan_file_id.
+            #   3. If neither is available but a Block Plan exists, fall
+            #      back to its modifiedTime as a documented proxy.
+            last_dispatch: str | None = None
+            if raycon_present and m1_folder_id:
+                # Re-resolve to pick up modifiedTime on the scenario.
+                try:
+                    m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
+                    rs = m1_docs.get("raycon_scenario_json")
+                    if rs and isinstance(rs.get("modifiedTime"), str):
+                        last_dispatch = rs["modifiedTime"]
+                except Exception:
+                    pass
+            if last_dispatch is None:
+                state = _load_raycon_dispatch_state()
+                last_dispatch, _ = _latest_dispatch_for_site(
+                    state,
+                    site_title,
+                    block_plan_file_id=block_plan_file_id,
+                )
+            if last_dispatch is None and block_plan_modified:
+                # Documented fallback: when the dispatch state file has
+                # no entry (e.g. this checkout's cron has never run for
+                # this site), use the Block Plan's Drive ``modifiedTime``
+                # as a proxy for "RayCon has been notified".
+                last_dispatch = block_plan_modified
+
+            minutes_since = _minutes_since_iso(last_dispatch)
+
+            vendor_gate_enabled = _vendor_gate_enabled()
+            blocking = _build_blocking_entries(
+                readiness=readiness,
+                vendor_gate_enabled=vendor_gate_enabled,
+                block_plan_present=block_plan_present,
+                raycon_last_dispatch=last_dispatch,
+                raycon_minutes_since=minutes_since,
+            )
+
+            ready_for_full_report = all(
+                entry["status"] == "present" for entry in blocking
+            )
+
+            # ``partial_report_possible`` floor: vendor SIR present (with
+            # the gate on) or any SIR present (legacy). Mirrors what
+            # ``_missing_required_docs`` would treat as the SIR slot.
+            if vendor_gate_enabled:
+                partial_report_possible = bool(readiness.get("sir_vendor"))
+            else:
+                partial_report_possible = bool(readiness.get("sir_found"))
+
+            projection = project_completeness_from_readiness(
+                raycon_scenario_found=raycon_present,
+            )
+            pending_paths: list[str] = []
+            for paths in projection.get("pending_reasons", {}).values():
+                pending_paths.extend(paths)
+            pending_set = set(pending_paths)
+            # ``would_be_filled_now`` is the complement of pending paths
+            # within the modeled token space (today: RayCon paths). When
+            # more pending axes are added, extend the modeled space here.
+            modeled_paths = set(raycon_token_paths())
+            would_be_filled_now = sorted(modeled_paths - pending_set)
+            would_be_pending = sorted(pending_set)
+
+            return {
+                "status": "success",
+                "site": site_title,
+                "ready_for_full_report": ready_for_full_report,
+                "partial_report_possible": partial_report_possible,
+                "vendor_gate_enabled": vendor_gate_enabled,
+                "blocking": blocking,
+                "would_be_filled_now": would_be_filled_now,
+                "would_be_pending": would_be_pending,
+                "projected_completeness": projection,
+                "pending_reason_labels": {
+                    reason: REASON_DISPLAY_LABELS.get(reason, reason)
+                    for reason in projection.get("pending_reasons", {})
+                },
+                "drive_folder_url": drive_folder_url,
+            }
+        except Exception as e:
+            logger.error("diagnose_site_readiness failed: %s", e)
+            return {
+                "status": "error",
+                "error": "diagnose_site_readiness failed",
+                "message": str(e),
+                "site": site_name,
             }
 
     return await asyncio.to_thread(_work)

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -3234,8 +3234,12 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
       ``last_dispatch`` (most recent ``/v1/jobs`` POST timestamp from the
       dispatch state file written by ``scripts/raycon_followup.py``), and
       ``minutes_since`` (integer minutes since that dispatch).
-    * ``ready_for_full_report`` — true iff every entry in ``blocking`` is
-      ``present``.
+    * ``ready_for_full_report`` — mirrors ``_missing_required_docs``
+      exactly. Under ``VENDOR_GATE_ENABLED=1`` this requires vendor SIR,
+      vendor BI, and RayCon scenario to all be present; under
+      ``VENDOR_GATE_ENABLED=0`` only SIR + BI presence is required and
+      RayCon absence does NOT block readiness (``blocking[]`` still
+      reports its actual status, but it's diagnostic-only).
     * ``partial_report_possible`` — true iff the floor for "we have
       something to write about" is met (vendor SIR present, or — with the
       legacy gate — bare SIR presence). A partial report is possible even
@@ -3244,6 +3248,11 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
       report would fill or leave pending if it ran right now.
     * ``vendor_gate_enabled`` — which view (vendor-strict vs. legacy) is
       being reported.
+    * ``m1_folder_missing`` — true when the per-site ``M1`` Drive
+      subfolder hasn't been created yet (the inbox scanner creates it
+      on first upload). When true, ``drive_folder_url`` is ``null`` and
+      the vendor / RayCon slots will all surface as missing/pending —
+      no folder is created, since this tool is strictly read-only.
 
     Use this BEFORE ``create_dd_report`` to decide whether to run now
     (accept partial) or wait.
@@ -3271,6 +3280,7 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
         # Local imports to avoid pulling anthropic et al. into the
         # top-level server import path.
         from .report_pipeline import (
+            _missing_required_docs,
             _vendor_gate_enabled,
             check_site_readiness_direct,
             list_shared_folders_once,
@@ -3306,6 +3316,11 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
             match_terms = _build_site_match_terms(site_title, address)
             shared_cache = list_shared_folders_once(gc)
 
+            # ``read_only=True`` propagates two suppressions through the
+            # readiness check: it skips the ``M1`` folder creation in
+            # ``_resolve_m1_folder`` and skips the provenance cache write
+            # in ``classify_provenance``. Both side effects would otherwise
+            # break the "strictly read-only" contract.
             readiness = check_site_readiness_direct(
                 gc,
                 drive_folder_url,
@@ -3313,17 +3328,21 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
                 shared_cache,
                 site_title=site_title,
                 site_address=address,
+                read_only=True,
             )
 
-            # Resolve M1 to find the Block Plan file ID and its
-            # modifiedTime. The Block Plan ID is the lookup key into the
-            # dispatch state map; its modifiedTime is the proxy for
-            # ``last_dispatch`` if the dispatch state file is missing
-            # (e.g. the cron has never run on this checkout).
+            # Resolve M1 (read-only — never create) to find the Block
+            # Plan file ID and its modifiedTime. The Block Plan ID is
+            # the lookup key into the dispatch state map; its
+            # modifiedTime is the proxy for ``last_dispatch`` if the
+            # dispatch state file is missing (e.g. the cron has never
+            # run on this checkout).
             block_plan_file_id: str | None = None
             block_plan_modified: str | None = None
             try:
-                m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+                m1_folder_id, _ = _resolve_m1_folder(
+                    gc, drive_folder_url, create_if_missing=False
+                )
             except Exception as e:
                 logger.warning(
                     "diagnose_site_readiness: M1 resolve failed for '%s': %s",
@@ -3331,6 +3350,9 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
                     e,
                 )
                 m1_folder_id = None
+
+            m1_folder_missing = m1_folder_id is None
+
             if m1_folder_id:
                 try:
                     m1_docs = _list_m1_documents_by_type(gc, m1_folder_id)
@@ -3393,9 +3415,13 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
                 raycon_minutes_since=minutes_since,
             )
 
-            ready_for_full_report = all(
-                entry["status"] == "present" for entry in blocking
-            )
+            # ``ready_for_full_report`` mirrors ``_missing_required_docs``
+            # exactly. Under the legacy gate (VENDOR_GATE_ENABLED=0) this
+            # means RayCon and vendor provenance do NOT block readiness —
+            # ``blocking[]`` still reports their actual status so the
+            # caller sees the full diagnostic view, but they don't pull
+            # ``ready_for_full_report`` to False.
+            ready_for_full_report = not _missing_required_docs(readiness)
 
             # ``partial_report_possible`` floor: vendor SIR present (with
             # the gate on) or any SIR present (legacy). Mirrors what
@@ -3425,6 +3451,7 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
                 "ready_for_full_report": ready_for_full_report,
                 "partial_report_possible": partial_report_possible,
                 "vendor_gate_enabled": vendor_gate_enabled,
+                "m1_folder_missing": m1_folder_missing,
                 "blocking": blocking,
                 "would_be_filled_now": would_be_filled_now,
                 "would_be_pending": would_be_pending,
@@ -3433,7 +3460,7 @@ async def diagnose_site_readiness(site_name: str) -> dict[str, Any]:
                     reason: REASON_DISPLAY_LABELS.get(reason, reason)
                     for reason in projection.get("pending_reasons", {})
                 },
-                "drive_folder_url": drive_folder_url,
+                "drive_folder_url": None if m1_folder_missing else drive_folder_url,
             }
         except Exception as e:
             logger.error("diagnose_site_readiness failed: %s", e)

--- a/tests/test_diagnose_site_readiness.py
+++ b/tests/test_diagnose_site_readiness.py
@@ -1,0 +1,443 @@
+"""Tests for the ``diagnose_site_readiness`` MCP tool.
+
+Recommendation 4B from ``docs/event-driven-ddr-recommendations.md``: a
+read-only "should I run now or wait?" diagnostic that surfaces the
+cron-path readiness view, RayCon dispatch state, and full token
+projection in one structured payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from due_diligence_reporter import server
+
+SITE_TITLE = "Alpha Keller"
+SITE_ADDRESS = "123 Main St"
+DRIVE_URL = "https://drive.google.com/drive/folders/abc123"
+
+
+def _record() -> dict:
+    return {"id": "wrike-1", "title": SITE_TITLE}
+
+
+def _summary() -> dict:
+    return {
+        "title": SITE_TITLE,
+        "address": SITE_ADDRESS,
+        "drive_folder_url": DRIVE_URL,
+    }
+
+
+def _readiness(
+    *,
+    sir_found: bool = True,
+    sir_vendor: bool = True,
+    inspection_found: bool = True,
+    inspection_vendor: bool = True,
+    raycon_scenario_found: bool = True,
+    report_exists: bool = False,
+) -> dict:
+    return {
+        "sir_found": sir_found,
+        "sir_vendor": sir_vendor,
+        "inspection_found": inspection_found,
+        "inspection_vendor": inspection_vendor,
+        "isp_found": False,
+        "raycon_scenario_found": raycon_scenario_found,
+        "report_exists": report_exists,
+        "e_occupancy_report_found": False,
+        "school_approval_report_found": False,
+        "all_files": [],
+    }
+
+
+def _run(site: str = SITE_TITLE) -> dict:
+    return asyncio.run(server.diagnose_site_readiness(site))
+
+
+def _vendor_gate_on(monkeypatch):
+    monkeypatch.setenv("VENDOR_GATE_ENABLED", "1")
+
+
+def _vendor_gate_off(monkeypatch):
+    monkeypatch.setenv("VENDOR_GATE_ENABLED", "0")
+
+
+def _no_dispatch_state(tmp_path: Path, monkeypatch):
+    """Point the dispatch state path at an empty location."""
+    monkeypatch.setattr(
+        server, "_RAYCON_DISPATCH_STATE_PATH", tmp_path / ".raycon_dispatch_state.json"
+    )
+
+
+def _patch_common(
+    *,
+    readiness: dict,
+    m1_docs: dict | None = None,
+):
+    """Bundle the patches every test in this file needs."""
+    if m1_docs is None:
+        m1_docs = {}
+    return [
+        patch("due_diligence_reporter.server.find_site_record", return_value=_record()),
+        patch("due_diligence_reporter.server.build_site_summary", return_value=_summary()),
+        patch(
+            "due_diligence_reporter.server._make_google_client",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "due_diligence_reporter.server._build_site_match_terms",
+            return_value=[SITE_TITLE],
+        ),
+        patch(
+            "due_diligence_reporter.server._resolve_m1_folder",
+            return_value=("m1-folder-id", "https://drive.google.com/drive/folders/m1"),
+        ),
+        patch(
+            "due_diligence_reporter.server._list_m1_documents_by_type",
+            return_value=m1_docs,
+        ),
+        patch(
+            "due_diligence_reporter.report_pipeline.list_shared_folders_once",
+            return_value={},
+        ),
+        patch(
+            "due_diligence_reporter.report_pipeline.check_site_readiness_direct",
+            return_value=readiness,
+        ),
+    ]
+
+
+def _enter_all(patchers):
+    started = [p.start() for p in patchers]
+    return started
+
+
+def _stop_all(patchers):
+    for p in patchers:
+        p.stop()
+
+
+# ---------------------------------------------------------------------------
+# 1. All docs present → ready_for_full_report=True, no pending tokens.
+# ---------------------------------------------------------------------------
+
+
+def test_all_docs_present_ready_for_full_report(tmp_path, monkeypatch):
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    patchers = _patch_common(
+        readiness=_readiness(),
+        m1_docs={
+            "block_plan": {"id": "bp-1", "modifiedTime": "2026-05-07T13:00:00Z"},
+            "raycon_scenario_json": {
+                "id": "rs-1",
+                "modifiedTime": "2026-05-07T13:30:00Z",
+            },
+        },
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    assert result["status"] == "success"
+    assert result["site"] == SITE_TITLE
+    assert result["ready_for_full_report"] is True
+    assert result["partial_report_possible"] is True
+    assert result["vendor_gate_enabled"] is True
+
+    statuses = {b["doc"]: b["status"] for b in result["blocking"]}
+    assert statuses == {
+        "vendor_sir": "present",
+        "building_inspection": "present",
+        "raycon_scenario": "present",
+    }
+    # When RayCon scenario is present, no block-plan / dispatch metadata
+    # should leak into the entry.
+    raycon_entry = next(b for b in result["blocking"] if b["doc"] == "raycon_scenario")
+    assert "block_plan_present" not in raycon_entry
+    assert "last_dispatch" not in raycon_entry
+    assert "minutes_since" not in raycon_entry
+
+    assert result["would_be_pending"] == []
+    assert len(result["would_be_filled_now"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Vendor SIR missing → not ready, partial NOT possible.
+# ---------------------------------------------------------------------------
+
+
+def test_vendor_sir_missing_blocks_partial(tmp_path, monkeypatch):
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    patchers = _patch_common(
+        readiness=_readiness(
+            sir_found=False,
+            sir_vendor=False,
+            raycon_scenario_found=False,
+        ),
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    assert result["status"] == "success"
+    assert result["ready_for_full_report"] is False
+    assert result["partial_report_possible"] is False
+
+    statuses = {b["doc"]: b["status"] for b in result["blocking"]}
+    assert statuses == {
+        "vendor_sir": "missing",
+        "building_inspection": "present",
+        "raycon_scenario": "pending",
+    }
+    raycon_entry = next(b for b in result["blocking"] if b["doc"] == "raycon_scenario")
+    assert raycon_entry["block_plan_present"] is False
+    assert raycon_entry["last_dispatch"] is None
+    assert raycon_entry["minutes_since"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. SIR present, BI missing, RayCon pending with Block Plan dispatched 14
+#    minutes ago → matches the example response shape.
+# ---------------------------------------------------------------------------
+
+
+def test_partial_with_pending_raycon_dispatched_14_min_ago(tmp_path, monkeypatch):
+    _vendor_gate_on(monkeypatch)
+
+    # Seed a dispatch state file 14 minutes in the past, keyed by
+    # block_plan_file_id.
+    state_path = tmp_path / ".raycon_dispatch_state.json"
+    now = datetime.now(tz=UTC)
+    last_dispatch_dt = now - timedelta(minutes=14)
+    state_path.write_text(
+        json.dumps(
+            {
+                "bp-1": {
+                    "last_dispatch": last_dispatch_dt.isoformat().replace(
+                        "+00:00", "Z"
+                    ),
+                    "count": 1,
+                    "site": SITE_TITLE,
+                    "raycon_run_id": "run-xyz",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server, "_RAYCON_DISPATCH_STATE_PATH", state_path)
+
+    patchers = _patch_common(
+        readiness=_readiness(
+            inspection_found=False,
+            inspection_vendor=False,
+            raycon_scenario_found=False,
+        ),
+        m1_docs={
+            "block_plan": {"id": "bp-1", "modifiedTime": "2026-05-07T13:00:00Z"},
+        },
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    assert result["status"] == "success"
+    assert result["site"] == SITE_TITLE
+    assert result["ready_for_full_report"] is False
+    assert result["partial_report_possible"] is True
+
+    statuses = {b["doc"]: b["status"] for b in result["blocking"]}
+    assert statuses == {
+        "vendor_sir": "present",
+        "building_inspection": "missing",
+        "raycon_scenario": "pending",
+    }
+
+    raycon_entry = next(b for b in result["blocking"] if b["doc"] == "raycon_scenario")
+    assert raycon_entry["block_plan_present"] is True
+    assert raycon_entry["last_dispatch"] is not None
+    # Allow ±1 min jitter for the test's own walltime.
+    assert raycon_entry["minutes_since"] in (13, 14, 15)
+
+    # Pending tokens should include all RayCon paths.
+    assert any(
+        path.startswith("exec.fastest_open_") for path in result["would_be_pending"]
+    )
+    assert any(path.startswith("exec.cost_") for path in result["would_be_pending"])
+    assert result["would_be_filled_now"] == []
+
+
+# ---------------------------------------------------------------------------
+# 4. RayCon scenario present → status: present, no pending block.
+# ---------------------------------------------------------------------------
+
+
+def test_raycon_scenario_present_uses_run_timestamp(tmp_path, monkeypatch):
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    patchers = _patch_common(
+        readiness=_readiness(),
+        m1_docs={
+            "block_plan": {"id": "bp-1", "modifiedTime": "2026-05-07T13:00:00Z"},
+            "raycon_scenario_json": {
+                "id": "rs-1",
+                "modifiedTime": "2026-05-07T13:30:00Z",
+            },
+        },
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    raycon_entry = next(b for b in result["blocking"] if b["doc"] == "raycon_scenario")
+    assert raycon_entry["status"] == "present"
+    # When present, we don't surface dispatch metadata.
+    assert "last_dispatch" not in raycon_entry
+    assert "block_plan_present" not in raycon_entry
+    assert "minutes_since" not in raycon_entry
+
+
+# ---------------------------------------------------------------------------
+# 5. Unknown site → graceful error response, not a crash.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_site_returns_graceful_error(tmp_path, monkeypatch):
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    with patch("due_diligence_reporter.server.find_site_record", return_value=None):
+        result = asyncio.run(server.diagnose_site_readiness("Nonexistent Site"))
+
+    assert result["status"] == "error"
+    assert "could not find" in result["message"].lower()
+    assert result["site"] == "Nonexistent Site"
+
+
+def test_empty_site_name_returns_graceful_error():
+    result = asyncio.run(server.diagnose_site_readiness(""))
+    assert result["status"] == "error"
+    assert "non-empty" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Vendor gate disabled → response reflects legacy view.
+# ---------------------------------------------------------------------------
+
+
+def test_vendor_gate_disabled_reports_legacy_view(tmp_path, monkeypatch):
+    _vendor_gate_off(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    # SIR found but NOT vendor-classified. Under the gate this would be
+    # missing; with the gate off, the file's mere presence satisfies SIR.
+    patchers = _patch_common(
+        readiness=_readiness(
+            sir_found=True,
+            sir_vendor=False,
+            inspection_found=True,
+            inspection_vendor=False,
+            raycon_scenario_found=True,
+        ),
+        m1_docs={
+            "raycon_scenario_json": {
+                "id": "rs-1",
+                "modifiedTime": "2026-05-07T13:30:00Z",
+            },
+        },
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    assert result["vendor_gate_enabled"] is False
+    statuses = {b["doc"]: b["status"] for b in result["blocking"]}
+    # All three slots are satisfied under the legacy gate even though the
+    # AI-only SIR/BI would be rejected by the vendor gate.
+    assert statuses == {
+        "vendor_sir": "present",
+        "building_inspection": "present",
+        "raycon_scenario": "present",
+    }
+    assert result["ready_for_full_report"] is True
+    assert result["partial_report_possible"] is True
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_minutes_since_iso_handles_z_suffix():
+    iso = "2026-05-07T13:00:00Z"
+    fixed_now = datetime(2026, 5, 7, 13, 14, tzinfo=UTC)
+    assert server._minutes_since_iso(iso, now=fixed_now) == 14
+
+
+def test_minutes_since_iso_returns_none_for_garbage():
+    assert server._minutes_since_iso("not-a-date") is None
+    assert server._minutes_since_iso(None) is None
+
+
+def test_latest_dispatch_for_site_prefers_block_plan_match():
+    state = {
+        "bp-old": {"last_dispatch": "2026-05-01T00:00:00Z", "site": "Alpha Keller"},
+        "bp-new": {"last_dispatch": "2026-05-07T12:00:00Z", "site": "Alpha Keller"},
+    }
+    iso, fid = server._latest_dispatch_for_site(
+        state, "Alpha Keller", block_plan_file_id="bp-new"
+    )
+    assert iso == "2026-05-07T12:00:00Z"
+    assert fid == "bp-new"
+
+
+def test_latest_dispatch_for_site_falls_back_to_most_recent_for_site():
+    state = {
+        "bp-rotated": {"last_dispatch": "2026-05-01T00:00:00Z", "site": "Alpha Keller"},
+        "bp-newest": {"last_dispatch": "2026-05-07T12:00:00Z", "site": "Alpha Keller"},
+        "bp-other": {"last_dispatch": "2026-05-09T12:00:00Z", "site": "Other Site"},
+    }
+    # block_plan_file_id is now stale (rotated upload), but we still want
+    # the most recent dispatch for *this* site.
+    iso, fid = server._latest_dispatch_for_site(
+        state, "Alpha Keller", block_plan_file_id="bp-current-not-in-state"
+    )
+    assert iso == "2026-05-07T12:00:00Z"
+    assert fid == "bp-newest"
+
+
+def test_load_raycon_dispatch_state_returns_empty_on_missing_file(tmp_path):
+    missing = tmp_path / "does-not-exist.json"
+    assert server._load_raycon_dispatch_state(missing) == {}
+
+
+def test_load_raycon_dispatch_state_returns_empty_on_corrupt_file(tmp_path):
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    assert server._load_raycon_dispatch_state(corrupt) == {}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_diagnose_site_readiness.py
+++ b/tests/test_diagnose_site_readiness.py
@@ -349,22 +349,20 @@ def test_vendor_gate_disabled_reports_legacy_view(tmp_path, monkeypatch):
     _vendor_gate_off(monkeypatch)
     _no_dispatch_state(tmp_path, monkeypatch)
 
-    # SIR found but NOT vendor-classified. Under the gate this would be
-    # missing; with the gate off, the file's mere presence satisfies SIR.
+    # SIR + BI present (legacy gate satisfied) but NOT vendor-classified
+    # AND RayCon scenario MISSING. Under the legacy gate
+    # ``_missing_required_docs`` only requires SIR + BI presence, so
+    # ``ready_for_full_report`` must be True even though the diagnostic
+    # ``blocking[]`` view still surfaces RayCon as pending and the
+    # vendor entries as ``present`` (legacy semantics: bare presence).
     patchers = _patch_common(
         readiness=_readiness(
             sir_found=True,
             sir_vendor=False,
             inspection_found=True,
             inspection_vendor=False,
-            raycon_scenario_found=True,
+            raycon_scenario_found=False,
         ),
-        m1_docs={
-            "raycon_scenario_json": {
-                "id": "rs-1",
-                "modifiedTime": "2026-05-07T13:30:00Z",
-            },
-        },
     )
     _enter_all(patchers)
     try:
@@ -374,15 +372,277 @@ def test_vendor_gate_disabled_reports_legacy_view(tmp_path, monkeypatch):
 
     assert result["vendor_gate_enabled"] is False
     statuses = {b["doc"]: b["status"] for b in result["blocking"]}
-    # All three slots are satisfied under the legacy gate even though the
-    # AI-only SIR/BI would be rejected by the vendor gate.
+    # Under the legacy gate, ``vendor_sir`` / ``building_inspection`` slots
+    # report bare presence, and RayCon is reported as pending — but
+    # ``ready_for_full_report`` still flips True (Fix 3: mirror
+    # ``_missing_required_docs`` exactly).
     assert statuses == {
         "vendor_sir": "present",
         "building_inspection": "present",
-        "raycon_scenario": "present",
+        "raycon_scenario": "pending",
     }
     assert result["ready_for_full_report"] is True
     assert result["partial_report_possible"] is True
+
+
+# ---------------------------------------------------------------------------
+# 7. Fix 1 — diagnose path must not create the M1 folder when absent.
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_does_not_create_m1_folder(tmp_path, monkeypatch):
+    """Diagnose against a site with no M1 folder must NOT call create_folder.
+
+    Verifies (a) ``gc.create_folder`` is never invoked, (b) the response
+    surfaces ``m1_folder_missing: True`` and ``drive_folder_url: None``,
+    (c) other fields populate gracefully (vendor_gate_enabled, blocking
+    showing all three docs missing/pending, partial_report_possible False).
+    """
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    fake_gc = MagicMock()
+    fake_gc.list_subfolders.return_value = []  # no M1 subfolder anywhere
+
+    # Use the *real* ``_resolve_m1_folder`` to confirm Fix 1's
+    # ``create_if_missing=False`` propagates from the diagnose path.
+    patchers = [
+        patch(
+            "due_diligence_reporter.server.find_site_record",
+            return_value=_record(),
+        ),
+        patch(
+            "due_diligence_reporter.server.build_site_summary",
+            return_value=_summary(),
+        ),
+        patch(
+            "due_diligence_reporter.server._make_google_client",
+            return_value=fake_gc,
+        ),
+        patch(
+            "due_diligence_reporter.server._build_site_match_terms",
+            return_value=[SITE_TITLE],
+        ),
+        patch(
+            "due_diligence_reporter.report_pipeline.list_shared_folders_once",
+            return_value={},
+        ),
+        patch(
+            "due_diligence_reporter.report_pipeline.check_site_readiness_direct",
+            return_value=_readiness(
+                sir_found=False,
+                sir_vendor=False,
+                inspection_found=False,
+                inspection_vendor=False,
+                raycon_scenario_found=False,
+            ),
+        ),
+    ]
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    # Fix 1: no folder creation.
+    fake_gc.create_folder.assert_not_called()
+
+    assert result["status"] == "success"
+    assert result["m1_folder_missing"] is True
+    assert result["drive_folder_url"] is None
+    assert result["vendor_gate_enabled"] is True
+    assert result["partial_report_possible"] is False
+    assert result["ready_for_full_report"] is False
+
+    statuses = {b["doc"]: b["status"] for b in result["blocking"]}
+    assert statuses == {
+        "vendor_sir": "missing",
+        "building_inspection": "missing",
+        "raycon_scenario": "pending",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 8. Fix 2 — diagnose path must not write the provenance cache.
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_does_not_write_provenance_cache(tmp_path, monkeypatch):
+    """Tier 2 provenance miss in the diagnose path must not call ``_save_cache``.
+
+    We exercise the *real* ``check_site_readiness_direct`` (not mocked)
+    so the ``read_only=True`` flag actually flows through to
+    ``classify_provenance``. The fake GoogleClient pretends to find an
+    SIR file whose filename does NOT match the AI heuristic and whose
+    bytes don't disambiguate, forcing the default-to-vendor Tier 2 path
+    that would normally write the cache.
+    """
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    sir_file = {
+        "id": "sir-1",
+        "name": "Vendor SIR Update.pdf",  # does NOT match AI filename heuristic
+        "modifiedTime": "2026-05-07T10:00:00Z",
+    }
+
+    fake_gc = MagicMock()
+    fake_gc.list_subfolders.return_value = [
+        {
+            "id": "m1-folder-id",
+            "name": "M1",
+            "webViewLink": "https://drive.google.com/drive/folders/m1",
+        }
+    ]
+    # Recursive listing returns no docs at the site root (so shared cache /
+    # M1 are the only sources). Provenance check still runs on the SIR.
+    fake_gc.list_files_recursive.return_value = []
+    fake_gc.list_files_in_folder.return_value = []
+    # Tier 2 would download bytes — return a vague PDF blob that lands
+    # on default-to-vendor.
+    fake_gc.download_file_bytes.return_value = b"%PDF-1.4 some vendor doc"
+
+    # Force the SIR into the readiness pipeline via the shared-folder cache
+    # fallback path. The simplest way to drive ``classify_provenance``
+    # through Tier 2 is to patch it directly and assert ``read_only=True``
+    # is forwarded — the cache is only written when ``read_only`` is False.
+    save_cache_calls: list[tuple] = []
+    classify_call_kwargs: list[dict] = []
+
+    def spy_classify_provenance(*args, **kwargs):
+        classify_call_kwargs.append(dict(kwargs))
+        # Return a vendor verdict so readiness fields populate normally.
+        from due_diligence_reporter.provenance import ProvenanceVerdict
+        return ProvenanceVerdict(
+            label="vendor", confidence=0.9, tier="content", reason="spy"
+        )
+
+    def spy_save_cache(*args, **kwargs):
+        save_cache_calls.append((args, kwargs))
+
+    patchers = [
+        patch(
+            "due_diligence_reporter.server.find_site_record",
+            return_value=_record(),
+        ),
+        patch(
+            "due_diligence_reporter.server.build_site_summary",
+            return_value=_summary(),
+        ),
+        patch(
+            "due_diligence_reporter.server._make_google_client",
+            return_value=fake_gc,
+        ),
+        patch(
+            "due_diligence_reporter.server._build_site_match_terms",
+            return_value=[SITE_TITLE],
+        ),
+        patch(
+            "due_diligence_reporter.server._list_m1_documents_by_type",
+            return_value={},
+        ),
+        patch(
+            "due_diligence_reporter.report_pipeline.list_shared_folders_once",
+            return_value={"sir": [sir_file]},
+        ),
+        # Patch the classifier so we can capture kwargs (specifically
+        # ``read_only``). This is the symbol referenced by
+        # ``check_site_readiness_direct``.
+        patch(
+            "due_diligence_reporter.report_pipeline.classify_provenance",
+            side_effect=spy_classify_provenance,
+        ),
+        # Patch ``_save_cache`` to verify it's NEVER invoked from the
+        # diagnose path. This belt-and-braces check guards against any
+        # future code path that reintroduces a cache write.
+        patch(
+            "due_diligence_reporter.provenance._save_cache",
+            side_effect=spy_save_cache,
+        ),
+        # Make ``match_site_in_shared_cache`` actually return our SIR
+        # so the readiness pipeline runs the provenance check on it.
+        patch(
+            "due_diligence_reporter.report_pipeline.match_site_in_shared_cache",
+            return_value={"sir": sir_file},
+        ),
+    ]
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    # Fix 2 core assertion: cache write never happened.
+    assert save_cache_calls == [], (
+        f"_save_cache must not be called from the diagnose path; "
+        f"got {len(save_cache_calls)} call(s)"
+    )
+    # And the classifier was invoked with read_only=True.
+    assert any(
+        kw.get("read_only") is True for kw in classify_call_kwargs
+    ), (
+        "classify_provenance must be called with read_only=True from the "
+        f"diagnose path; saw kwargs: {classify_call_kwargs}"
+    )
+    # Sanity: response is still a success envelope.
+    assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# 9. Fix 3 — gate-off + RayCon missing + vendor docs missing →
+#    ready_for_full_report mirrors _missing_required_docs (i.e. True if
+#    SIR + BI present), and blocking[] still surfaces all three docs.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_off_raycon_missing_vendor_missing_ready_true(tmp_path, monkeypatch):
+    """Gate-off, RayCon missing, vendor docs missing → ready=True.
+
+    Under VENDOR_GATE_ENABLED=0, ``_missing_required_docs`` only
+    requires SIR + BI presence. The diagnose tool's
+    ``ready_for_full_report`` must mirror that exactly even though
+    ``blocking[]`` reports vendor SIR/BI/RayCon with their actual
+    statuses (so the agent sees the truth).
+    """
+    _vendor_gate_off(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    patchers = _patch_common(
+        readiness=_readiness(
+            sir_found=True,
+            sir_vendor=False,         # vendor missing
+            inspection_found=True,
+            inspection_vendor=False,  # vendor missing
+            raycon_scenario_found=False,  # RayCon missing
+        ),
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    # ``_missing_required_docs`` under gate-off only checks SIR + BI
+    # bare presence — both are present here, so ready_for_full_report
+    # must be True even with RayCon missing and vendor classification
+    # absent.
+    assert result["vendor_gate_enabled"] is False
+    assert result["ready_for_full_report"] is True
+    assert result["partial_report_possible"] is True
+
+    # ``blocking[]`` must still surface all three docs honestly so the
+    # caller can see the real picture.
+    statuses = {b["doc"]: b["status"] for b in result["blocking"]}
+    assert statuses == {
+        "vendor_sir": "present",       # legacy view: bare presence
+        "building_inspection": "present",
+        "raycon_scenario": "pending",  # actual status, even though
+                                       # not blocking under gate-off
+    }
+    raycon_entry = next(
+        b for b in result["blocking"] if b["doc"] == "raycon_scenario"
+    )
+    assert raycon_entry["block_plan_present"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **Recommendation 4B** from `event-driven-ddr-recommendations.md`: adds a new read-only MCP tool, `diagnose_site_readiness(site_name)`, that surfaces in one structured payload everything an agent / operator needs to decide whether to run `create_dd_report` now (accept partial) or wait for a missing input.

`check_site_readiness` is **not** renamed or replaced — both tools coexist:

- `check_site_readiness` — the pre-generation projection used internally by `create_dd_report`. Unchanged.
- `diagnose_site_readiness` — user/agent-facing diagnostic that composes the cron-path readiness view (vendor gate enforced), RayCon dispatch state, and the full token projection. Read-only.

> **Fix-forward addendum:** Addresses 3 blocking findings from code review: (1) M1 folder no longer created, (2) provenance cache no longer written, (3) `blocking` mirrors `_missing_required_docs` under gate-off. See "Read-only contract" below.

### Example response shape

```json
{
  "site": "Alpha Keller",
  "ready_for_full_report": false,
  "blocking": [
    {"doc": "vendor_sir", "status": "missing"},
    {"doc": "building_inspection", "status": "present"},
    {"doc": "raycon_scenario", "status": "pending",
     "block_plan_present": true,
     "last_dispatch": "2026-05-07T13:42Z",
     "minutes_since": 14}
  ],
  "partial_report_possible": true,
  "would_be_filled_now": ["exec.address", "exec.zoning_status", "..."],
  "would_be_pending": ["exec.fastest_open_capacity", "exec.cost_*"]
}
```

The full payload also includes `vendor_gate_enabled`, `m1_folder_missing`, `projected_completeness`, `pending_reason_labels`, and `drive_folder_url`. See the docstring on `diagnose_site_readiness` in `server.py` for field-by-field semantics.

### Read-only contract

Strictly read-only — three reinforcing guarantees:

1. **No M1 folder creation.** `_resolve_m1_folder` gained a `create_if_missing: bool = True` kwarg; the diagnose path passes `create_if_missing=False`. When the per-site M1 subfolder is absent, the response surfaces `m1_folder_missing: True` and `drive_folder_url: null`. Existing callers keep the default `True` and behave exactly as before.
2. **No provenance cache write.** `classify_provenance` gained a `read_only: bool = False` kwarg that suppresses `_save_cache` on Tier 2 misses. `check_site_readiness_direct` gained a matching `read_only` flag and threads it to both `_resolve_m1_folder` and `classify_provenance`. The diagnose path calls it with `read_only=True`. Cron paths default to `False` and continue to populate the cache.
3. **No generation, republish, or other side effects.** Same as before — this commit just plugs the two leaks above.

### Implementation notes

- Reuses existing helpers — no reinvention:
  - `report_pipeline.check_site_readiness_direct(..., read_only=True)` (returns `sir_vendor`, `inspection_vendor`, `raycon_scenario_found`).
  - `report_pipeline._vendor_gate_enabled` for the gate state, and `_missing_required_docs` for `ready_for_full_report`.
  - `completeness.project_completeness_from_readiness` + `raycon_token_paths` for `would_be_filled_now` / `would_be_pending`.
  - `m1_lookup._resolve_m1_folder(..., create_if_missing=False)` + `_list_m1_documents_by_type` for the Block Plan / RayCon scenario JSON.
  - `.raycon_dispatch_state.json` (written by `scripts/raycon_followup.py`) for `last_dispatch` / `minutes_since` / `block_plan_present`. Looked up by `block_plan_file_id` first; falls back to most-recent entry for the site so a rotated Block Plan still surfaces a dispatch.
- `last_dispatch` resolution order: (1) when RayCon scenario is present, the scenario JSON's Drive `modifiedTime` (the run timestamp); (2) otherwise the dispatch state file; (3) documented fallback to the Block Plan's `modifiedTime`. `null` only when none of the three are available.
- `partial_report_possible` floor mirrors `_missing_required_docs` semantics — vendor SIR with the gate on, bare SIR presence with the gate off.
- `ready_for_full_report` mirrors `_missing_required_docs` exactly. Under `VENDOR_GATE_ENABLED=1` this requires vendor SIR + vendor BI + RayCon scenario; under `VENDOR_GATE_ENABLED=0` only SIR + BI presence is required, and RayCon absence does NOT block readiness. The diagnostic `blocking[]` view still reports each doc's actual status so the caller sees the full picture.
- Vendor-gate awareness — the tool reports the cron-path view by default. It does NOT bypass the gate; `vendor_gate_enabled` is surfaced so the caller sees which view they're getting.

### Files changed

- `src/due_diligence_reporter/m1_lookup.py` — `_resolve_m1_folder` gained `create_if_missing: bool = True` kwarg.
- `src/due_diligence_reporter/provenance.py` — `classify_provenance` / `_classify_provenance_inner` gained `read_only: bool = False` kwarg that suppresses `_save_cache`.
- `src/due_diligence_reporter/report_pipeline.py` — `check_site_readiness_direct` gained `read_only: bool = False` kwarg, threaded to both `_resolve_m1_folder` and `classify_provenance`.
- `src/due_diligence_reporter/server.py` — new `@mcp.tool()` `diagnose_site_readiness`, plus helpers (`_load_raycon_dispatch_state`, `_latest_dispatch_for_site`, `_minutes_since_iso`, `_build_blocking_entries`). Diagnose path calls `check_site_readiness_direct(..., read_only=True)` and `_resolve_m1_folder(..., create_if_missing=False)`. Imports of `REASON_DISPLAY_LABELS` and `raycon_token_paths` added; `report_pipeline` symbols imported lazily inside the tool body to avoid pulling `anthropic` into the top-level server import path.
- `tests/test_diagnose_site_readiness.py` — tests covering all six original scenarios + 3 fix-forward tests + helper unit tests.
- `CHANGELOG.md` — added entry under Unreleased / Added.

## Divergence from the example response shape

The implementation matches the example, with four additive (non-removing) extras:

- `vendor_gate_enabled: bool` at top-level — required by the spec to surface which view the caller is seeing.
- `m1_folder_missing: bool` at top-level — true when the per-site M1 subfolder hasn't been created yet (no folder is created — read-only). When true, `drive_folder_url` is `null`.
- `projected_completeness` — the same dict `check_site_readiness` returns under `report_metadata.completeness`, hoisted to the top level so callers don't have to recompute it.
- `pending_reason_labels` — display labels for the reason keys in `projected_completeness.pending_reasons`, so a UI / agent can present "RayCon cost & capacity" instead of `raycon_scenario_pending`.

These are additions, not changes — the example fields (`site`, `ready_for_full_report`, `blocking`, `partial_report_possible`, `would_be_filled_now`, `would_be_pending`) match the spec.

## Test plan

- [x] `uv run pytest tests/test_diagnose_site_readiness.py -v` — 16 tests, all green
- [x] `uv run pytest` — full suite, 1128 passed (was 1125 before this PR; +3 new fix-forward tests)
- [x] `uv run ruff check` on changed files — clean

Tests cover:

1. All docs present → `ready_for_full_report: true`, no pending tokens.
2. Vendor SIR missing → `partial_report_possible: false`, RayCon and BI statuses correct.
3. SIR present, BI missing, RayCon pending with Block Plan dispatched 14 min ago → matches the example response shape.
4. RayCon scenario present → `status: present`, no dispatch metadata leaks into the entry, scenario `modifiedTime` used as `last_dispatch`.
5. Unknown site → graceful error response, not a crash.
6. Vendor gate disabled (updated; no longer pre-sets RayCon as present — that masked Fix 3) → legacy view, RayCon reported as pending in `blocking[]` but `ready_for_full_report` still True since `_missing_required_docs` only requires SIR + BI under gate-off.
7. **Fix 1** — `test_diagnose_does_not_create_m1_folder`: no `create_folder` call, `m1_folder_missing: True`, `drive_folder_url: None`.
8. **Fix 2** — `test_diagnose_does_not_write_provenance_cache`: `_save_cache` not called from the diagnose path; `classify_provenance` invoked with `read_only=True`.
9. **Fix 3** — `test_gate_off_raycon_missing_vendor_missing_ready_true`: gate-off + RayCon missing + vendor missing → `ready_for_full_report=True`, `blocking[]` still reports all three docs honestly.

Plus helper unit tests for `_minutes_since_iso`, `_latest_dispatch_for_site` (block-plan-keyed match + site-fallback), and corrupt/missing dispatch state file handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
