### PR TITLE
fix(events): cache sharing + envelope normalization + provenance gate (P0/P1 from /check)

### DIFF
--- a/.github/workflows/inbox-scan.yml
+++ b/.github/workflows/inbox-scan.yml
@@ -36,16 +36,15 @@ jobs:
         # Persists .dd_republish_state.json across cron ticks so the 12h
         # DD_REPUBLISH_FORCE_AFTER window is honored. Save key is
         # run-id-scoped so each run writes a fresh entry; restore-keys
-        # falls back to the latest entry that matches the prefix.
-        # Workflow-scoped key so inbox-scan doesn't trample
-        # raycon-followup's cache (and vice versa).
+        # falls back to the latest entry that matches the prefix. The
+        # cache is shared across workflows on purpose so inbox-scan and
+        # raycon-followup see each other's dedup state.
         id: restore-dd-republish-state
         uses: actions/cache/restore@v4
         with:
           path: .dd_republish_state.json
-          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
+          key: dd-republish-state-${{ github.run_id }}
           restore-keys: |
-            dd-republish-state-${{ github.workflow }}-
             dd-republish-state-
 
       - name: Install uv
@@ -185,7 +184,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .dd_republish_state.json
-          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
+          key: dd-republish-state-${{ github.run_id }}
 
       - name: Done
         run: echo "Inbox scan completed"

--- a/.github/workflows/raycon-followup.yml
+++ b/.github/workflows/raycon-followup.yml
@@ -63,9 +63,14 @@ on:
         required: false
         type: string
       status:
-        description: 'RayCon job status: succeeded | failed | validation_failed (callback observability only)'
+        description: 'RayCon job status (callback observability only)'
         required: false
-        type: string
+        type: choice
+        default: 'succeeded'
+        options:
+          - succeeded
+          - failed
+          - partial
 
 concurrency:
   group: raycon-followup
@@ -99,9 +104,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .dd_republish_state.json
-          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
+          key: dd-republish-state-${{ github.run_id }}
           restore-keys: |
-            dd-republish-state-${{ github.workflow }}-
             dd-republish-state-
 
       - name: Install uv
@@ -235,7 +239,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .dd_republish_state.json
-          key: dd-republish-state-${{ github.workflow }}-${{ github.run_id }}
+          key: dd-republish-state-${{ github.run_id }}
 
       - name: Done
         run: echo "RayCon follow-up completed"

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -121,6 +121,37 @@ BLOCK_PLAN_PFP_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+_CALLBACK_INPUT_RE = re.compile(r"^[A-Za-z0-9_:\-]+$")
+
+
+def _validate_callback_input(
+    name: str,
+    value: str | None,
+    *,
+    max_len: int = 64,
+    pattern: re.Pattern[str] = _CALLBACK_INPUT_RE,
+) -> str | None:
+    """Reject malformed RayCon callback inputs (workflow_dispatch surface).
+
+    Returns the value unchanged when valid, ``None`` when malformed (or
+    when the input was already None/empty). Drops malformed values
+    silently — the cron safety net always re-runs, so a rejected
+    callback degrades to "next scheduled run picks it up" rather than
+    a script-killing crash.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    if len(value) > max_len or not pattern.fullmatch(value):
+        logger.warning(
+            "Rejecting malformed %s callback input (len=%d)", name, len(value)
+        )
+        return None
+    return value
+
+
 def _filename_matches_block_plan(name: str) -> bool:
     """Return True if ``name`` (already lowercased) looks like a Block Plan.
 
@@ -743,10 +774,9 @@ def _process_site(
                 dry_run=dry_run,
             )
         except Exception as e:
-            logger.error(
-                "DD Report republish callback raised for site=%s: %s",
+            logger.exception(
+                "DD Report republish callback raised for site=%s",
                 site_name,
-                e,
             )
             republish_result = {"dd_report_republish": "failed", "reason": str(e)}
         if republish_result:
@@ -824,6 +854,17 @@ def main(argv: list[str] | None = None) -> int:
         help="RayCon job status (succeeded|failed|validation_failed) — observability only.",
     )
     args = parser.parse_args(argv)
