### PR TITLE
Retry stale failed RayCon scenarios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ RAYCON_WEBHOOK_SECRET=
 # which is gated by RAYCON_REQUIRE_FIREBASE_AUTH=true on RayCon's side
 # (currently disabled). Leave blank in production.
 RAYCON_API_KEY=
-# RAYCON_JOBS_URL defaults to https://raycon-api-dkxp2hji2q-uc.a.run.app/v1/jobs (optional override)
+# RAYCON_JOBS_URL defaults to https://raycon-api-738625530258.us-central1.run.app/v1/jobs (optional override)
 
 # Shovels.ai permit history API — DEPRECATED for DDR.
 #

--- a/.github/workflows/raycon-followup.yml
+++ b/.github/workflows/raycon-followup.yml
@@ -108,6 +108,20 @@ jobs:
           restore-keys: |
             dd-republish-state-
 
+      - name: Restore RayCon runtime state
+        # Persists dispatch and alert dedup state across cron ticks.
+        # Without this, failed-scenario retries and Chat alert suppression
+        # reset on every clean Actions checkout.
+        id: restore-raycon-runtime-state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .raycon_dispatch_state.json
+            .raycon_followup_alerts.json
+          key: raycon-runtime-state-${{ github.run_id }}
+          restore-keys: |
+            raycon-runtime-state-
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -240,6 +254,17 @@ jobs:
         with:
           path: .dd_republish_state.json
           key: dd-republish-state-${{ github.run_id }}
+
+      - name: Save RayCon runtime state
+        # Always run so recovery dispatches and alert suppression survive
+        # the next scheduled checkout.
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .raycon_dispatch_state.json
+            .raycon_followup_alerts.json
+          key: raycon-runtime-state-${{ github.run_id }}
 
       - name: Done
         run: echo "RayCon follow-up completed"

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -48,7 +48,7 @@ import json
 import logging
 import re
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -66,8 +66,12 @@ from due_diligence_reporter.dd_republish import (  # noqa: E402
     DD_REPUBLISH_STATE_PATH,
     REASON_RAYCON,
     find_existing_dd_report,
-    load_state as _load_dd_republish_state_shared,
     maybe_republish_dd_report,
+)
+from due_diligence_reporter.dd_republish import (  # noqa: E402
+    load_state as _load_dd_republish_state_shared,
+)
+from due_diligence_reporter.dd_republish import (  # noqa: E402
     save_state as _save_dd_republish_state_shared,
 )
 from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
