### PR TITLE
Fix vendor gate incomplete reason

### DIFF
--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -1216,6 +1216,7 @@ def _check_generated_report(
         doc_id=doc_id,
         doc_url=doc_url,
         unresolved_tokens=completeness.get("unresolved_tokens", []),
+        error=str(completeness.get("summary") or completeness.get("message") or ""),
     )
 
 
@@ -1385,15 +1386,16 @@ def process_site_pipeline(
             _vendor_gate_enabled()
             and completeness_result.status == "report_incomplete"
         ):
+            failure_reason = completeness_result.error or (
+                "Report generated but "
+                f"{len(completeness_result.unresolved_tokens)} tokens "
+                "unresolved"
+            )
             _notify_vendor_gate_extraction_failure(
                 settings.google_chat_webhook_url,
                 site_title,
                 drive_folder_url=drive_folder_url,
-                failure_reason=(
-                    "Report generated but "
-                    f"{len(completeness_result.unresolved_tokens)} tokens "
-                    "unresolved"
-                ),
+                failure_reason=failure_reason,
                 trace_url=trace_url or "",
             )
         # Publish partial data to the dashboard with dd_status="in_progress"
@@ -1575,11 +1577,18 @@ def post_pipeline_result(
     elif result.status == "report_incomplete":
         count = len(result.unresolved_tokens)
         tokens = ", ".join(result.unresolved_tokens[:10])
-        msg = (
-            f"DD Report for {result.site_title} has {count} unfilled placeholder(s).\n"
-            f"Tokens: {tokens}\n"
-            f"Report: {result.doc_url or '(no URL)'}"
-        )
+        if result.error:
+            msg = (
+                f"DD Report for {result.site_title} is incomplete.\n"
+                f"Reason: {result.error}\n"
+                f"Report: {result.doc_url or '(no URL)'}"
+            )
+        else:
+            msg = (
+                f"DD Report for {result.site_title} has {count} unfilled placeholder(s).\n"
+                f"Tokens: {tokens}\n"
+                f"Report: {result.doc_url or '(no URL)'}"
+            )
 
     elif result.status == "generation_failed":
         msg = (

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -438,6 +438,7 @@ class TestProcessSitePipeline:
 
         assert result.status == "report_incomplete"
         assert result.doc_id == "doc123"
+        assert result.error == "Report NOT ready to send. 1 raw template token(s)."
         # The HTTP publish must fire on the incomplete branch.
         mock_publish.assert_called_once()
         kwargs = mock_publish.call_args.kwargs
@@ -449,6 +450,83 @@ class TestProcessSitePipeline:
         positional = mock_publish.call_args.args
         assert positional[0] == "Alpha Keller"
         assert positional[1] == trace.final_report_data
+
+    @patch("due_diligence_reporter.report_pipeline.post_google_chat_message")
+    @patch("due_diligence_reporter.report_pipeline._save_pipeline_trace")
+    @patch("due_diligence_reporter.report_pipeline.publish_to_dashboard")
+    @patch("due_diligence_reporter.server.check_report_completeness")
+    @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
+    @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
+    def test_vendor_gate_alert_uses_completeness_summary(
+        self,
+        mock_readiness,
+        mock_agent,
+        mock_completeness,
+        mock_publish,
+        mock_save_trace,
+        mock_chat,
+        monkeypatch,
+    ):
+        """Vendor-gate alerts should explain the real completeness failure.
+
+        A report can fail completeness with zero unresolved {{...}} tokens
+        when raw template tokens leak or the Can-We-Open answer is invalid.
+        """
+        monkeypatch.setenv("VENDOR_GATE_ENABLED", "1")
+        mock_readiness.return_value = {
+            "sir_found": True,
+            "sir_vendor": True,
+            "isp_found": False,
+            "inspection_found": True,
+            "inspection_vendor": True,
+            "raycon_scenario_found": True,
+            "report_exists": False,
+        }
+        mock_save_trace.return_value = "https://drive.google.com/trace"
+        mock_agent.return_value = {
+            "success": True,
+            "doc_id": "doc123",
+            "doc_url": "https://docs.google.com/document/d/doc123",
+            "trace": ReportTrace(
+                site_name="Alpha Tulsa 421 E 11th St",
+                started_at="2026-05-13T15:53:12+00:00",
+                events=[],
+                final_report_data={"exec.c_answer": "Yes"},
+            ),
+        }
+
+        async def fake_completeness(doc_id):
+            return {
+                "ready_to_send": False,
+                "unresolved_token_count": 0,
+                "unresolved_tokens": [],
+                "raw_template_token_count": 1,
+                "raw_template_tokens": ["INSERT_ANSWER"],
+                "pending_section_count": 0,
+                "summary": "Report NOT ready to send. 1 raw template token(s).",
+            }
+
+        mock_completeness.side_effect = fake_completeness
+        mock_publish.return_value = True
+        settings = _make_settings()
+        settings.google_chat_webhook_url = "https://chat.example/webhook"
+
+        result = process_site_pipeline(
+            MagicMock(),
+            "Alpha Tulsa 421 E 11th St",
+            "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Tulsa 421 E 11th St"],
+            {},
+            "system prompt",
+            settings,
+        )
+
+        assert result.status == "report_incomplete"
+        mock_chat.assert_called()
+        messages = [call.args[1] for call in mock_chat.call_args_list]
+        vendor_message = next(m for m in messages if "Human Intervention Needed" in m)
+        assert "Reason: Report NOT ready to send. 1 raw template token(s)." in vendor_message
+        assert "0 tokens unresolved" not in vendor_message
 
     @patch("due_diligence_reporter.report_pipeline.publish_to_dashboard")
     @patch("due_diligence_reporter.server.check_report_completeness")


### PR DESCRIPTION
Summary
- Preserve completeness summaries on incomplete pipeline results.
- Use the real completeness failure in vendor-gate and report-incomplete Chat alerts.
- Add regression coverage for reports with zero unresolved placeholders but leaked raw template tokens.

Test plan
- uv run pytest tests/test_report_pipeline.py::TestProcessSitePipeline::test_report_incomplete_still_publishes_to_dashboard_in_progress tests/test_report_pipeline.py::TestProcessSitePipeline::test_vendor_gate_alert_uses_completeness_summary -q
- uv run ruff check src/due_diligence_reporter/report_pipeline.py tests/test_report_pipeline.py