+
+    # Reject malformed callback inputs (charset + length cap) before they
+    # reach logging or downstream filters. The workflow_dispatch surface
+    # is HTTP-reachable via the GitHub PAT path, so RayCon-side bugs (or
+    # a stale token's misuse) shouldn't be able to wedge log
+    # ingestion or smuggle log-injection sequences through.
+    args.site_id = _validate_callback_input("site_id", args.site_id)
+    args.run_id = _validate_callback_input("run_id", args.run_id)
+    args.raycon_status = _validate_callback_input(
+        "status", args.raycon_status, max_len=32
+    )
 
     if args.site_id or args.run_id or args.raycon_status:
         logger.info(

--- a/src/due_diligence_reporter/dd_republish.py
+++ b/src/due_diligence_reporter/dd_republish.py
@@ -196,40 +196,47 @@ def load_state(
     return state
 
 
-def save_state(state: dict[str, str], path: Path = DD_REPUBLISH_STATE_PATH) -> None:
-    """Persist the dedup map atomically.
+def atomic_write_json(path: Path, data: Any) -> None:
+    """Atomically write *data* as pretty JSON to *path*.
 
     Writes to a sibling tempfile in the same directory then ``os.replace``
     onto the target path so concurrent readers never see a half-written
     file. Tempfile lives in the same directory to keep ``os.replace``
-    atomic on a single filesystem. Best-effort; logs but does not raise.
+    atomic on a single filesystem. Raises on failure — callers decide
+    whether to swallow or propagate.
+
+    Shared utility used by both ``save_state`` (this module) and
+    ``_save_failure_state`` (report_pipeline) so any state file written
+    at repo root has the same crash-safety guarantees.
     """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(data, sort_keys=True, indent=2)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        prefix=path.name + ".",
+        suffix=".tmp",
+        delete=False,
+    )
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = json.dumps(state, sort_keys=True, indent=2)
-        # delete=False so we control the rename; we explicitly clean up
-        # on failure. Using NamedTemporaryFile so the temp name is
-        # collision-safe across racing writers.
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=str(path.parent),
-            prefix=path.name + ".",
-            suffix=".tmp",
-            delete=False,
-        )
+        tmp.write(payload)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.replace(tmp.name, path)
+    except Exception:
         try:
-            tmp.write(payload)
-            tmp.flush()
-            os.fsync(tmp.fileno())
-            tmp.close()
-            os.replace(tmp.name, path)
-        except Exception:
-            try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
-            raise
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+
+
+def save_state(state: dict[str, str], path: Path = DD_REPUBLISH_STATE_PATH) -> None:
+    """Persist the dedup map atomically. Best-effort; logs but does not raise."""
+    try:
+        atomic_write_json(path, state)
     except Exception as e:
         logger.warning("Failed to write DD republish state at %s: %s", path, e)
 
@@ -429,6 +436,24 @@ def maybe_republish_dd_report(
     # that don't plumb id (no live caller does today, but keep safe).
     state_key = _state_key(site_id or site_name, reason, fingerprint)
     last_iso = republish_state.get(state_key)
+    if last_iso is None and reason == REASON_RAYCON:
+        # Legacy migration compat. Pre-Rec.3 the RayCon path keyed on
+        # `{site}:raycon_scenario:{run_id}` (no drive_modified_time
+        # suffix). load_state preserves those keys verbatim, but live
+        # callers now build a fingerprint like
+        # `{run_id}:{drive_modified_time}`. The drive_modified_time
+        # is ISO 8601 and contains colons of its own, so we can't
+        # rpartition on `:`. Instead we strip the trailing
+        # `:{drive_modified_time}` chunk by splitting on the run_id
+        # boundary and check whether the legacy-shaped key exists.
+        # Only applied for the RayCon reason — SIR/BI never had a
+        # legacy keying scheme to migrate from.
+        run_id_only_fingerprint = fingerprint.split(":", 1)[0]
+        if run_id_only_fingerprint and run_id_only_fingerprint != fingerprint:
+            legacy_state_key = _state_key(
+                site_id or site_name, reason, run_id_only_fingerprint
+            )
+            last_iso = republish_state.get(legacy_state_key)
     last_dt = _parse_iso(last_iso) if last_iso else None
     if not force and last_dt is not None and (now - last_dt) < force_after:
         logger.info(
@@ -490,13 +515,12 @@ def maybe_republish_dd_report(
             force_regenerate=True,
         )
     except Exception as e:
-        logger.error(
-            "DD republish failed: reason=%s site_id=%s site=%s fingerprint=%s err=%s",
+        logger.exception(
+            "DD republish failed: reason=%s site_id=%s site=%s fingerprint=%s",
             reason,
             site_id or "?",
             site_name,
             fingerprint,
-            e,
         )
         return RepublishOutcome(
             decision="failed",

--- a/src/due_diligence_reporter/google_client.py
+++ b/src/due_diligence_reporter/google_client.py
@@ -419,6 +419,26 @@ class GoogleClient:
             logger.error("Failed to make file %s public: %s", file_id, error)
             raise RuntimeError(f"Failed to set public permission: {error}") from error
 
+    def rename_file(self, file_id: str, new_name: str) -> None:
+        """Rename a Drive file (or Doc) in place.
+
+        Used by the DD Report cross-day path: when ``force_regenerate=True``
+        finds yesterday's report Doc, we rename it to today's date and
+        overwrite its body in place rather than creating a duplicate Doc.
+        """
+        try:
+            _google_api_execute(
+                self.drive_service.files().update(
+                    fileId=file_id,
+                    body={"name": new_name},
+                    fields="id, name",
+                    supportsAllDrives=True,
+                )
+            )
+        except HttpError as error:
+            logger.error("Failed to rename file %s -> %s: %s", file_id, new_name, error)
+            raise RuntimeError(f"Failed to rename file: {error}") from error
+
     def get_document(self, document_id: str) -> dict[str, Any]:
         """Retrieve the full Google Docs document structure (body, lists, etc.).
 

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -13,7 +13,25 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict
+
+try:
+    from typing import NotRequired  # Python 3.11+
+except ImportError:  # pragma: no cover - 3.10 fallback
+    from typing_extensions import NotRequired  # type: ignore[no-redef]
+
+
+class DDRepublishResult(TypedDict, total=False):
+    """Normalized envelope returned by :func:`_maybe_fire_dd_republish`.
+
+    Every code path returns this shape so callers can branch on
+    ``status`` without keying on ``KeyError``-prone optional fields.
+    """
+
+    status: str  # "skipped" | "fired" | "failed"
+    reason: str
+    dd_report_republish: NotRequired[str]
+    republish_reason: NotRequired[str]
 
 from .classifier import classify_document
 from .config import Settings
@@ -243,7 +261,8 @@ def _maybe_fire_dd_republish(
     doc_type: str,
     drive_file: dict[str, Any],
     dry_run: bool,
-) -> dict[str, Any]:
+    m1_folder_id: str | None = None,
+) -> DDRepublishResult:
     """Fire the shared DD Report republish callback for a vendor doc arrival.
 
     Builds the content fingerprint from the Drive file's
@@ -253,19 +272,41 @@ def _maybe_fire_dd_republish(
 
     Failures inside the callback are swallowed and surfaced into the
     returned dict so the inbox scan never breaks on a flaky republish.
+
+    All four return paths share the :class:`DDRepublishResult` envelope
+    shape (``status`` + ``reason`` + optional callback fields) so
+    callers can branch on ``status`` without keying on optional fields.
     """
+    from .provenance import is_vendor_sourced  # local import to avoid cycles
+
     reason = _INBOX_DOC_TYPE_TO_REPUBLISH_REASON.get(doc_type)
     if not reason:
-        return {"status": "skipped", "reason": f"doc_type {doc_type} not authoritative"}
+        return {
+            "status": "skipped",
+            "reason": f"doc_type {doc_type} not authoritative",
+        }
 
     file_id = str(drive_file.get("id", "")).strip()
     modified_time = str(drive_file.get("modifiedTime", "")).strip()
     if not file_id:
         return {"status": "skipped", "reason": "missing drive file id"}
+
+    # Provenance gate: only republish for vendor-sourced files. AI-named
+    # uploads (Greg's "I'll just rename it" path) bypass the vendor
+    # gate elsewhere but should never trigger a DD republish, since
+    # they aren't trusted authoritative inputs.
+    if not is_vendor_sourced(
+        drive_file,
+        gc=gc,
+        m1_folder_id=m1_folder_id,
+        doc_type=doc_type,
+    ):
+        return {"status": "skipped", "reason": "ai_named_skipped"}
+
     fingerprint = f"{file_id}:{modified_time}" if modified_time else file_id
 
     try:
-        return callback(
+        result = callback(
             gc=gc,
             site_summary=site_summary,
             reason=reason,
@@ -273,13 +314,20 @@ def _maybe_fire_dd_republish(
             dry_run=dry_run,
         )
     except Exception as e:
-        logger.error(
-            "DD Report republish callback raised for site=%s doc_type=%s: %s",
+        logger.exception(
+            "DD Report republish callback raised for site=%s doc_type=%s",
             site_summary.get("title"),
             doc_type,
-            e,
         )
-        return {"status": "failed", "error": str(e)}
+        return {"status": "failed", "reason": str(e)}
+
+    # Preserve every key the callback returned (dd_report_republish,
+    # republish_reason, site_id, content_fingerprint, doc_url, etc.)
+    # while normalizing status/reason on top.
+    fired: DDRepublishResult = {"status": "fired", "reason": "ok"}
+    if isinstance(result, dict):
+        fired.update(result)  # type: ignore[typeddict-item]
+    return fired
 
 
 def _run_block_plan_downstream(
@@ -829,6 +877,7 @@ def process_email(
                         doc_type=doc_type,
                         drive_file=drive_file,
                         dry_run=dry_run,
+                        m1_folder_id=target_folder_id,
                     )
                     if republish_result:
                         uploaded[-1]["dd_report_republish"] = republish_result

--- a/src/due_diligence_reporter/provenance.py
+++ b/src/due_diligence_reporter/provenance.py
@@ -381,10 +381,20 @@ def is_vendor_sourced(
     *,
     m1_folder_id: str | None = None,
     doc_type: str | None = None,
+    read_only: bool = False,
 ) -> bool:
-    """Return True iff the file is vendor-sourced (or unknown — see policy)."""
+    """Return True iff the file is vendor-sourced (or unknown — see policy).
+
+    ``read_only`` propagates through to :func:`classify_provenance` so
+    callers in observability/diagnostic contexts can probe provenance
+    without mutating the on-disk cache.
+    """
     return classify_provenance(
-        file_info, gc, m1_folder_id=m1_folder_id, doc_type=doc_type
+        file_info,
+        gc,
+        m1_folder_id=m1_folder_id,
+        doc_type=doc_type,
+        read_only=read_only,
     ).is_vendor
 
 

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -1105,8 +1105,10 @@ def _load_failure_state(path: Path) -> dict[str, dict[str, Any]]:
 
 def _save_failure_state(state: dict[str, dict[str, Any]], path: Path) -> None:
     """Persist a best-effort failure-state map. Logs but does not raise."""
+    from .dd_republish import atomic_write_json
+
     try:
-        path.write_text(json.dumps(state, sort_keys=True, indent=2), encoding="utf-8")
+        atomic_write_json(path, state)
     except Exception as e:
         logger.warning("Failed to write failure state at %s: %s", path, e)
 

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -2405,19 +2405,33 @@ def _find_existing_report_doc(
     gc: GoogleClient,
     *,
     folder_id: str,
-    doc_name: str,
+    site_name: str,
 ) -> dict[str, Any] | None:
-    """Return an existing same-name DD report in the site folder, if present."""
+    """Return an existing DD report Doc for *site_name* in the folder.
+
+    Matches by prefix ``"{site_name} DD Report - "`` so the cross-day
+    ``force_regenerate=True`` path can find yesterday's Doc and rename
+    it to today's date in place, rather than creating a duplicate Doc
+    per day. Returns the most recently modified match if multiple
+    exist (a one-off cleanup we accept for legacy folders).
+    """
     try:
         files = gc.list_files_in_folder(folder_id)
     except Exception as e:
         logger.warning("Could not list folder %s while checking for existing report: %s", folder_id, e)
         return None
 
+    prefix = f"{site_name.strip()} DD Report - "
+    candidate: dict[str, Any] | None = None
     for file_info in files:
-        if file_info.get("name") == doc_name:
-            return file_info
-    return None
+        name = str(file_info.get("name", ""))
+        if not name.startswith(prefix):
+            continue
+        if candidate is None or str(file_info.get("modifiedTime", "")) > str(
+            candidate.get("modifiedTime", "")
+        ):
+            candidate = file_info
+    return candidate
 
 
 def _fill_scenario_placeholders(
@@ -2759,7 +2773,9 @@ async def create_dd_report(
     def _work() -> dict[str, Any]:
         try:
             gc = _make_google_client()
-            existing_doc = _find_existing_report_doc(gc, folder_id=folder_id, doc_name=doc_name)
+            existing_doc = _find_existing_report_doc(
+                gc, folder_id=folder_id, site_name=site_name
+            )
             doc_id: str | None = None
             doc_url: str | None = None
             if existing_doc:
@@ -2768,6 +2784,22 @@ async def create_dd_report(
                     raise RuntimeError(f"Existing DD report is missing a valid document ID: {doc_name}")
                 doc_id = existing_doc_id
                 doc_url = existing_doc.get("webViewLink")
+                old_name = str(existing_doc.get("name", "")).strip()
+                if old_name and old_name != doc_name:
+                    # Cross-day regenerate: same site, different report-date suffix.
+                    # Rename in place so we never accumulate one Doc per day.
+                    logger.info(
+                        "Renaming existing DD Doc from %s to %s", old_name, doc_name
+                    )
+                    try:
+                        gc.rename_file(doc_id, doc_name)
+                    except Exception as rename_err:  # noqa: BLE001
+                        logger.warning(
+                            "Failed to rename DD Doc %s -> %s; continuing with stale name: %s",
+                            old_name,
+                            doc_name,
+                            rename_err,
+                        )
                 logger.info("Existing DD report found, rebuilding in place: %s (id=%s)", doc_name, doc_id)
                 _clear_document_body(gc, doc_id=doc_id)
             else:

--- a/tests/test_dd_republish.py
+++ b/tests/test_dd_republish.py
@@ -685,3 +685,39 @@ class TestRayConCompositeFingerprint:
         assert runner.call_count == 2
         # Two distinct keys recorded — one per arrival.
         assert len(state) == 2
+
+
+# ---------------------------------------------------------------------------
+# Legacy fingerprint migration dedup (Fix 9)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyFingerprintMigrationDedup:
+    """A migrated legacy entry (`{site}:raycon_scenario:{run_id}`) must
+    dedup against incoming live keys (`{site}:raycon_scenario:{run_id}:{drive_modified_time}`).
+
+    Pre-Rec.3, RayCon dedup keyed on `{site}:{run_id}`. ``load_state``
+    rewrites those into `{site}:raycon_scenario:{run_id}` (no drive
+    modified time suffix). Live callers now build a longer fingerprint;
+    without the prefix-match in ``maybe_republish_dd_report``, the
+    one-shot republish would re-fire after the cutover. This test
+    locks in the prefix-match behavior.
+    """
+
+    def test_legacy_entry_dedups_against_live_composite_key(self):
+        runner = _pipeline_runner_factory()
+        # Recent enough to be inside the force_after window.
+        recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        # Migrated legacy key — no `:drive_modified_time` suffix.
+        legacy_state = {"site-123:raycon_scenario:rc_run_abc": recent}
+
+        # Live caller's fingerprint includes drive_modified_time.
+        outcome = _call_helper(
+            reason=REASON_RAYCON,
+            fingerprint="rc_run_abc:2026-05-08T10:00:00Z",
+            state=legacy_state,
+            runner=runner,
+        )
+
+        assert outcome.decision == "skip_no_diff"
+        runner.assert_not_called()

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -1607,6 +1607,123 @@ class TestDDRepublishCallbackWiring:
         assert len(result["uploaded"]) == 1
         republish = result["uploaded"][0].get("dd_report_republish") or {}
         assert republish.get("status") == "failed"
-        assert "pipeline blew up" in republish.get("error", "")
+        # `reason` is the normalized envelope key (Fix 2).
+        assert "pipeline blew up" in republish.get("reason", "")
 
 
+
+
+# ---------------------------------------------------------------------------
+# _maybe_fire_dd_republish envelope shape (Fix 2)
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeFireDDRepublishEnvelopeShapes:
+    """All four return paths share the normalized DDRepublishResult shape."""
+
+    REQUIRED_KEYS = {"status", "reason"}
+    VALID_STATUSES = {"skipped", "fired", "failed"}
+
+    def _drive_file(self, **overrides):
+        base = {"id": "fid", "modifiedTime": "2026-05-08T10:00:00Z"}
+        base.update(overrides)
+        return base
+
+    def test_skipped_unrecognized_doc_type(self):
+        from due_diligence_reporter.inbox_scanner import _maybe_fire_dd_republish
+
+        result = _maybe_fire_dd_republish(
+            callback=MagicMock(),
+            gc=MagicMock(),
+            site_summary={"title": "S"},
+            doc_type="dashboard_aggregate",
+            drive_file=self._drive_file(),
+            dry_run=False,
+        )
+        assert self.REQUIRED_KEYS <= set(result.keys())
+        assert result["status"] == "skipped"
+        assert result["status"] in self.VALID_STATUSES
+
+    def test_skipped_missing_drive_file_id(self):
+        from due_diligence_reporter.inbox_scanner import _maybe_fire_dd_republish
+
+        result = _maybe_fire_dd_republish(
+            callback=MagicMock(),
+            gc=MagicMock(),
+            site_summary={"title": "S"},
+            doc_type="sir",
+            drive_file={"id": "", "modifiedTime": "t"},
+            dry_run=False,
+        )
+        assert self.REQUIRED_KEYS <= set(result.keys())
+        assert result["status"] == "skipped"
+
+    @patch("due_diligence_reporter.provenance.is_vendor_sourced", return_value=True)
+    def test_fired_callback_keys_preserved(self, _vendor):
+        from due_diligence_reporter.inbox_scanner import _maybe_fire_dd_republish
+
+        callback = MagicMock(
+            return_value={
+                "dd_report_republish": "republish",
+                "republish_reason": "vendor_sir",
+                "doc_url": "https://docs.google.com/x",
+            }
+        )
+        result = _maybe_fire_dd_republish(
+            callback=callback,
+            gc=MagicMock(),
+            site_summary={"title": "S"},
+            doc_type="sir",
+            drive_file=self._drive_file(),
+            dry_run=False,
+        )
+        assert self.REQUIRED_KEYS <= set(result.keys())
+        assert result["status"] == "fired"
+        # Callback fields must survive the wrap.
+        assert result.get("dd_report_republish") == "republish"
+        assert result.get("republish_reason") == "vendor_sir"
+        assert result.get("doc_url") == "https://docs.google.com/x"
+
+    @patch("due_diligence_reporter.provenance.is_vendor_sourced", return_value=True)
+    def test_failed_callback_normalized(self, _vendor):
+        from due_diligence_reporter.inbox_scanner import _maybe_fire_dd_republish
+
+        callback = MagicMock(side_effect=RuntimeError("kaboom"))
+        result = _maybe_fire_dd_republish(
+            callback=callback,
+            gc=MagicMock(),
+            site_summary={"title": "S"},
+            doc_type="sir",
+            drive_file=self._drive_file(),
+            dry_run=False,
+        )
+        assert self.REQUIRED_KEYS <= set(result.keys())
+        assert result["status"] == "failed"
+        assert "kaboom" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Provenance gate inside _maybe_fire_dd_republish (Fix 5)
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeFireDDRepublishProvenanceGate:
+    """AI-named files must be skipped before the callback fires."""
+
+    @patch("due_diligence_reporter.provenance.is_vendor_sourced", return_value=False)
+    def test_skips_ai_named(self, mock_is_vendor):
+        from due_diligence_reporter.inbox_scanner import _maybe_fire_dd_republish
+
+        callback = MagicMock()
+        result = _maybe_fire_dd_republish(
+            callback=callback,
+            gc=MagicMock(),
+            site_summary={"title": "S"},
+            doc_type="sir",
+            drive_file={"id": "fid", "modifiedTime": "t"},
+            dry_run=False,
+            m1_folder_id="m1_folder",
+        )
+        assert result == {"status": "skipped", "reason": "ai_named_skipped"}
+        callback.assert_not_called()
+        mock_is_vendor.assert_called_once()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -207,6 +207,42 @@ class TestContentTier:
         v = classify_provenance(None, gc=None)  # type: ignore[arg-type]
         assert v.provenance_classification_failed is False
 
+    def test_is_vendor_sourced_read_only_propagated(self):
+        """``read_only=True`` must suppress the cache write side effect."""
+        from due_diligence_reporter import provenance as prov
+
+        upload_calls: list[dict] = []
+
+        class FakeGC:
+            def list_files_in_folder(self, _id):
+                return []  # no existing cache file
+
+            def download_file_bytes(self, _id):
+                # Returning bytes triggers the Tier-2 path.
+                return b"Some vendor content"
+
+            def upload_file_to_folder(self, **kw):
+                upload_calls.append(kw)
+                return {"id": "cache"}
+
+        # Force a cacheable verdict (vendor, non-error tier) so the only
+        # reason _save_cache wouldn't be called is read_only=True.
+        with patch(
+            "due_diligence_reporter.provenance._classify_by_content"
+        ) as mock_content:
+            mock_content.return_value = prov.ProvenanceVerdict(
+                "vendor", 0.9, "content", "letterhead"
+            )
+            assert prov.is_vendor_sourced(
+                {"name": "Vendor.pdf", "id": "abc", "modifiedTime": "t1"},
+                gc=FakeGC(),
+                m1_folder_id="m1",
+                read_only=True,
+            )
+        assert upload_calls == [], (
+            "read_only=True must NOT write the provenance cache back to Drive"
+        )
+
     def test_cache_hit(self):
         cache_blob = (
             '{"abc": {"modifiedTime": "t1", "label": "vendor", '


### PR DESCRIPTION
## Summary

Fix-forward PR addressing /check Phase 4 findings on PRs #82-#91. Greg's "errors before merge candidate" rule: this is one PR with all P0+P1 fixes verified locally.

## Fixes

**P0 (must-include):**
1. **Cross-workflow cache key sharing** — Drop `${{ github.workflow }}` from `actions/cache` key/restore-keys in `raycon-followup.yml` and `inbox-scan.yml`. The state cache is now actually shared across workflows; the misleading inline comment is removed.
2. **`_maybe_fire_dd_republish` envelope normalization** — All four return paths now produce a single `DDRepublishResult` TypedDict shape (`status` + `reason` + optional callback fields). Callers branch on `status` without keying on optional fields.
3. **Silent-failure logger calls** — Replace 3× `logger.error(..., e)` with `logger.exception(...)` in `dd_republish.py:492`, `scripts/raycon_followup.py:745`, `inbox_scanner.py` republish path so tracebacks reach the log.

**P1:**
4. **Cross-day Doc duplication** — `_find_existing_report_doc` now matches by `"{site} DD Report - "` prefix; on cross-day match the existing Doc is renamed to today's filename and rebuilt in place (no more one-Doc-per-day dupes). New `GoogleClient.rename_file` helper added in the existing Drive client module.
5. **Provenance gate in inbox-scan republish** — `_maybe_fire_dd_republish` now calls `is_vendor_sourced` before firing the callback. AI-named uploads return `{"status": "skipped", "reason": "ai_named_skipped"}` and never trigger a republish.
6. **`is_vendor_sourced` `read_only` propagation** — Added `read_only: bool = False` kwarg propagated through to `classify_provenance` for diagnose/observability callers.
7. **`status` workflow input + arg validation** — `raycon-followup.yml` `status` is now `type: choice` (`succeeded|failed|partial`). `raycon_followup.py` adds `_validate_callback_input` (charset + length cap) for `--site-id`, `--run-id`, `--status`. Malformed values drop silently and the cron safety net picks up.
8. **Atomic `_save_failure_state`** — Extracted `atomic_write_json(path, data)` helper in `dd_republish.py`; `report_pipeline._save_failure_state` and `dd_republish.save_state` both use it now.
9. **Legacy fingerprint migration dedup** — `maybe_republish_dd_report` now checks for the legacy `{site}:raycon_scenario:{run_id}` key when the live composite key (with `:{drive_modified_time}` suffix) misses, so migrated legacy entries don't re-fire after the cutover.

## Testing

- `uv run pytest`: **1140 passed** (1133 pre-existing + 7 new).
- New tests added:
  - `test_inbox_scanner.py::TestMaybeFireDDRepublishEnvelopeShapes` (4 sub-tests covering all 4 return paths)
  - `test_inbox_scanner.py::TestMaybeFireDDRepublishProvenanceGate::test_skips_ai_named`
  - `test_dd_republish.py::TestLegacyFingerprintMigrationDedup::test_legacy_entry_dedups_against_live_composite_key`
  - `test_provenance.py::TestContentTier::test_is_vendor_sourced_read_only_propagated`
- YAML validated via `python -c "import yaml; yaml.safe_load(...)"` for both workflows.
- Verified no other callers of `_save_failure_state` or `is_vendor_sourced` regressed (default args preserve backwards compatibility).

## Test plan

- [ ] Re-run `/check` to confirm P0/P1 findings from Phase 4 are clear.
- [ ] Merge after Greg's review.
- [ ] Watch the next `inbox-scan` and `raycon-followup` runs to confirm the cache restore-keys land each other's saves.

All P0+P1 from /check Phase 4 — verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)