@@ -287,7 +291,7 @@ def _filter_dedup_alerts(
     The updated state records ``now`` as the last-alert time for every site we
     are about to notify on, so the next run within the window is suppressed.
     """
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     fresh: list[dict[str, Any]] = []
     new_state = dict(state)
     for row in alerts:
@@ -367,7 +371,7 @@ def _dispatch_raycon_job(
     dispatch so the caller can persist the updated map at the end of the
     run. On error or skip, ``dispatch_state`` is left untouched.
     """
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     site_name = str(site_summary.get("title", "")).strip() or "(unnamed)"
     block_plan_file_id = str(block_plan.get("id", "")).strip()
     block_plan_url = str(
@@ -519,6 +523,112 @@ def _poll_dispatch_state_status(
     return {"status": status, "status_response": status_response}
 
 
+def _failed_scenario_base_row(
+    site_name: str,
+    scenario: dict[str, Any],
+    report_fields: dict[str, str],
+) -> dict[str, Any]:
+    reason = report_fields.get("exec.raycon_failure_reason", "") or "unspecified"
+    return {
+        "site": site_name,
+        "alert": f"raycon run failed: {reason}",
+        "raycon_status": report_fields.get("exec.raycon_status", ""),
+        "raycon_run_id": report_fields.get("exec.raycon_run_id", ""),
+        "json_modified": scenario.get("_drive_modified_time", ""),
+    }
+
+
+def _failed_scenario_dispatch_row(
+    site_name: str,
+    reason: str,
+    dispatch_result: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "site": site_name,
+        "dispatched": True,
+        "dispatch_reason": "failed_scenario_retry",
+        "previous_failure": reason,
+        "job_id": dispatch_result.get("job_id"),
+        "raycon_run_id": dispatch_result.get("raycon_run_id"),
+        "status": dispatch_result.get("status"),
+        "status_url_present": dispatch_result.get("status_url_present"),
+        "block_plan_file_id": dispatch_result.get("block_plan_file_id"),
+    }
+
+
+def _failed_scenario_status_row(
+    site_name: str,
+    block_plan_file_id: str,
+    base_row: dict[str, Any],
+    status: str,
+) -> dict[str, Any] | None:
+    if status in RAYCON_IN_PROGRESS_STATUSES:
+        return {
+            "site": site_name,
+            "skipped": f"raycon recovery job {status}",
+            "block_plan_file_id": block_plan_file_id,
+            "raycon_run_id": base_row["raycon_run_id"],
+            "json_modified": base_row["json_modified"],
+        }
+    if status == "completed":
+        return {
+            **base_row,
+            "alert": (
+                "raycon recovery completed but failed raycon_scenario.json "
+                "is still visible in M1"
+            ),
+            "block_plan_file_id": block_plan_file_id,
+        }
+    return None
+
+
+def _handle_failed_scenario(
+    site_summary: dict[str, Any],
+    site_name: str,
+    block_plan: dict[str, Any],
+    m1_folder_id: str,
+    scenario: dict[str, Any],
+    report_fields: dict[str, str],
+    *,
+    dispatch_state: dict[str, dict[str, Any]] | None,
+    dry_run: bool,
+    redispatch_after: timedelta,
+) -> dict[str, Any]:
+    base_row = _failed_scenario_base_row(site_name, scenario, report_fields)
+    reason = base_row["alert"].removeprefix("raycon run failed: ")
+    block_plan_file_id = str(block_plan.get("id", "")).strip()
+    if dispatch_state is None or not block_plan_file_id:
+        return base_row
+
+    status_result = _poll_dispatch_state_status(block_plan_file_id, dispatch_state)
+    status = str(status_result.get("status", "") or "").strip().lower()
+    status_row = _failed_scenario_status_row(
+        site_name, block_plan_file_id, base_row, status
+    )
+    if status_row is not None:
+        return status_row
+
+    dispatch_result = _dispatch_raycon_job(
+        site_summary,
+        block_plan,
+        m1_folder_id,
+        dispatch_state,
+        dry_run=dry_run,
+        redispatch_after=redispatch_after,
+    )
+    if dispatch_result.get("dispatched"):
+        return _failed_scenario_dispatch_row(site_name, reason, dispatch_result)
+    if dispatch_result.get("dispatch_error"):
+        return {
+            "site": site_name,
+            "error": f"raycon failed-scenario retry: {dispatch_result['dispatch_error']}",
+            "previous_failure": reason,
+        }
+    if dispatch_result.get("dispatch_skipped"):
+        base_row["dispatch_skipped"] = dispatch_result.get("dispatch_skipped")
+    return base_row
+
+
 def _find_existing_dd_report(
     gc: GoogleClient, site_folder_id: str
 ) -> dict[str, Any] | None:
@@ -559,7 +669,7 @@ def _republish_dd_report_if_present(
     publish has already succeeded by the time we get here, and a
     republish error should not undo that.
     """
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
 
     # Composite fingerprint mirrors the SIR/BI shape (file_id:modifiedTime).
     # If RayCon recomputes the same run_id but writes fresh content (new
@@ -683,7 +793,7 @@ def _process_site(
         return {"site": site_name, "error": f"schema error: {e}"}
 
     if scenario is None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         bp_modified = _parse_iso(str(block_plan.get("modifiedTime", "")))
         is_stuck = (
             bp_modified is not None and (now - bp_modified) > alert_after
@@ -781,14 +891,17 @@ def _process_site(
     # so EDU Ops sees it in Chat and we don't pollute the site's M1 folder.
     if raycon_payload_failed(scenario):
         report_fields = raycon_scenario_to_report_fields(scenario)
-        reason = report_fields.get("exec.raycon_failure_reason", "") or "unspecified"
-        return {
-            "site": site_name,
-            "alert": f"raycon run failed: {reason}",
-            "raycon_status": report_fields.get("exec.raycon_status", ""),
-            "raycon_run_id": report_fields.get("exec.raycon_run_id", ""),
-            "json_modified": scenario.get("_drive_modified_time", ""),
-        }
+        return _handle_failed_scenario(
+            site_summary,
+            site_name,
+            block_plan,
+            m1_folder_id,
+            scenario,
+            report_fields,
+            dispatch_state=dispatch_state,
+            dry_run=dry_run,
+            redispatch_after=redispatch_after,
+        )
 
     # Scenario JSON is here and the run succeeded — publish the report
     # Doc if missing or stale.

--- a/src/due_diligence_reporter/config.py
+++ b/src/due_diligence_reporter/config.py
@@ -112,7 +112,7 @@ class Settings(BaseSettings):
     # RayCon async hand-off (inbox scanner pings RayCon when a Block Plan
     # lands; RayCon writes raycon_scenario.json into the site's M1 folder).
     raycon_jobs_url: str = Field(
-        "https://raycon-api-dkxp2hji2q-uc.a.run.app/v1/jobs",
+        "https://raycon-api-738625530258.us-central1.run.app/v1/jobs",
         description="Endpoint that accepts RayCon scenario job requests.",
     )
     raycon_api_key: str = Field(

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -7,7 +7,7 @@ Google client, Wrike, and ``save_skill_report``.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from scripts.raycon_followup import (
@@ -16,7 +16,6 @@ from scripts.raycon_followup import (
     _process_site,
     _republish_dd_report_if_present,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -35,7 +34,7 @@ def _site(title: str = "Alpha Keller") -> dict:
 
 def _block_plan(modified_minutes_ago: int = 5) -> dict:
     """Fake Drive file dict for a Block Plan PDF."""
-    when = datetime.now(timezone.utc) - timedelta(minutes=modified_minutes_ago)
+    when = datetime.now(UTC) - timedelta(minutes=modified_minutes_ago)
     return {
         "id": "bp_file_1",
         "name": "Block Plan v3.pdf",
@@ -49,7 +48,7 @@ def _scenario_payload(json_modified: str | None = None) -> dict:
         "site_id": "S1",
         "scenarios": [{"name": "fastest_open"}],
         "_drive_modified_time": json_modified
-        or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
     }
 
 
@@ -79,7 +78,7 @@ class TestProcessSite:
 
         # Pre-populate dispatch state so we suppress this run's dispatch and
         # exercise the original alert path.
-        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        recent = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
         dispatch_state = {
             "bp_file_1": {"last_dispatch": recent, "count": 1, "site": "Alpha Keller"}
         }
@@ -263,6 +262,104 @@ class TestFailedScenarioAlerts:
         # Critical: no Doc published for a failed run.
         mock_save.assert_not_called()
         assert "published" not in row
+
+    @patch("scripts.raycon_followup.post_raycon_job")
+    @patch("scripts.raycon_followup.save_skill_report")
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_failed_status_dispatches_recovery_when_state_is_available(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+        mock_save,
+        mock_post,
+    ):
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        mock_read_scenario.return_value = {
+            "schema_version": "1.0",
+            "status": "failed",
+            "raycon_run_id": "rc_old",
+            "validation": {
+                "passed": False,
+                "errors": [
+                    "Real estate spreadsheet did not resolve a usable microschool tier"
+                ],
+            },
+            "_drive_modified_time": "2026-05-05T21:18:26Z",
+        }
+        mock_post.return_value = {
+            "status": "queued",
+            "job_id": "job-retry",
+            "raycon_run_id": None,
+            "idempotency_key": "block_plan|site-123|bp_file_1",
+            "retry_after_seconds": 30,
+            "status_url": "https://raycon.test/v1/jobs/status/job-retry?token=opaque",
+            "cached": False,
+        }
+
+        dispatch_state: dict = {}
+        row = _process_site(
+            MagicMock(),
+            _site(),
+            dry_run=False,
+            alert_after=timedelta(minutes=60),
+            dispatch_state=dispatch_state,
+            redispatch_after=timedelta(minutes=30),
+        )
+
+        assert row["dispatched"] is True
+        assert row["dispatch_reason"] == "failed_scenario_retry"
+        assert "microschool tier" in row["previous_failure"]
+        assert row["job_id"] == "job-retry"
+        assert dispatch_state["bp_file_1"]["job_id"] == "job-retry"
+        mock_post.assert_called_once()
+        mock_save.assert_not_called()
+
+    @patch("scripts.raycon_followup.post_raycon_job")
+    @patch("scripts.raycon_followup.read_raycon_scenario_from_m1")
+    @patch("scripts.raycon_followup._find_block_plan")
+    @patch("scripts.raycon_followup._resolve_m1_folder")
+    def test_failed_status_respects_recent_recovery_dispatch(
+        self,
+        mock_resolve,
+        mock_find_bp,
+        mock_read_scenario,
+        mock_post,
+    ):
+        mock_resolve.return_value = ("m1_folder_id", "M1")
+        mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
+        mock_read_scenario.return_value = {
+            "schema_version": "1.0",
+            "status": "failed",
+            "raycon_run_id": "rc_old",
+            "validation": {"passed": False, "errors": ["no_address_match"]},
+            "_drive_modified_time": "2026-05-05T21:18:26Z",
+        }
+        recent = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        dispatch_state = {
+            "bp_file_1": {
+                "last_dispatch": recent,
+                "count": 1,
+                "site": "Alpha Keller",
+                "raycon_run_id": "rc_retry",
+            }
+        }
+
+        row = _process_site(
+            MagicMock(),
+            _site(),
+            dry_run=False,
+            alert_after=timedelta(minutes=60),
+            dispatch_state=dispatch_state,
+            redispatch_after=timedelta(minutes=30),
+        )
+
+        assert "raycon run failed" in row["alert"]
+        assert row["dispatch_skipped"] == "recently dispatched"
+        mock_post.assert_not_called()
 
     @patch("scripts.raycon_followup.save_skill_report")
     @patch("scripts.raycon_followup._find_published_doc")
@@ -561,7 +658,7 @@ class TestSafetyNetDispatch:
         mock_find_bp.return_value = _block_plan(modified_minutes_ago=5)
         mock_read_scenario.return_value = None
 
-        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        recent = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
         dispatch_state = {
             "bp_file_1": {
                 "last_dispatch": recent,
@@ -610,7 +707,7 @@ class TestSafetyNetDispatch:
             "status": "accepted",
         }
 
-        old = (datetime.now(timezone.utc) - timedelta(minutes=45)).isoformat()
+        old = (datetime.now(UTC) - timedelta(minutes=45)).isoformat()
         dispatch_state = {
             "bp_file_1": {
                 "last_dispatch": old,
@@ -736,7 +833,7 @@ class TestSafetyNetDispatch:
 
 class TestFilterDedupAlerts:
     def test_first_alert_passes_through_and_state_updated(self):
-        now = datetime(2026, 4, 30, 15, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 30, 15, 0, tzinfo=UTC)
         alerts = [{"site": "Alpha Keller", "alert": "no scenario after 1:00:00"}]
 
         fresh, new_state = _filter_dedup_alerts(alerts, {}, now=now)
@@ -746,7 +843,7 @@ class TestFilterDedupAlerts:
         assert new_state["Alpha Keller"] == now.isoformat()
 
     def test_recent_alert_is_suppressed(self):
-        now = datetime(2026, 4, 30, 15, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 30, 15, 0, tzinfo=UTC)
         recent = (now - timedelta(hours=2)).isoformat()
         alerts = [{"site": "Alpha Keller", "alert": "stuck"}]
 
@@ -759,7 +856,7 @@ class TestFilterDedupAlerts:
         assert new_state["Alpha Keller"] == recent
 
     def test_old_alert_outside_window_passes_through(self):
-        now = datetime(2026, 4, 30, 15, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 30, 15, 0, tzinfo=UTC)
         old = (now - timedelta(hours=25)).isoformat()
         alerts = [{"site": "Alpha Keller", "alert": "stuck"}]
 
@@ -852,7 +949,7 @@ class TestDDReportRepublish:
             "id": "dd1",
             "name": "Alpha Keller DD Report - 2026-05-01",
         }
-        recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
         republish_state = {"site-123:raycon_scenario:rc_run_abc": recent}
 
         gc = MagicMock()


### PR DESCRIPTION
## Summary
- Redispatch failed RayCon scenario JSONs when dispatch state is available, so stale terminal failures do not block fixed RayCon reruns forever.
- Persist RayCon dispatch and alert runtime state across scheduled follow-up workflow runs.
- Update the default RayCon jobs endpoint to the current production URL.

## Test plan
- uv run ruff check scripts/raycon_followup.py tests/test_raycon_followup.py src/due_diligence_reporter/config.py
- uv run pytest tests/test_raycon_followup.py tests/test_raycon_client.py -q