### PR TITLE
feat(raycon): receive callback dispatch and scope follow-up to single site

### DIFF
--- a/.github/workflows/raycon-followup.yml
+++ b/.github/workflows/raycon-followup.yml
@@ -7,6 +7,25 @@ name: RayCon Follow-up
 #
 # Re-running is safe: only re-publishes when the JSON is newer than
 # the existing report Doc.
+#
+# ---------------------------------------------------------------------------
+# RayCon callback receiver (Rec. 2 from event-driven-ddr-recommendations.md)
+# ---------------------------------------------------------------------------
+# When RayCon finishes a job it fires `workflow_dispatch` against this file
+# with `site_id`, `run_id`, and `status` inputs. When `site_id` is provided
+# the script scopes its work to that single site instead of sweeping every
+# active site, which is the whole point of the callback.
+#
+# Auth model: PAT-only. GitHub's workflow_dispatch API strips custom
+# request headers, so a body-level HMAC adds complexity without real
+# security gain when the endpoint already requires a workflow-scoped
+# token. RayCon authenticates with a fine-scoped PAT (workflow scope,
+# this repo only). The outbound `RAYCON_WEBHOOK_SECRET` used for
+# DDR -> RayCon signing is unrelated and stays in place.
+#
+# Cron remains as the deterministic safety net: any callback GitHub
+# rejects, RayCon abandons, or this workflow fails to deliver gets
+# picked up on the next 5-minute tick.
 
 on:
   schedule:
@@ -32,6 +51,20 @@ on:
         description: 'Alert when a Block Plan has no scenario after this many minutes'
         required: false
         default: '60'
+        type: string
+      # New inputs for RayCon callback (Rec. 2). All optional so manual
+      # triggers and the cron path keep working unchanged.
+      site_id:
+        description: 'Single site to scope the run to (RayCon callback). Wrike site record id.'
+        required: false
+        type: string
+      run_id:
+        description: 'RayCon run UUID (callback observability only)'
+        required: false
+        type: string
+      status:
+        description: 'RayCon job status: succeeded | failed | validation_failed (callback observability only)'
+        required: false
         type: string
 
 concurrency:
@@ -161,8 +194,17 @@ jobs:
           INPUT_SITE: ${{ inputs.site }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_ALERT_AFTER_MINUTES: ${{ inputs.alert_after_minutes }}
+          # RayCon callback inputs (Rec. 2). site_id scopes the run to a
+          # single site; run_id and status are observability-only and
+          # logged so on-call can correlate with RayCon-side logs.
+          INPUT_SITE_ID: ${{ inputs.site_id }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          INPUT_STATUS: ${{ inputs.status }}
         run: |
           set -euo pipefail
+          if [ -n "${INPUT_SITE_ID:-}" ] || [ -n "${INPUT_RUN_ID:-}" ] || [ -n "${INPUT_STATUS:-}" ]; then
+            echo "RayCon callback dispatch: site_id='${INPUT_SITE_ID:-}' run_id='${INPUT_RUN_ID:-}' status='${INPUT_STATUS:-}'"
+          fi
           ARGS=()
           if [ -n "${INPUT_SITE:-}" ]; then
             ARGS+=(--site "$INPUT_SITE")
@@ -172,6 +214,15 @@ jobs:
           fi
           if [ -n "${INPUT_ALERT_AFTER_MINUTES:-}" ]; then
             ARGS+=(--alert-after-minutes "$INPUT_ALERT_AFTER_MINUTES")
+          fi
+          if [ -n "${INPUT_SITE_ID:-}" ]; then
+            ARGS+=(--site-id "$INPUT_SITE_ID")
+          fi
+          if [ -n "${INPUT_RUN_ID:-}" ]; then
+            ARGS+=(--run-id "$INPUT_RUN_ID")
+          fi
+          if [ -n "${INPUT_STATUS:-}" ]; then
+            ARGS+=(--status "$INPUT_STATUS")
           fi
           uv run python scripts/raycon_followup.py "${ARGS[@]}"
 

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -797,7 +797,41 @@ def main(argv: list[str] | None = None) -> int:
             "behavior is to republish."
         ),
     )
+    # Rec. 2: RayCon callback receiver. When --site-id is set, scope the
+    # run to a single site instead of sweeping the full portfolio. The
+    # GitHub Actions workflow passes these from the RayCon callback's
+    # workflow_dispatch inputs.
+    parser.add_argument(
+        "--site-id",
+        dest="site_id",
+        default=None,
+        help=(
+            "Wrike site record id to scope the run to (RayCon callback). "
+            "When set, only that site is processed. Unknown ids exit cleanly "
+            "with a logged warning so the cron safety net can pick the run up."
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        dest="run_id",
+        default=None,
+        help="RayCon run UUID — observability only, logged for cross-system correlation.",
+    )
+    parser.add_argument(
+        "--status",
+        dest="raycon_status",
+        default=None,
+        help="RayCon job status (succeeded|failed|validation_failed) — observability only.",
+    )
     args = parser.parse_args(argv)
+
+    if args.site_id or args.run_id or args.raycon_status:
+        logger.info(
+            "RayCon callback dispatch: site_id=%s run_id=%s status=%s",
+            args.site_id or "(none)",
+            args.run_id or "(none)",
+            args.raycon_status or "(none)",
+        )
 
     settings = get_settings()
     gc = GoogleClient.from_oauth_config(
@@ -813,6 +847,27 @@ def main(argv: list[str] | None = None) -> int:
 
     summaries = [build_site_summary(r) for r in active_records]
     summaries = [s for s in summaries if _site_filter(s, args.site)]
+
+    # Rec. 2: when the RayCon callback supplies a site_id, scope the run
+    # to that single site. Unknown ids exit cleanly (return 0) so the
+    # 5-minute cron can recover on its next tick — same fallback shape
+    # the rest of the system uses.
+    if args.site_id:
+        target_id = str(args.site_id).strip()
+        scoped = [s for s in summaries if str(s.get("id", "")).strip() == target_id]
+        if not scoped:
+            logger.warning(
+                "RayCon callback site_id=%s did not match any active site; "
+                "exiting 0 so cron picks it up on the next tick.",
+                target_id,
+            )
+            return 0
+        logger.info(
+            "RayCon callback scoping run to single site: id=%s title=%s",
+            target_id,
+            scoped[0].get("title", "(unnamed)"),
+        )
+        summaries = scoped
 
     alert_after = timedelta(minutes=args.alert_after_minutes)
     redispatch_after = timedelta(minutes=args.redispatch_after_minutes)

--- a/scripts/smoke_test_raycon_callback.sh
+++ b/scripts/smoke_test_raycon_callback.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Simulates the dispatch RayCon fires when a job completes.
+#
+# Usage: scripts/smoke_test_raycon_callback.sh <site_id> [run_id] [status]
+# Requires: gh CLI authenticated with workflow scope on this repo.
+#
+# Replays the exact shape RayCon sends so we can verify the receiver
+# end-to-end without coordinating with the RayCon team. See Rec. 2 in
+# event-driven-ddr-recommendations.md and the brief at
+# /home/user/workspace/raycon-callback-ask.md for the contract.
+set -euo pipefail
+
+SITE_ID="${1:?site_id required (use a Wrike site record id from the active site list)}"
+RUN_ID="${2:-smoke-$(date +%s)}"
+STATUS="${3:-succeeded}"
+
+gh api -X POST \
+  repos/GFooteGK1/due-diligence-reporter/actions/workflows/raycon-followup.yml/dispatches \
+  --input - <<JSON
+{"ref":"main","inputs":{"site_id":"${SITE_ID}","run_id":"${RUN_ID}","status":"${STATUS}"}}
+JSON
+
+echo "Dispatched. Tail logs with:"
+echo "  gh run watch --repo GFooteGK1/due-diligence-reporter \$(gh run list --workflow raycon-followup.yml --limit 1 --json databaseId --jq '.[0].databaseId')"

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -1174,3 +1174,218 @@ class TestSchemaFailHandling:
         assert any(
             "not valid JSON" in record.getMessage() for record in caplog.records
         )
+
+
+# ---------------------------------------------------------------------------
+# RayCon callback receiver — `main()` entry point (Rec. 2)
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackReceiverScoping:
+    """Verify the workflow_dispatch callback path scopes to a single site
+    and falls back cleanly when site_id is unknown or absent.
+
+    Tests target ``main()`` with the integration boundaries (Wrike,
+    Google, _process_site) mocked. The point is to prove the wiring —
+    parsing the new flags, narrowing the site list, and exiting cleanly
+    on an unknown id — not to re-test what `_process_site` already does.
+    """
+
+    def _patch_integration_points(self, summaries):
+        """Return a dict of patches that stand in for Wrike + Google.
+
+        Callers use this with ``contextlib.ExitStack`` to keep test bodies
+        short. ``summaries`` is the list ``main()`` will iterate (each
+        entry is what ``build_site_summary`` would have returned).
+        """
+        from unittest.mock import patch as _patch
+
+        # Each Wrike record carries an ``id`` so build_site_summary's
+        # passthrough returns it unchanged.
+        records = [{"id": s["id"]} for s in summaries]
+
+        return {
+            "get_settings": _patch("scripts.raycon_followup.get_settings"),
+            "google_client": _patch(
+                "scripts.raycon_followup.GoogleClient.from_oauth_config",
+                return_value=MagicMock(),
+            ),
+            "load_wrike_config": _patch(
+                "scripts.raycon_followup.load_wrike_config",
+                return_value=MagicMock(access_token="t"),
+            ),
+            "get_all_site_records": _patch(
+                "scripts.raycon_followup._get_all_site_records",
+                return_value=records,
+            ),
+            "get_active_status_ids": _patch(
+                "scripts.raycon_followup._get_active_status_ids",
+                return_value={"active"},
+            ),
+            "filter_active": _patch(
+                "scripts.raycon_followup.filter_active_site_records",
+                return_value=records,
+            ),
+            "build_summary": _patch(
+                "scripts.raycon_followup.build_site_summary",
+                # Map record -> the matching summary the test set up.
+                side_effect=lambda rec: next(
+                    s for s in summaries if s["id"] == rec["id"]
+                ),
+            ),
+            "process_site": _patch(
+                "scripts.raycon_followup._process_site",
+                return_value={"site": "stub", "skipped": "test"},
+            ),
+            "save_dispatch": _patch("scripts.raycon_followup._save_dispatch_state"),
+            "save_republish": _patch("scripts.raycon_followup._save_republish_state"),
+            "load_dispatch": _patch(
+                "scripts.raycon_followup._load_dispatch_state", return_value={}
+            ),
+            "load_republish": _patch(
+                "scripts.raycon_followup._load_republish_state", return_value={}
+            ),
+        }
+
+    def _run_main(self, argv, summaries):
+        from contextlib import ExitStack
+
+        from scripts.raycon_followup import main
+
+        patches = self._patch_integration_points(summaries)
+        with ExitStack() as stack:
+            mocks = {name: stack.enter_context(p) for name, p in patches.items()}
+            rc = main(argv)
+        return rc, mocks
+
+    def test_site_id_scopes_run_to_one_site(self):
+        """--site-id X causes _process_site to be called exactly once,
+        with the site whose id == X."""
+        summaries = [
+            {"id": "site-A", "title": "Alpha", "drive_folder_url": "https://x/A"},
+            {"id": "site-B", "title": "Bravo", "drive_folder_url": "https://x/B"},
+            {"id": "site-C", "title": "Charlie", "drive_folder_url": "https://x/C"},
+        ]
+        rc, mocks = self._run_main(
+            ["--site-id", "site-B", "--run-id", "r1", "--status", "succeeded"],
+            summaries,
+        )
+        assert rc == 0
+        assert mocks["process_site"].call_count == 1
+        # _process_site is called positionally: (gc, site_summary, **kw)
+        called_summary = mocks["process_site"].call_args.args[1]
+        assert called_summary["id"] == "site-B"
+        assert called_summary["title"] == "Bravo"
+
+    def test_missing_site_id_falls_back_to_full_sweep(self):
+        """Manual / cron path: no --site-id → every site is processed."""
+        summaries = [
+            {"id": "site-A", "title": "Alpha", "drive_folder_url": "https://x/A"},
+            {"id": "site-B", "title": "Bravo", "drive_folder_url": "https://x/B"},
+            {"id": "site-C", "title": "Charlie", "drive_folder_url": "https://x/C"},
+        ]
+        rc, mocks = self._run_main([], summaries)
+        assert rc == 0
+        assert mocks["process_site"].call_count == 3
+
+    def test_unknown_site_id_exits_zero_with_warning(self, caplog):
+        """Unknown site_id → log warning, return 0, do not call _process_site.
+
+        Cron will catch the run on its next tick — same fallback shape
+        the rest of the system uses.
+        """
+        import logging
+
+        summaries = [
+            {"id": "site-A", "title": "Alpha", "drive_folder_url": "https://x/A"},
+        ]
+        with caplog.at_level(logging.WARNING, logger="raycon_followup"):
+            rc, mocks = self._run_main(
+                ["--site-id", "site-DOES-NOT-EXIST"], summaries
+            )
+        assert rc == 0
+        assert mocks["process_site"].call_count == 0
+        assert any(
+            "site-DOES-NOT-EXIST" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_run_id_and_status_logged_for_observability(self, caplog):
+        """run_id and status are observability-only but must be logged."""
+        import logging
+
+        summaries = [
+            {"id": "site-A", "title": "Alpha", "drive_folder_url": "https://x/A"},
+        ]
+        with caplog.at_level(logging.INFO, logger="raycon_followup"):
+            rc, _ = self._run_main(
+                [
+                    "--site-id", "site-A",
+                    "--run-id", "raycon-run-deadbeef",
+                    "--status", "succeeded",
+                ],
+                summaries,
+            )
+        assert rc == 0
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "raycon-run-deadbeef" in joined
+        assert "succeeded" in joined
+
+
+class TestCallbackIdempotencyWiring:
+    """The receiver path leans on the shared dd_republish helper for
+    idempotency on (site_id, reason, content_fingerprint). This test is a
+    thin wrapper that exercises the receiver-flavored
+    ``_republish_dd_report_if_present`` twice with the same run_id +
+    _drive_modified_time and asserts the underlying pipeline ran exactly
+    once — proving PR #88/#89's dedup still holds when the trigger is a
+    callback rather than the cron.
+    """
+
+    @patch("scripts.raycon_followup.process_site_pipeline")
+    @patch("scripts.raycon_followup._find_existing_dd_report")
+    def test_two_callback_invocations_same_run_id_dedup(
+        self, mock_find_dd, mock_pipeline
+    ):
+        from scripts.raycon_followup import _republish_dd_report_if_present
+
+        # An existing DD Report exists so the helper would otherwise
+        # republish; we want to prove dedup blocks the second call.
+        mock_find_dd.return_value = {"id": "doc-1", "name": "Alpha DD Report"}
+        result_obj = MagicMock()
+        result_obj.status = "report_created"
+        result_obj.doc_url = "https://docs.google.com/document/d/doc-1"
+        mock_pipeline.return_value = result_obj
+
+        site_summary = {
+            "id": "site-1",
+            "title": "Alpha",
+            "drive_folder_url": "https://drive.google.com/drive/folders/abc123",
+            "address": "123 Main St",
+        }
+        republish_state: dict[str, str] = {}
+        gc = MagicMock()
+
+        # Settings stub — the helper just passes it through to the
+        # pipeline runner, which we've mocked.
+        settings = MagicMock()
+
+        common = {
+            "settings": settings,
+            "system_prompt": "prompt",
+            "shared_cache": {},
+            "republish_state": republish_state,
+            "dry_run": False,
+            "drive_modified_time": "2026-05-07T14:42:00Z",
+        }
+
+        first = _republish_dd_report_if_present(
+            gc, site_summary, "run-aaaa", **common
+        )
+        second = _republish_dd_report_if_present(
+            gc, site_summary, "run-aaaa", **common
+        )
+
+        assert first["dd_report_republish"] == "republished"
+        assert second["dd_report_republish"] == "deduped"
+        assert mock_pipeline.call_count == 1


### PR DESCRIPTION
## Summary

Implements **Recommendation 2** from `event-driven-ddr-recommendations.md`. RayCon's job-completion callback now fires `workflow_dispatch` against `raycon-followup.yml` with `{site_id, run_id, status}`; when `site_id` is provided the script scopes `_process_site` to that one site instead of sweeping the full active-site list. The 5-minute cron stays in place as the safety net.

The brief sent to the RayCon team lives at `/home/user/workspace/raycon-callback-ask.md`. Greg confirmed the bug driving this PR by simulating the dispatch shape against production:

```
gh api -X POST repos/.../actions/workflows/raycon-followup.yml/dispatches \
  -f ref=main -f inputs[site_id]=test ... → HTTP 422 Unexpected inputs
```

The current workflow only declared `site / dry_run / alert_after_minutes` — RayCon's callback inputs were rejected at GitHub's API before the workflow even started. This PR adds `site_id`, `run_id`, and `status` as optional inputs (manual / cron paths unchanged) and wires `--site-id` through the script for single-site scoping.

### Auth model: PAT-only

Greg explicitly chose option 2b — trust the workflow-scoped GitHub PAT and skip body-level HMAC. GitHub's `workflow_dispatch` API strips custom request headers, so an `X-RayCon-Signature` header would never reach the workflow, and reading the body to verify HMAC adds complexity without real security gain when the endpoint already requires a fine-scoped token (`workflow` scope, this repo only). Documented in a comment block at the top of `raycon-followup.yml`.

The outbound `RAYCON_WEBHOOK_SECRET` used for DDR → RayCon signing is unrelated and untouched.

### Idempotency (already covered by PR #88 / #89)

The shared `dd_republish` helper dedups on `(site_id, reason, content_fingerprint)` where the RayCon fingerprint is `run_id:_drive_modified_time` (PR #89). A callback re-firing for the same `run_id` with unchanged scenario contents is a no-op. PR #89's regression test in `tests/test_dd_republish.py` already covers this; the new `TestCallbackIdempotencyWiring` test exercises the same dedup through the receiver-flavored `_republish_dd_report_if_present` wrapper.

### What's in this PR

| File | Change |
|---|---|
| `.github/workflows/raycon-followup.yml` | Added 3 optional `workflow_dispatch` inputs (`site_id`, `run_id`, `status`); pass-through to script as `--site-id / --run-id / --status`; comment block documenting PAT-only auth + cron-as-safety-net |
| `scripts/raycon_followup.py` | New `--site-id / --run-id / --status` flags; when `site_id` is set, narrow `summaries` to the matching site; unknown id logs warning and exits 0 (cron picks it up next tick); `run_id` and `status` are observability-only and logged for cross-system correlation |
| `scripts/smoke_test_raycon_callback.sh` | New executable that replays RayCon's exact dispatch shape on demand (`gh api` POST with `{ref, inputs:{site_id, run_id, status}}`) |
| `tests/test_raycon_followup.py` | `TestCallbackReceiverScoping` — single-site scoping, full-sweep fallback, unknown-id graceful exit, observability logging; `TestCallbackIdempotencyWiring` — proves PR #88/#89's dedup still holds via the receiver path |

### What's NOT changed

- Cron schedule — untouched, still the deterministic safety net
- Manual MCP `create_dd_report` path — untouched
- `RAYCON_WEBHOOK_SECRET` (outbound DDR → RayCon signing) — untouched
- Existing `--site` substring filter, `--dry-run`, `--alert-after-minutes`, `--skip-dd-republish` — untouched
- Wire format for `/v1/jobs` — untouched

## Test plan

- [x] `uv run pytest tests/test_raycon_followup.py` — 42 passed (5 new tests)
- [x] `uv run pytest` (full suite) — 1133 passed
- [x] Ruff lint count unchanged from baseline
- [ ] Post-merge smoke test (Greg — see below)

### Post-merge smoke test

Run the new helper against a real active site (substitute a Wrike site id from `_get_all_site_records()`):

```bash
scripts/smoke_test_raycon_callback.sh <wrike-site-id> smoke-$(date +%s) succeeded
```

Or invoke the raw `gh api` shape RayCon will use (matches Greg's earlier 422 reproduction, but now expected to return 204):

```bash
gh api -X POST \
  repos/GFooteGK1/due-diligence-reporter/actions/workflows/raycon-followup.yml/dispatches \
  --input - <<'JSON'
{"ref":"main","inputs":{"site_id":"<wrike-site-id>","run_id":"smoke-1","status":"succeeded"}}
JSON
```

Then watch the run:

```bash
gh run watch --repo GFooteGK1/due-diligence-reporter \
  $(gh run list --workflow raycon-followup.yml --limit 1 --json databaseId --jq '.[0].databaseId')
```

Expected log line in the workflow output:
```
RayCon callback scoping run to single site: id=<wrike-site-id> title=<site name>
```