### PR TITLE
Add SIR learning loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,10 @@ oauth_response.json
 .ruff_cache/
 .mypy_cache/
 pytest-cache-files-*/
+.pytest-tmp/
 tests/_tmp/
 _tmp_report/
+.ddr-runs/
 
 # OS
 .DS_Store

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -246,6 +246,17 @@ inbox scanner, classifier, and folder pings to RayCon, and `isp_found`
 is still surfaced in the readiness payload as informational — but
 report generation no longer waits on it.
 
+### SIR Learning Loop
+
+Readiness also records non-blocking SIR comparison metadata. When both an
+AI-generated SIR and a CDS/vendor SIR are present, the pipeline writes a
+`sir.learning_review` step with status `ready_for_review`. Missing pairs are
+recorded as `waiting_for_cds_sir`, `waiting_for_ai_sir`, or `not_applicable`.
+
+This does not change report readiness. It makes recent AI/CDS SIR pairs visible
+in the run manifest, Google Chat observability lines, and `ddr status` so the
+team can run the review process in `docs/process/sir-learning-loop.md`.
+
 ---
 
 ## Step-by-Step Workflow
@@ -282,9 +293,10 @@ report generation no longer waits on it.
 1. Searches shared Drive folders for SIR, ISP, and Building Inspection using site match terms
 2. Falls back to recursive site folder search with three-tier classification
 3. Checks if a DD report already exists
-4. Returns presence booleans, file metadata, and missing doc list
+4. Records SIR learning-review state when AI/CDS SIR candidates are present
+5. Returns presence booleans, file metadata, review metadata, and missing doc list
 
-**Output:** `sir_found`, `isp_found`, `inspection_found`, `report_exists`, `files` dict with `name`/`id`/`webViewLink` per doc type, `missing_docs` list, `p1_assignee_name`, `p1_assignee_email`.
+**Output:** `sir_found`, `isp_found`, `inspection_found`, `report_exists`, `sir_learning_review`, `files` dict with `name`/`id`/`webViewLink` per doc type, `missing_docs` list, `p1_assignee_name`, `p1_assignee_email`.
 
 ---
 

--- a/docs/process/dd-end-to-end-flow.mmd
+++ b/docs/process/dd-end-to-end-flow.mmd
@@ -33,6 +33,7 @@ flowchart TD
     subgraph Pipeline["B. Shared DD report pipeline"]
         P0["Call process_site_pipeline()"]
         P1["Readiness check:<br/>match shared-folder source docs by site terms<br/>scan site folder recursively for AI-generated artifacts only"]
+        P1A["Record SIR learning-review state:<br/>AI SIR vs CDS/vendor SIR candidate<br/>non-blocking manifest step"]
         P2{"Required docs present?<br/>Current gate = SIR + Building Inspection"}
         P3["Status: waiting_on_docs<br/>post Google Chat result"]
         P4{"DD report already exists?"}
@@ -88,7 +89,7 @@ flowchart TD
     A3 --> D2["Select one site<br/>load prompt and build match terms"]
     D2 --> P0
 
-    P0 --> P1 --> P2
+    P0 --> P1 --> P1A --> P2
     P2 -- No --> P3
     P2 -- Yes --> P4
     P4 -- Yes --> P5
@@ -114,7 +115,7 @@ flowchart TD
     classDef alert fill:#fbe8e8,stroke:#a02d2d,color:#531616;
 
     class A1,A2,A3 trigger;
-    class I1,I6,I7,I13,I14,I15,I16,I17,I18,I20,D1,D2,P0,P1,P6,P7,P9,P10,P11,P13,P15,P17,P19,P20,P23,P24 process;
+    class I1,I6,I7,I13,I14,I15,I16,I17,I18,I20,D1,D2,P0,P1,P1A,P6,P7,P9,P10,P11,P13,P15,P17,P19,P20,P23,P24 process;
     class I2,I4,I8,I10,I12,I19,P2,P4,P8,P12,P14,P18,P21 decision;
     class I3,I9,I21,P5,P25 output;
     class I5,I11,P3,P16,P22 alert;

--- a/docs/process/sir-learning-loop.md
+++ b/docs/process/sir-learning-loop.md
@@ -1,0 +1,87 @@
+# SIR Learning Loop
+
+## Purpose
+
+Compare recent AI SIRs against CDS/vendor SIRs, then feed the verified gaps
+back into the SIR and DDR pipeline. The comparison is not AI versus CDS as a
+winner-take-all exercise. It is AI SIR versus CDS/vendor SIR versus evidence.
+
+## Batch Review Process
+
+1. Select recent sites where both an AI SIR and a CDS/vendor SIR exist.
+2. Review the pair section by section against source evidence.
+3. Tag every material difference with one primary category:
+   - AI missed item
+   - CDS missed item
+   - AI unsupported claim
+   - CDS unsupported claim
+   - Better wording needed
+   - Template or prompt gap
+   - Source retrieval gap
+4. Decide whether the difference affects opening risk, permit path, cost, or
+   DDR token output.
+5. Convert accepted findings into one or more learning outputs:
+   - SIR prompt update
+   - Source retrieval rule
+   - SIR template change
+   - DDR prompt or token mapping change
+   - QC checklist item
+
+## Review Table
+
+Use one row per issue, not one row per section.
+
+| Field | Meaning |
+|---|---|
+| Site | Wrike site title |
+| AI SIR | Link or file ID |
+| CDS/vendor SIR | Link or file ID |
+| Section | SIR section or DDR token area |
+| AI finding | What the AI SIR said or missed |
+| CDS finding | What CDS/vendor said or missed |
+| Evidence checked | Source used to adjudicate the difference |
+| Gap category | One of the standard tags above |
+| Severity | Blocking, material, cleanup |
+| DDR impact | Token, prompt, trace, dashboard, or none |
+| Learning action | Concrete change to make |
+| Owner | Person or system owner |
+| Status | Open, accepted, implemented, rejected |
+
+## Pipeline Hook
+
+`check_site_readiness_direct()` now emits `sir_learning_review` metadata when it
+sees SIR candidates. `process_site_pipeline()` records a non-blocking
+`sir.learning_review` manifest step:
+
+- `ready_for_review`: both AI SIR and CDS/vendor SIR are present.
+- `waiting_for_cds_sir`: AI SIR exists, CDS/vendor SIR is not present yet.
+- `waiting_for_ai_sir`: CDS/vendor SIR exists, AI SIR is not present yet.
+- `not_applicable`: no usable SIR comparison candidate exists.
+
+The step is observable in the local run manifest, uploaded manifest, Google
+Chat pipeline lines, and `ddr status --run-id ...`.
+
+## Fit With DDR Improvements
+
+This loop plugs into the broader DDR quality work from the run manifest effort:
+
+- The manifest tells us which sites are review-ready.
+- The comparison identifies whether the root problem is source retrieval,
+  SIR generation, CDS/vendor interpretation, or DDR synthesis.
+- DDR changes should only come from adjudicated findings, not from raw
+  disagreement between two documents.
+- When a finding affects DDR output, update the narrowest layer that owns the
+  issue: retrieval first, SIR prompt/template second, DDR prompt/token mapping
+  third, dashboard presentation last.
+
+## Operating Cadence
+
+Run a weekly sample of recent review-ready sites until the gap rate stabilizes.
+Track:
+
+- number of SIR pairs reviewed
+- AI missed items per SIR
+- unsupported AI claims per SIR
+- CDS/vendor corrections that changed DDR output
+- learning actions implemented
+- repeat issues after implementation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 
 [project.scripts]
 due-diligence-reporter-mcp = "due_diligence_reporter.server:main"
+ddr = "due_diligence_reporter.ddr_cli:main"
 
 [tool.ruff]
 line-length = 100

--- a/scripts/daily_dd_check.py
+++ b/scripts/daily_dd_check.py
@@ -18,6 +18,7 @@ Environment (from .env):
     EMAIL_SENDER, EMAIL_APP_PASSWORD, DD_TEMPLATE_V3_GOOGLE_DOC_ID,
     GOOGLE_DRIVE_ROOT_FOLDER_ID, OPENAI_API_KEY
 """
+# ruff: noqa: E402, I001
 
 from __future__ import annotations
 
@@ -170,6 +171,14 @@ def main(site_filter: str | None = None) -> None:
             print(f"  [XX] {r.site_title} -- generation failed: {r.error}")
         else:
             print(f"  [??] {r.site_title} -- {r.status}")
+        if r.run_id:
+            print(
+                "       "
+                f"run_id={r.run_id} "
+                f"failed_step={r.failed_step or '-'} "
+                f"quality={r.quality_score}/{r.quality_band or '-'} "
+                f"manifest={r.manifest_path or '-'}"
+            )
     print("=" * 60)
 
 

--- a/scripts/scan_inbox.py
+++ b/scripts/scan_inbox.py
@@ -22,6 +22,7 @@ Environment (from .env):
     DD_TEMPLATE_V3_GOOGLE_DOC_ID, GOOGLE_DRIVE_ROOT_FOLDER_ID,
     EMAIL_SENDER, EMAIL_APP_PASSWORD, DD_REPORT_EMAIL_RECIPIENTS
 """
+# ruff: noqa: E402, I001
 
 from __future__ import annotations
 
@@ -38,6 +39,9 @@ from dotenv import load_dotenv  # noqa: E402
 
 load_dotenv(_project_root / ".env")
 
+from due_diligence_reporter.cds_verification import (  # noqa: E402
+    generate_cds_verification_report,
+)
 from due_diligence_reporter.config import get_settings  # noqa: E402
 from due_diligence_reporter.dd_republish import (  # noqa: E402
     load_state as _load_dd_republish_state,
@@ -55,9 +59,6 @@ from due_diligence_reporter.report_pipeline import (  # noqa: E402
     post_pipeline_result,
     process_site_pipeline,
 )
-from due_diligence_reporter.cds_verification import (  # noqa: E402
-    generate_cds_verification_report,
-)
 from due_diligence_reporter.utils import (  # noqa: E402
     build_site_match_terms as _build_site_match_terms,
     escape_html_text,
@@ -70,11 +71,11 @@ from due_diligence_reporter.wrike import (  # noqa: E402
     _get_active_status_ids,
     _get_all_site_records,
     extract_address_from_record,
-    extract_school_feasibility_from_record,
-    extract_timeline_confidence_from_record,
     extract_google_folder_from_record,
     extract_p1_email_from_record,
     extract_p1_from_record,
+    extract_school_feasibility_from_record,
+    extract_timeline_confidence_from_record,
     filter_active_site_records,
     load_wrike_config,
 )
@@ -434,6 +435,14 @@ for you to fill in: CDS Verified Finding, CDS Source, and CDS Confidence.</p>
 
         # Print result
         print(f"  Pipeline: {site_title} -> {result.status}")
+        if result.run_id:
+            print(
+                "    "
+                f"run_id={result.run_id} "
+                f"failed_step={result.failed_step or '-'} "
+                f"quality={result.quality_score}/{result.quality_band or '-'} "
+                f"manifest={result.manifest_path or '-'}"
+            )
         if result.missing_docs:
             print(f"    Missing: {', '.join(result.missing_docs)}")
         if result.doc_url:

--- a/src/due_diligence_reporter/ddr_cli.py
+++ b/src/due_diligence_reporter/ddr_cli.py
@@ -1,0 +1,74 @@
+"""Operator CLI for DD pipeline manifests."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from .pipeline_manifest import load_run_manifest
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="ddr", description="Inspect DD pipeline runs")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser("status", help="Show one run status")
+    status_parser.add_argument("--run-id", required=True)
+
+    trace_parser = subparsers.add_parser("trace", help="Show one run trace")
+    trace_parser.add_argument("--run-id", required=True)
+    trace_parser.add_argument("--failed-only", action="store_true")
+
+    rerun_parser = subparsers.add_parser("rerun", help="Print the step rerun command")
+    rerun_parser.add_argument("--run-id", required=True)
+    rerun_parser.add_argument("--step", required=True)
+
+    diagnose_parser = subparsers.add_parser("diagnose", help="Print diagnostic command")
+    diagnose_parser.add_argument("--site", required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "status":
+        _print_status(load_run_manifest(args.run_id))
+    elif args.command == "trace":
+        _print_trace(load_run_manifest(args.run_id), failed_only=args.failed_only)
+    elif args.command == "rerun":
+        _print_rerun(load_run_manifest(args.run_id), args.step)
+    elif args.command == "diagnose":
+        print(f"uv run python scripts/daily_dd_check.py --site \"{args.site}\"")
+
+
+def _print_status(manifest: dict[str, Any]) -> None:
+    quality = manifest.get("quality") or {}
+    sir_review = manifest.get("sir_learning_review") or {}
+    print(f"Run: {manifest.get('run_id')}")
+    print(f"Site: {manifest.get('site_title')}")
+    print(f"Status: {manifest.get('final_status')}")
+    print(f"Failed step: {manifest.get('failed_step') or '(none)'}")
+    print(f"Quality: {quality.get('score')} ({quality.get('band')})")
+    print(f"SIR review: {sir_review.get('status') or '(none)'}")
+    print(f"Next action: {manifest.get('next_operator_action') or '(none)'}")
+    print(f"Manifest: {manifest.get('manifest_path') or '(unknown)'}")
+
+
+def _print_trace(manifest: dict[str, Any], *, failed_only: bool) -> None:
+    for step in manifest.get("steps", []):
+        status = step.get("status")
+        if failed_only and status not in {"failed", "blocked"}:
+            continue
+        line = f"{step.get('step')}: {status} ({step.get('duration_ms')} ms)"
+        error = step.get("error") or {}
+        if error:
+            line += f" - {error.get('code')}: {error.get('message')}"
+        print(line)
+
+
+def _print_rerun(manifest: dict[str, Any], step_name: str) -> None:
+    for step in manifest.get("steps", []):
+        if step.get("step") == step_name:
+            print(step.get("rerun_command") or f"ddr rerun --run-id {manifest.get('run_id')} --step {step_name}")
+            return
+    print(f"Unknown step: {step_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/due_diligence_reporter/pipeline_contracts.py
+++ b/src/due_diligence_reporter/pipeline_contracts.py
@@ -1,0 +1,175 @@
+"""Typed contracts for DD pipeline run observability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+StepStatus = Literal["pending", "running", "succeeded", "failed", "blocked", "skipped"]
+QualityBand = Literal["green", "yellow", "orange", "red"]
+QualityCheckStatus = Literal["passed", "failed", "warning", "not_applicable"]
+
+
+def utc_now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp."""
+    return datetime.now(UTC).isoformat()
+
+
+def make_run_id(site_title: str) -> str:
+    """Build a stable-enough, human-readable run id for one pipeline run."""
+    safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in site_title).strip("-")
+    while "--" in safe:
+        safe = safe.replace("--", "-")
+    safe = safe[:48] or "site"
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    return f"{stamp}-{safe}-{uuid4().hex[:8]}"
+
+
+@dataclass
+class PipelineError:
+    code: str
+    message: str
+    retryable: bool
+    operator_action: str
+    cause: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "operator_action": self.operator_action,
+            "cause": self.cause,
+        }
+
+
+@dataclass
+class ArtifactRef:
+    kind: str
+    name: str
+    uri: str | None = None
+    drive_file_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "uri": self.uri,
+            "drive_file_id": self.drive_file_id,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class StepResult:
+    run_id: str
+    step: str
+    status: StepStatus
+    started_at: str
+    ended_at: str
+    duration_ms: int
+    attempt: int = 1
+    error: PipelineError | None = None
+    artifacts: list[ArtifactRef] = field(default_factory=list)
+    rerun_command: str | None = None
+    skipped_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "step": self.step,
+            "status": self.status,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_ms": self.duration_ms,
+            "attempt": self.attempt,
+            "error": self.error.to_dict() if self.error else None,
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "rerun_command": self.rerun_command,
+            "skipped_reason": self.skipped_reason,
+        }
+
+
+@dataclass
+class QualityCheck:
+    name: str
+    status: QualityCheckStatus
+    points: int
+    max_points: int
+    details: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "points": self.points,
+            "max_points": self.max_points,
+            "details": self.details,
+        }
+
+
+@dataclass
+class RunQualityReport:
+    score: int
+    band: QualityBand
+    checks: list[QualityCheck]
+    caps_applied: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "band": self.band,
+            "checks": [check.to_dict() for check in self.checks],
+            "caps_applied": self.caps_applied,
+        }
+
+
+@dataclass
+class PipelineRun:
+    run_id: str
+    site_title: str
+    site_id: str | None
+    started_at: str
+    ended_at: str | None
+    final_status: str
+    steps: list[StepResult]
+    quality: RunQualityReport | None = None
+    sir_learning_review: dict[str, Any] | None = None
+    manifest_path: str | None = None
+    manifest_url: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "site_title": self.site_title,
+            "site_id": self.site_id,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "final_status": self.final_status,
+            "steps": [step.to_dict() for step in self.steps],
+            "quality": self.quality.to_dict() if self.quality else None,
+            "sir_learning_review": self.sir_learning_review,
+            "manifest_path": self.manifest_path,
+            "manifest_url": self.manifest_url,
+            "failed_step": failed_step_name(self.steps),
+            "next_operator_action": next_operator_action(self.steps),
+        }
+
+
+def failed_step_name(steps: list[StepResult]) -> str | None:
+    """Return the first failed or blocked step name."""
+    for step in steps:
+        if step.status in {"failed", "blocked"}:
+            return step.step
+    return None
+
+
+def next_operator_action(steps: list[StepResult]) -> str | None:
+    """Return the first operator action attached to a failed or blocked step."""
+    for step in steps:
+        if step.status in {"failed", "blocked"} and step.error:
+            return step.error.operator_action
+    return None

--- a/src/due_diligence_reporter/pipeline_manifest.py
+++ b/src/due_diligence_reporter/pipeline_manifest.py
@@ -1,0 +1,71 @@
+"""Manifest persistence and redaction checks for DD pipeline runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from .pipeline_contracts import PipelineRun
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+RUN_MANIFEST_DIR = PROJECT_ROOT / ".ddr-runs"
+
+_SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "app_password",
+    "password",
+    "authorization",
+    "credential",
+    "secret",
+)
+
+
+def local_manifest_path(run_id: str) -> Path:
+    return RUN_MANIFEST_DIR / f"{run_id}.json"
+
+
+def persist_run_manifest(run: PipelineRun, *, root: Path | None = None) -> Path:
+    """Persist a run manifest locally and return its path."""
+    base = root or RUN_MANIFEST_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / f"{run.run_id}.json"
+    path.write_text(json.dumps(run.to_dict(), indent=2), encoding="utf-8")
+    run.manifest_path = str(path)
+    return path
+
+
+def load_run_manifest(run_id: str, *, root: Path | None = None) -> dict[str, Any]:
+    path = (root or RUN_MANIFEST_DIR) / f"{run_id}.json"
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def manifest_has_secret_like_value(payload: dict[str, Any]) -> bool:
+    """Return True if a manifest payload appears to contain secret material."""
+    return _contains_secret(payload)
+
+
+def _contains_secret(value: Any, key_path: str = "") -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).lower()
+            if any(part in lowered for part in _SENSITIVE_KEY_PARTS):
+                if child not in (None, "", [], {}):
+                    return True
+            if _contains_secret(child, f"{key_path}.{lowered}"):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_secret(item, key_path) for item in value)
+    elif isinstance(value, str):
+        return _looks_like_secret(value)
+    return False
+
+
+def _looks_like_secret(value: str) -> bool:
+    stripped = value.strip()
+    if len(stripped) < 20:
+        return False
+    secret_prefixes = ("sk-", "xoxb-", "ya29.", "ghp_", "github_pat_")
+    return stripped.startswith(secret_prefixes)

--- a/src/due_diligence_reporter/pipeline_quality.py
+++ b/src/due_diligence_reporter/pipeline_quality.py
@@ -1,0 +1,177 @@
+"""Deterministic quality scoring for DD pipeline run manifests."""
+
+from __future__ import annotations
+
+from .pipeline_contracts import (
+    PipelineRun,
+    QualityBand,
+    QualityCheck,
+    QualityCheckStatus,
+    RunQualityReport,
+    StepResult,
+)
+
+
+def quality_band(score: int) -> QualityBand:
+    if score >= 90:
+        return "green"
+    if score >= 70:
+        return "yellow"
+    if score >= 40:
+        return "orange"
+    return "red"
+
+
+def evaluate_run_quality(
+    run: PipelineRun,
+    *,
+    manifest_persisted: bool,
+    secret_detected: bool = False,
+) -> RunQualityReport:
+    """Score how trustworthy and actionable a run result is."""
+    checks = [
+        _step_observability(run),
+        _artifact_integrity(run, manifest_persisted),
+        _source_quality(run),
+        _report_validity(run),
+        _side_effect_reliability(run),
+    ]
+    score = sum(check.points for check in checks)
+    caps = _quality_caps(run, manifest_persisted, secret_detected)
+    for _cap_name, cap_value in caps:
+        if score > cap_value:
+            score = cap_value
+    return RunQualityReport(
+        score=max(0, min(100, score)),
+        band=quality_band(score),
+        checks=checks,
+        caps_applied=[name for name, _value in caps],
+    )
+
+
+def _step_observability(run: PipelineRun) -> QualityCheck:
+    points = 0
+    details: list[str] = []
+    if run.run_id:
+        points += 5
+    else:
+        details.append("missing run_id")
+    if run.steps:
+        points += 8
+    else:
+        details.append("no steps recorded")
+    if all(step.duration_ms >= 0 for step in run.steps):
+        points += 4
+    failed = [step for step in run.steps if step.status in {"failed", "blocked"}]
+    if failed:
+        if failed[0].error:
+            points += 4
+        else:
+            details.append("failed/blocked step missing error")
+        if failed[0].rerun_command or (failed[0].error and failed[0].error.operator_action):
+            points += 4
+        else:
+            details.append("failed/blocked step missing operator action")
+    else:
+        points += 8
+    return QualityCheck("step_observability", _status(points, 25), points, 25, "; ".join(details))
+
+
+def _artifact_integrity(run: PipelineRun, manifest_persisted: bool) -> QualityCheck:
+    points = 0
+    details: list[str] = []
+    if manifest_persisted:
+        points += 8
+    else:
+        details.append("manifest not persisted")
+    if any(step.artifacts for step in run.steps):
+        points += 6
+    elif run.final_status in {"waiting_on_docs", "report_exists", "yielded_to_pipeline"}:
+        points += 6
+    else:
+        details.append("no artifacts recorded")
+    if all(_artifacts_have_refs(step) for step in run.steps):
+        points += 6
+    else:
+        details.append("artifact missing uri or drive_file_id")
+    return QualityCheck("artifact_integrity", _status(points, 20), points, 20, "; ".join(details))
+
+
+def _source_quality(run: PipelineRun) -> QualityCheck:
+    readiness = _step(run, "readiness.check")
+    source_alert = _step(run, "source.alert")
+    if readiness and readiness.status == "blocked":
+        return QualityCheck("source_quality", "passed", 20, 20, "blocked with explicit missing docs")
+    if source_alert and source_alert.status == "failed":
+        return QualityCheck("source_quality", "warning", 12, 20, "source read issues detected")
+    if readiness and readiness.status == "succeeded":
+        return QualityCheck("source_quality", "passed", 20, 20)
+    return QualityCheck("source_quality", "not_applicable", 16, 20, "source checks not reached")
+
+
+def _report_validity(run: PipelineRun) -> QualityCheck:
+    validation = _step(run, "report.validate")
+    if not validation:
+        if run.final_status in {"waiting_on_docs", "report_exists", "yielded_to_pipeline"}:
+            return QualityCheck("report_validity", "not_applicable", 25, 25, "report not expected")
+        return QualityCheck("report_validity", "warning", 12, 25, "validation not recorded")
+    if validation.status == "succeeded":
+        return QualityCheck("report_validity", "passed", 25, 25)
+    if validation.status in {"failed", "blocked"}:
+        return QualityCheck("report_validity", "failed", 0, 25, validation.error.message if validation.error else "")
+    return QualityCheck("report_validity", "not_applicable", 20, 25, validation.skipped_reason or "")
+
+
+def _side_effect_reliability(run: PipelineRun) -> QualityCheck:
+    side_effects = [
+        step for step in run.steps
+        if step.step in {"trace.save", "manifest.save", "publish.dashboard", "notify.email", "notify.chat"}
+    ]
+    if not side_effects:
+        return QualityCheck("side_effect_reliability", "not_applicable", 8, 10)
+    failed = [step.step for step in side_effects if step.status == "failed"]
+    if failed:
+        return QualityCheck("side_effect_reliability", "warning", 5, 10, ", ".join(failed))
+    return QualityCheck("side_effect_reliability", "passed", 10, 10)
+
+
+def _quality_caps(
+    run: PipelineRun,
+    manifest_persisted: bool,
+    secret_detected: bool,
+) -> list[tuple[str, int]]:
+    caps: list[tuple[str, int]] = []
+    if secret_detected:
+        caps.append(("secret_like_value_detected", 0))
+    if not run.run_id:
+        caps.append(("no_run_id", 40))
+    if not manifest_persisted:
+        caps.append(("no_persisted_manifest", 60))
+    failed = [step for step in run.steps if step.status in {"failed", "blocked"}]
+    if failed and not failed[0].step:
+        caps.append(("failed_or_blocked_without_failed_step", 50))
+    if failed and not (failed[0].error and failed[0].error.operator_action):
+        caps.append(("failed_or_blocked_without_operator_action", 70))
+    validation = _step(run, "report.validate")
+    if run.final_status == "report_incomplete" or (validation and validation.status == "failed"):
+        caps.append(("report_created_with_unresolved_required_tokens", 69))
+    source_alert = _step(run, "source.alert")
+    if source_alert and source_alert.status == "failed":
+        caps.append(("required_source_doc_unreadable_after_readiness", 69))
+    return caps
+
+
+def _status(points: int, max_points: int) -> QualityCheckStatus:
+    if points == max_points:
+        return "passed"
+    if points == 0:
+        return "failed"
+    return "warning"
+
+
+def _step(run: PipelineRun, name: str) -> StepResult | None:
+    return next((step for step in run.steps if step.step == name), None)
+
+
+def _artifacts_have_refs(step: StepResult) -> bool:
+    return all(artifact.uri or artifact.drive_file_id for artifact in step.artifacts)

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import anthropic
 
@@ -27,7 +27,21 @@ from .config import Settings, get_settings
 from .dashboard_publisher import publish_to_dashboard
 from .google_client import GoogleClient
 from .m1_lookup import _list_m1_documents_by_type, _resolve_m1_folder
+from .pipeline_contracts import (
+    ArtifactRef,
+    PipelineError,
+    PipelineRun,
+    StepResult,
+    StepStatus,
+    failed_step_name,
+    make_run_id,
+    next_operator_action,
+    utc_now_iso,
+)
+from .pipeline_manifest import manifest_has_secret_like_value, persist_run_manifest
+from .pipeline_quality import evaluate_run_quality
 from .provenance import classify_provenance
+from .sir_learning import build_sir_learning_review
 from .utils import (
     escape_html_text,
     extract_folder_id_from_url,
@@ -454,6 +468,17 @@ def check_site_readiness_direct(
                 "M1 lookup failed for raycon_scenario_json in %s: %s", site_title, e
             )
 
+    sir_review_files = [f for f in site_folder_files if f.get("doc_type") == "sir"]
+    shared_sir = shared_docs.get("sir")
+    if shared_sir:
+        sir_review_files.append({**shared_sir, "doc_type": "sir"})
+    sir_learning_review = build_sir_learning_review(
+        sir_review_files,
+        gc,
+        m1_folder_id=m1_folder_id,
+        read_only=read_only,
+    )
+
     return {
         "sir_found": files_by_type["sir"] is not None,
         "isp_found": files_by_type["isp"] is not None,
@@ -469,6 +494,7 @@ def check_site_readiness_direct(
         "e_occupancy_report_found": files_by_type["e_occupancy_report"] is not None,
         "school_approval_report_found": files_by_type["school_approval_report"] is not None,
         "all_files": ai_generated_site_files,
+        "sir_learning_review": sir_learning_review.to_dict(),
     }
 
 
@@ -639,6 +665,239 @@ class PipelineResult:
     error: str | None = None
     trace_url: str | None = None
     trace: ReportTrace | None = None
+    run_id: str | None = None
+    failed_step: str | None = None
+    quality_score: int | None = None
+    quality_band: str | None = None
+    manifest_path: str | None = None
+    sir_review_status: str | None = None
+    sir_learning_review: dict[str, Any] | None = None
+    steps: list[StepResult] = field(default_factory=list)
+
+
+class _RunRecorder:
+    """Collect step results for one pipeline run."""
+
+    def __init__(self, site_title: str, site_id: str | None = None) -> None:
+        self.run_id = make_run_id(site_title)
+        self.site_title = site_title
+        self.site_id = site_id
+        self.started_at = utc_now_iso()
+        self.steps: list[StepResult] = []
+        self.sir_learning_review: dict[str, Any] | None = None
+
+    def start(self) -> tuple[str, float]:
+        return utc_now_iso(), time.monotonic()
+
+    def record(
+        self,
+        step: str,
+        started_at: str,
+        started_monotonic: float,
+        status: str,
+        *,
+        error: PipelineError | None = None,
+        artifacts: list[ArtifactRef] | None = None,
+        skipped_reason: str | None = None,
+    ) -> StepResult:
+        rerun = None
+        if status in {"failed", "blocked"}:
+            rerun = _rerun_command(self.run_id, step)
+        result = StepResult(
+            run_id=self.run_id,
+            step=step,
+            status=cast(StepStatus, status),
+            started_at=started_at,
+            ended_at=utc_now_iso(),
+            duration_ms=int((time.monotonic() - started_monotonic) * 1000),
+            error=error,
+            artifacts=artifacts or [],
+            rerun_command=rerun,
+            skipped_reason=skipped_reason,
+        )
+        self.steps.append(result)
+        return result
+
+    def to_run(self, final_status: str) -> PipelineRun:
+        return PipelineRun(
+            run_id=self.run_id,
+            site_title=self.site_title,
+            site_id=self.site_id,
+            started_at=self.started_at,
+            ended_at=utc_now_iso(),
+            final_status=final_status,
+            steps=list(self.steps),
+            sir_learning_review=self.sir_learning_review,
+        )
+
+
+def _rerun_command(run_id: str, step: str) -> str:
+    return f"ddr rerun --run-id {run_id} --step {step}"
+
+
+def _pipeline_error(
+    run_id: str,
+    step: str,
+    code: str,
+    message: str,
+    *,
+    retryable: bool = True,
+    cause: str | None = None,
+) -> PipelineError:
+    return PipelineError(
+        code=code,
+        message=message,
+        retryable=retryable,
+        operator_action=_rerun_command(run_id, step),
+        cause=cause,
+    )
+
+
+def _finalize_pipeline_result(
+    result: PipelineResult,
+    recorder: _RunRecorder,
+    *,
+    gc: GoogleClient | None = None,
+    drive_folder_url: str = "",
+) -> PipelineResult:
+    if result.sir_learning_review is None:
+        result.sir_learning_review = recorder.sir_learning_review
+    if result.sir_learning_review:
+        result.sir_review_status = str(result.sir_learning_review.get("status") or "")
+    run = recorder.to_run(result.status)
+    manifest_persisted = False
+    secret_detected = manifest_has_secret_like_value(run.to_dict())
+    started_at, started_monotonic = recorder.start()
+    if secret_detected:
+        recorder.record(
+            "manifest.save",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(
+                recorder.run_id,
+                "manifest.save",
+                "manifest_secret_detected",
+                "Run manifest contains secret-like material and was not persisted",
+                retryable=False,
+            ),
+        )
+    else:
+        try:
+            path = persist_run_manifest(run)
+            manifest_persisted = True
+            result.manifest_path = str(path)
+            recorder.record(
+                "manifest.save",
+                started_at,
+                started_monotonic,
+                "succeeded",
+                artifacts=[ArtifactRef(kind="manifest", name=path.name, uri=str(path))],
+            )
+        except Exception as e:  # pragma: no cover - defensive path
+            recorder.record(
+                "manifest.save",
+                started_at,
+                started_monotonic,
+                "failed",
+                error=_pipeline_error(
+                    recorder.run_id,
+                    "manifest.save",
+                    "manifest_save_failed",
+                    str(e),
+                ),
+            )
+    run = recorder.to_run(result.status)
+    run.manifest_path = result.manifest_path
+    run.quality = evaluate_run_quality(
+        run,
+        manifest_persisted=manifest_persisted,
+        secret_detected=secret_detected,
+    )
+    if manifest_persisted:
+        path = persist_run_manifest(run)
+        result.manifest_path = str(path)
+        _record_manifest_upload_step(recorder, gc, drive_folder_url, run)
+        run = recorder.to_run(result.status)
+        run.manifest_path = result.manifest_path
+        run.manifest_url = _manifest_upload_url(run.steps)
+        run.quality = evaluate_run_quality(
+            run,
+            manifest_persisted=manifest_persisted,
+            secret_detected=secret_detected,
+        )
+        persist_run_manifest(run)
+    result.run_id = run.run_id
+    result.steps = list(run.steps)
+    result.failed_step = failed_step_name(run.steps)
+    quality = run.quality
+    assert quality is not None
+    result.quality_score = quality.score
+    result.quality_band = quality.band
+    result.manifest_path = run.manifest_path
+    return result
+
+
+def _record_manifest_upload_step(
+    recorder: _RunRecorder,
+    gc: GoogleClient | None,
+    drive_folder_url: str,
+    run: PipelineRun,
+) -> None:
+    started_at, started_monotonic = recorder.start()
+    folder_id = extract_folder_id_from_url(drive_folder_url)
+    if gc is None or not isinstance(gc, GoogleClient) or not folder_id:
+        recorder.record(
+            "manifest.upload",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason="no Drive folder available",
+        )
+        return
+    try:
+        payload = json.dumps(run.to_dict(), indent=2).encode("utf-8")
+        uploaded = gc.upload_file_to_folder(
+            folder_id=folder_id,
+            file_name=f"{run.run_id} pipeline manifest.json",
+            file_bytes=payload,
+            mime_type="application/json",
+        )
+    except Exception as e:
+        recorder.record(
+            "manifest.upload",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(
+                recorder.run_id,
+                "manifest.upload",
+                "manifest_upload_failed",
+                str(e),
+            ),
+        )
+        return
+    recorder.record(
+        "manifest.upload",
+        started_at,
+        started_monotonic,
+        "succeeded",
+        artifacts=[
+            ArtifactRef(
+                kind="manifest",
+                name=str(uploaded.get("name", "pipeline manifest")),
+                uri=uploaded.get("webViewLink"),
+                drive_file_id=uploaded.get("id"),
+            )
+        ],
+    )
+
+
+def _manifest_upload_url(steps: list[StepResult]) -> str | None:
+    for step in steps:
+        if step.step == "manifest.upload" and step.artifacts:
+            return step.artifacts[0].uri
+    return None
 
 
 def _get_payload_error(result: dict[str, Any]) -> str | None:
@@ -1225,10 +1484,10 @@ def _email_pipeline_report(
     site_title: str,
     doc_url: str,
     p1_email: str | None,
-) -> None:
+) -> str | None:
     """Send the completed DD report email when email settings are configured."""
     if not settings.email_sender or not settings.email_app_password:
-        return
+        return "email settings not configured"
 
     recipients = [
         r.strip()
@@ -1266,13 +1525,199 @@ def _email_pipeline_report(
             global_cc=settings.global_email_cc,
         )
         logger.info("Email sent for '%s' to %s", site_title, recipients)
+        return None
     except Exception as e:
         logger.error("Failed to send email for '%s': %s", site_title, e)
+        return str(e)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Full single-site pipeline
 # ─────────────────────────────────────────────────────────────────────────────
+
+
+def _record_trace_save_step(
+    recorder: _RunRecorder,
+    gc: GoogleClient,
+    drive_folder_url: str,
+    site_title: str,
+    trace: ReportTrace | None,
+) -> str | None:
+    started_at, started_monotonic = recorder.start()
+    trace_url: Any = _save_pipeline_trace(gc, drive_folder_url, site_title, trace)
+    if trace is None:
+        recorder.record(
+            "trace.save",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason="no trace available",
+        )
+    elif trace_url is not None and not isinstance(trace_url, str):
+        recorder.record(
+            "trace.save",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason="trace save returned non-string URL",
+        )
+        return None
+    elif trace_url:
+        recorder.record(
+            "trace.save",
+            started_at,
+            started_monotonic,
+            "succeeded",
+            artifacts=[ArtifactRef(kind="trace", name="Report trace", uri=trace_url)],
+        )
+    else:
+        recorder.record(
+            "trace.save",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(
+                recorder.run_id,
+                "trace.save",
+                "trace_save_failed",
+                "Trace could not be saved",
+            ),
+        )
+    return cast(str | None, trace_url)
+
+
+def _record_source_alert_step(
+    recorder: _RunRecorder,
+    settings: Settings,
+    site_title: str,
+    trace: ReportTrace | None,
+    *,
+    drive_folder_url: str,
+    trace_url: str,
+) -> None:
+    started_at, started_monotonic = recorder.start()
+    issues = _extract_source_read_issues(trace)
+    _notify_source_read_issues(
+        settings.google_chat_webhook_url,
+        site_title,
+        trace,
+        drive_folder_url=drive_folder_url,
+        trace_url=trace_url,
+    )
+    if issues:
+        recorder.record(
+            "source.alert",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(
+                recorder.run_id,
+                "source.alert",
+                "source_read_issue",
+                f"{len(issues)} required source document read issue(s)",
+            ),
+        )
+    else:
+        recorder.record("source.alert", started_at, started_monotonic, "succeeded")
+
+
+def _record_sir_learning_review_step(
+    recorder: _RunRecorder,
+    review: dict[str, Any] | None,
+) -> None:
+    started_at, started_monotonic = recorder.start()
+    recorder.sir_learning_review = review
+    if not review:
+        recorder.record(
+            "sir.learning_review",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason="no SIR review metadata",
+        )
+        return
+
+    status = str(review.get("status") or "not_applicable")
+    if status == "ready_for_review":
+        recorder.record(
+            "sir.learning_review",
+            started_at,
+            started_monotonic,
+            "succeeded",
+            artifacts=[
+                ArtifactRef(
+                    kind="sir_learning_review",
+                    name="AI/CDS SIR comparison candidate",
+                    metadata=review,
+                )
+            ],
+        )
+        return
+
+    recorder.record(
+        "sir.learning_review",
+        started_at,
+        started_monotonic,
+        "skipped",
+        skipped_reason=str(review.get("reason") or status),
+    )
+
+
+def _record_email_step(
+    recorder: _RunRecorder,
+    settings: Settings,
+    site_title: str,
+    doc_url: str,
+    p1_email: str | None,
+) -> None:
+    started_at, started_monotonic = recorder.start()
+    error = _email_pipeline_report(settings, site_title, doc_url, p1_email)
+    if error == "email settings not configured":
+        recorder.record(
+            "notify.email",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason=error,
+        )
+    elif error:
+        recorder.record(
+            "notify.email",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(recorder.run_id, "notify.email", "email_failed", error),
+        )
+    else:
+        recorder.record("notify.email", started_at, started_monotonic, "succeeded")
+
+
+def _record_dashboard_step(recorder: _RunRecorder, **kwargs: Any) -> None:
+    started_at, started_monotonic = recorder.start()
+    error = _publish_to_dashboard_best_effort(**kwargs)
+    if error == "no final_report_data on trace":
+        recorder.record(
+            "publish.dashboard",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason=error,
+        )
+    elif error:
+        recorder.record(
+            "publish.dashboard",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(
+                recorder.run_id,
+                "publish.dashboard",
+                "dashboard_publish_failed",
+                error,
+            ),
+        )
+    else:
+        recorder.record("publish.dashboard", started_at, started_monotonic, "succeeded")
 
 
 def process_site_pipeline(
@@ -1307,6 +1752,8 @@ def process_site_pipeline(
 
     Returns a PipelineResult describing what happened.
     """
+    recorder = _RunRecorder(site_title)
+    started_at, started_monotonic = recorder.start()
     try:
         readiness = check_site_readiness_direct(
             gc,
@@ -1318,24 +1765,105 @@ def process_site_pipeline(
         )
     except Exception as e:
         logger.error("Failed to check readiness for '%s': %s", site_title, e)
-        return PipelineResult(site_title=site_title, status="error", error=str(e))
+        recorder.record(
+            "readiness.check",
+            started_at,
+            started_monotonic,
+            "failed",
+            error=_pipeline_error(
+                recorder.run_id,
+                "readiness.check",
+                "readiness_check_failed",
+                str(e),
+            ),
+        )
+        return _finalize_pipeline_result(
+            PipelineResult(site_title=site_title, status="error", error=str(e)),
+            recorder,
+            gc=gc,
+            drive_folder_url=drive_folder_url,
+        )
 
     readiness_result = _resolve_readiness_result(
         site_title, readiness, force_regenerate=force_regenerate
     )
+    sir_learning_review = readiness.get("sir_learning_review")
     if readiness_result is not None:
-        return readiness_result
+        if readiness_result.status == "waiting_on_docs":
+            recorder.record(
+                "readiness.check",
+                started_at,
+                started_monotonic,
+                "blocked",
+                error=_pipeline_error(
+                    recorder.run_id,
+                    "readiness.check",
+                    "missing_required_documents",
+                    ", ".join(readiness_result.missing_docs),
+                    retryable=False,
+                ),
+            )
+        elif readiness_result.status == "error":
+            recorder.record(
+                "readiness.check",
+                started_at,
+                started_monotonic,
+                "failed",
+                error=_pipeline_error(
+                    recorder.run_id,
+                    "readiness.check",
+                    "readiness_payload_error",
+                    readiness_result.error or "Readiness check failed",
+                ),
+            )
+        else:
+            recorder.record("readiness.check", started_at, started_monotonic, "succeeded")
+            recorder.record(
+                "report.generate",
+                *recorder.start(),
+                "skipped",
+                skipped_reason=readiness_result.status,
+            )
+        _record_sir_learning_review_step(recorder, sir_learning_review)
+        return _finalize_pipeline_result(
+            readiness_result,
+            recorder,
+            gc=gc,
+            drive_folder_url=drive_folder_url,
+        )
+    recorder.record("readiness.check", started_at, started_monotonic, "succeeded")
+    _record_sir_learning_review_step(recorder, sir_learning_review)
 
+    started_at, started_monotonic = recorder.start()
     agent_result, generation_result = _run_pipeline_agent(site_title, system_prompt, settings)
     if generation_result is not None:
-        generation_result.trace_url = _save_pipeline_trace(
+        gen_status = "skipped" if generation_result.status == "yielded_to_pipeline" else "failed"
+        gen_error = None
+        if gen_status == "failed":
+            gen_error = _pipeline_error(
+                recorder.run_id,
+                "report.generate",
+                "report_generation_failed",
+                generation_result.error or generation_result.status,
+            )
+        recorder.record(
+            "report.generate",
+            started_at,
+            started_monotonic,
+            gen_status,
+            error=gen_error,
+            skipped_reason=generation_result.status if gen_status == "skipped" else None,
+        )
+        generation_result.trace_url = _record_trace_save_step(
+            recorder,
             gc,
             drive_folder_url,
             site_title,
             generation_result.trace,
         )
-        _notify_source_read_issues(
-            settings.google_chat_webhook_url,
+        _record_source_alert_step(
+            recorder,
+            settings,
             site_title,
             generation_result.trace,
             drive_folder_url=drive_folder_url,
@@ -1356,27 +1884,54 @@ def process_site_pipeline(
                 failure_reason=generation_result.error or "",
                 trace_url=generation_result.trace_url or "",
             )
-        return generation_result
+        return _finalize_pipeline_result(
+            generation_result,
+            recorder,
+            gc=gc,
+            drive_folder_url=drive_folder_url,
+        )
     assert agent_result is not None
+    recorder.record("report.generate", started_at, started_monotonic, "succeeded")
 
     doc_id = agent_result["doc_id"]
     doc_url = agent_result.get("doc_url", "")
-    trace_url = _save_pipeline_trace(
+    trace_url = _record_trace_save_step(
+        recorder,
         gc,
         drive_folder_url,
         site_title,
         agent_result.get("trace"),
     )
-    _notify_source_read_issues(
-        settings.google_chat_webhook_url,
+    _record_source_alert_step(
+        recorder,
+        settings,
         site_title,
         agent_result.get("trace"),
         drive_folder_url=drive_folder_url,
         trace_url=trace_url or "",
     )
 
+    started_at, started_monotonic = recorder.start()
     completeness, completeness_result = _check_generated_report(site_title, doc_id, doc_url)
     if completeness_result is not None:
+        validation_status = "failed"
+        validation_code = "report_validation_failed"
+        if completeness_result.status == "error":
+            validation_code = "report_validation_error"
+        recorder.record(
+            "report.validate",
+            started_at,
+            started_monotonic,
+            validation_status,
+            error=_pipeline_error(
+                recorder.run_id,
+                "report.validate",
+                validation_code,
+                completeness_result.error
+                or f"{len(completeness_result.unresolved_tokens)} unresolved token(s)",
+            ),
+            artifacts=[ArtifactRef(kind="google_doc", name="DD report", uri=doc_url, drive_file_id=doc_id)],
+        )
         completeness_result.trace_url = trace_url
         completeness_result.trace = agent_result.get("trace")
         # Same escalation as the agent-failure branch above: vendor gate
@@ -1406,7 +1961,8 @@ def process_site_pipeline(
         # reaches the dashboard, even when the agent successfully filled
         # most of the template. Keeps the success-path publish unchanged.
         if completeness_result.status == "report_incomplete":
-            _publish_to_dashboard_best_effort(
+            _record_dashboard_step(
+                recorder,
                 site_title=site_title,
                 trace=agent_result.get("trace"),
                 drive_folder_url=drive_folder_url,
@@ -1418,12 +1974,25 @@ def process_site_pipeline(
                 timeline_confidence=timeline_confidence,
                 wrike_created_at=wrike_created_at,
             )
-        return completeness_result
+        return _finalize_pipeline_result(
+            completeness_result,
+            recorder,
+            gc=gc,
+            drive_folder_url=drive_folder_url,
+        )
     assert completeness is not None
+    recorder.record(
+        "report.validate",
+        started_at,
+        started_monotonic,
+        "succeeded",
+        artifacts=[ArtifactRef(kind="google_doc", name="DD report", uri=doc_url, drive_file_id=doc_id)],
+    )
 
-    _email_pipeline_report(settings, site_title, doc_url, p1_email)
+    _record_email_step(recorder, settings, site_title, doc_url, p1_email)
 
-    _publish_to_dashboard_best_effort(
+    _record_dashboard_step(
+        recorder,
         site_title=site_title,
         trace=agent_result.get("trace"),
         drive_folder_url=drive_folder_url,
@@ -1435,14 +2004,19 @@ def process_site_pipeline(
         wrike_created_at=wrike_created_at,
     )
 
-    return PipelineResult(
-        site_title=site_title,
-        status="report_created",
-        doc_id=doc_id,
-        doc_url=doc_url,
-        pending_count=completeness.get("pending_section_count", 0),
-        trace_url=trace_url,
-        trace=agent_result.get("trace"),
+    return _finalize_pipeline_result(
+        PipelineResult(
+            site_title=site_title,
+            status="report_created",
+            doc_id=doc_id,
+            doc_url=doc_url,
+            pending_count=completeness.get("pending_section_count", 0),
+            trace_url=trace_url,
+            trace=agent_result.get("trace"),
+        ),
+        recorder,
+        gc=gc,
+        drive_folder_url=drive_folder_url,
     )
 
 
@@ -1463,7 +2037,7 @@ def _publish_to_dashboard_best_effort(
     school_feasibility: str | None = None,
     timeline_confidence: str | None = None,
     wrike_created_at: str | None = None,
-) -> None:
+) -> str | None:
     """Fire-and-forget dashboard publish. Never raises.
 
     Phase 3 fields (dd_site_score + dd_site_score_band) are derived
@@ -1484,7 +2058,7 @@ def _publish_to_dashboard_best_effort(
             "Skipping dashboard publish for %s \u2014 no final_report_data on trace",
             site_title,
         )
-        return
+        return "no final_report_data on trace"
     try:
         publish_to_dashboard(
             site_title,
@@ -1498,6 +2072,7 @@ def _publish_to_dashboard_best_effort(
             timeline_confidence=timeline_confidence,
             wrike_created_at=wrike_created_at,
         )
+        return None
     except Exception as e:
         # publish_to_dashboard already swallows requests errors; this is a
         # belt-and-suspenders guard against anything truly unexpected.
@@ -1526,6 +2101,7 @@ def _publish_to_dashboard_best_effort(
                 site_title,
                 record_err,
             )
+        return str(e)
 
 
 # Google Chat notification per pipeline result
@@ -1559,10 +2135,15 @@ def post_pipeline_result(
         ]
         if drive_folder_url:
             lines.append(f"Drive: {drive_folder_url}")
+        lines.extend(_pipeline_observability_lines(result))
         msg = "\n".join(lines)
 
     elif result.status == "report_exists":
-        msg = f"DD Check -- {result.site_title}\nReport already exists, skipping."
+        msg = "\n".join([
+            f"DD Check -- {result.site_title}",
+            "Report already exists, skipping.",
+            *_pipeline_observability_lines(result),
+        ])
 
     elif result.status == "report_created":
         msg = (
@@ -1573,6 +2154,7 @@ def post_pipeline_result(
             msg += f"\nTrace: {result.trace_url}"
         if result.pending_count:
             msg += f"\nPending fields: {result.pending_count}"
+        msg += "\n" + "\n".join(_pipeline_observability_lines(result))
 
     elif result.status == "report_incomplete":
         count = len(result.unresolved_tokens)
@@ -1589,24 +2171,46 @@ def post_pipeline_result(
                 f"Tokens: {tokens}\n"
                 f"Report: {result.doc_url or '(no URL)'}"
             )
+        msg += "\n" + "\n".join(_pipeline_observability_lines(result))
 
     elif result.status == "generation_failed":
         msg = (
             f"DD Report generation FAILED for {result.site_title}\n"
             f"Error: {result.error or 'unknown'}"
         )
+        msg += "\n" + "\n".join(_pipeline_observability_lines(result))
 
     elif result.status == "error":
         msg = (
             f"DD Check ERROR for {result.site_title}\n"
             f"Error: {result.error or 'unknown'}"
         )
+        msg += "\n" + "\n".join(_pipeline_observability_lines(result))
 
     else:
         msg = f"DD Check -- {result.site_title}\nStatus: {result.status}"
+        msg += "\n" + "\n".join(_pipeline_observability_lines(result))
 
     for url in urls:
         try:
             post_google_chat_message(url, msg)
         except Exception as e:
             logger.error("Failed to post Chat message for '%s' to %s: %s", result.site_title, url[:60], e)
+
+
+def _pipeline_observability_lines(result: PipelineResult) -> list[str]:
+    lines: list[str] = []
+    if result.run_id:
+        lines.append(f"Run ID: {result.run_id}")
+    if result.failed_step:
+        lines.append(f"Failed step: {result.failed_step}")
+    if result.quality_score is not None and result.quality_band:
+        lines.append(f"Run quality: {result.quality_score} ({result.quality_band})")
+    if result.manifest_path:
+        lines.append(f"Manifest: {result.manifest_path}")
+    if result.sir_review_status:
+        lines.append(f"SIR review: {result.sir_review_status}")
+    action = next_operator_action(result.steps)
+    if action:
+        lines.append(f"Next action: {action}")
+    return lines

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -186,6 +186,7 @@ def _resolve_site_for_tool(site_name_or_id: str) -> tuple[dict[str, Any] | None,
         "status": "not_found",
         "error": "No site found",
         "message": (
+            "Could not find a confident site match. "
             f"No site matched '{resolution.query}'. Closest near-matches below — "
             "refine the name or paste the Wrike ID/permalink."
         ),

--- a/src/due_diligence_reporter/sir_learning.py
+++ b/src/due_diligence_reporter/sir_learning.py
@@ -1,0 +1,182 @@
+"""SIR comparison learning-loop metadata.
+
+The DDR pipeline should surface AI-vs-CDS SIR review opportunities without
+letting an unreviewed comparison become source-of-truth for a DD report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .provenance import ProvenanceVerdict, classify_provenance
+
+SirReviewStatus = Literal[
+    "not_applicable",
+    "waiting_for_ai_sir",
+    "waiting_for_cds_sir",
+    "ready_for_review",
+]
+
+
+@dataclass(frozen=True)
+class SirReviewCandidate:
+    """One SIR file selected for AI-vs-CDS comparison."""
+
+    role: Literal["ai_sir", "cds_sir"]
+    name: str
+    file_id: str | None
+    uri: str | None
+    provenance_label: str
+    provenance_confidence: float
+    provenance_tier: str
+    provenance_reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "name": self.name,
+            "file_id": self.file_id,
+            "uri": self.uri,
+            "provenance_label": self.provenance_label,
+            "provenance_confidence": self.provenance_confidence,
+            "provenance_tier": self.provenance_tier,
+            "provenance_reason": self.provenance_reason,
+        }
+
+
+@dataclass(frozen=True)
+class SirLearningReview:
+    """Pipeline-visible review state for one site."""
+
+    status: SirReviewStatus
+    reason: str
+    ai_sir: SirReviewCandidate | None = None
+    cds_sir: SirReviewCandidate | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "reason": self.reason,
+            "ai_sir": self.ai_sir.to_dict() if self.ai_sir else None,
+            "cds_sir": self.cds_sir.to_dict() if self.cds_sir else None,
+            "review_dimensions": [
+                "AI missed item",
+                "CDS missed item",
+                "AI unsupported claim",
+                "CDS unsupported claim",
+                "better wording needed",
+                "template or prompt gap",
+                "source retrieval gap",
+            ],
+            "learning_outputs": [
+                "prompt update",
+                "retrieval rule",
+                "SIR template change",
+                "DDR prompt or token mapping change",
+                "QC checklist item",
+            ],
+        }
+
+
+def build_sir_learning_review(
+    files: list[dict[str, Any]],
+    gc: Any | None,
+    *,
+    m1_folder_id: str | None = None,
+    read_only: bool = False,
+) -> SirLearningReview:
+    """Classify SIR candidates and return the current comparison state."""
+    candidates = _sir_files(files)
+    if not candidates:
+        return SirLearningReview("not_applicable", "no SIR candidates found")
+
+    classified = [
+        (_classify_sir(file_info, gc, m1_folder_id, read_only), file_info)
+        for file_info in candidates
+    ]
+    ai_file = _pick_latest([
+        (verdict, file_info)
+        for verdict, file_info in classified
+        if verdict.label == "ai_generated"
+    ])
+    cds_file = _pick_latest([
+        (verdict, file_info)
+        for verdict, file_info in classified
+        if verdict.label != "ai_generated" and verdict.is_vendor
+    ])
+
+    if ai_file and cds_file:
+        return SirLearningReview(
+            "ready_for_review",
+            "AI SIR and CDS/vendor SIR are both present",
+            ai_sir=_candidate("ai_sir", ai_file[1], ai_file[0]),
+            cds_sir=_candidate("cds_sir", cds_file[1], cds_file[0]),
+        )
+    if ai_file:
+        return SirLearningReview(
+            "waiting_for_cds_sir",
+            "AI SIR present; CDS/vendor SIR not found yet",
+            ai_sir=_candidate("ai_sir", ai_file[1], ai_file[0]),
+        )
+    if cds_file:
+        return SirLearningReview(
+            "waiting_for_ai_sir",
+            "CDS/vendor SIR present; AI SIR not found yet",
+            cds_sir=_candidate("cds_sir", cds_file[1], cds_file[0]),
+        )
+    return SirLearningReview("not_applicable", "SIR candidates could not be classified")
+
+
+def _sir_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for file_info in files:
+        if file_info.get("doc_type") != "sir":
+            continue
+        key = str(file_info.get("id") or file_info.get("name") or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(file_info)
+    return result
+
+
+def _classify_sir(
+    file_info: dict[str, Any],
+    gc: Any | None,
+    m1_folder_id: str | None,
+    read_only: bool,
+) -> ProvenanceVerdict:
+    return classify_provenance(
+        file_info,
+        gc,
+        m1_folder_id=m1_folder_id,
+        doc_type="sir",
+        read_only=read_only,
+    )
+
+
+def _pick_latest(
+    items: list[tuple[ProvenanceVerdict, dict[str, Any]]],
+) -> tuple[ProvenanceVerdict, dict[str, Any]] | None:
+    if not items:
+        return None
+    return max(items, key=lambda item: str(item[1].get("modifiedTime", "")))
+
+
+def _candidate(
+    role: Literal["ai_sir", "cds_sir"],
+    file_info: dict[str, Any],
+    verdict: ProvenanceVerdict,
+) -> SirReviewCandidate:
+    return SirReviewCandidate(
+        role=role,
+        name=str(file_info.get("name", "")),
+        file_id=str(file_info.get("id") or "") or None,
+        uri=file_info.get("webViewLink") or file_info.get("uri"),
+        provenance_label=verdict.label,
+        provenance_confidence=verdict.confidence,
+        provenance_tier=verdict.tier,
+        provenance_reason=verdict.reason,
+    )

--- a/tests/test_ddr_cli.py
+++ b/tests/test_ddr_cli.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+
+from due_diligence_reporter import ddr_cli
+
+
+def test_ddr_status_reads_manifest(monkeypatch, tmp_path, capsys) -> None:
+    manifest = {
+        "run_id": "run-1",
+        "site_title": "Alpha Keller",
+        "final_status": "generation_failed",
+        "failed_step": "report.generate",
+        "next_operator_action": "ddr rerun --run-id run-1 --step report.generate",
+        "manifest_path": str(tmp_path / "run-1.json"),
+        "quality": {"score": 61, "band": "orange"},
+        "steps": [],
+    }
+    (tmp_path / "run-1.json").write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr("due_diligence_reporter.pipeline_manifest.RUN_MANIFEST_DIR", tmp_path)
+
+    ddr_cli.main(["status", "--run-id", "run-1"])
+
+    out = capsys.readouterr().out
+    assert "Run: run-1" in out
+    assert "Failed step: report.generate" in out
+    assert "Quality: 61 (orange)" in out
+
+
+def test_ddr_trace_failed_only_filters_successes(monkeypatch, tmp_path, capsys) -> None:
+    manifest = {
+        "run_id": "run-1",
+        "steps": [
+            {"step": "readiness.check", "status": "succeeded", "duration_ms": 1},
+            {
+                "step": "report.generate",
+                "status": "failed",
+                "duration_ms": 2,
+                "error": {"code": "boom", "message": "failed"},
+            },
+        ],
+    }
+    (tmp_path / "run-1.json").write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr("due_diligence_reporter.pipeline_manifest.RUN_MANIFEST_DIR", tmp_path)
+
+    ddr_cli.main(["trace", "--run-id", "run-1", "--failed-only"])
+
+    out = capsys.readouterr().out
+    assert "report.generate: failed" in out
+    assert "readiness.check" not in out

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+
+from due_diligence_reporter.pipeline_contracts import (
+    ArtifactRef,
+    PipelineError,
+    PipelineRun,
+    QualityCheck,
+    RunQualityReport,
+    StepResult,
+)
+from due_diligence_reporter.pipeline_manifest import manifest_has_secret_like_value
+from due_diligence_reporter.pipeline_quality import evaluate_run_quality
+
+
+def _step(
+    status: str = "succeeded",
+    *,
+    step: str = "readiness.check",
+    error: PipelineError | None = None,
+) -> StepResult:
+    return StepResult(
+        run_id="run-1",
+        step=step,
+        status=status,  # type: ignore[arg-type]
+        started_at="2026-05-14T00:00:00+00:00",
+        ended_at="2026-05-14T00:00:01+00:00",
+        duration_ms=100,
+        error=error,
+        rerun_command=f"ddr rerun --run-id run-1 --step {step}" if error else None,
+    )
+
+
+def test_pipeline_run_serializes_to_json() -> None:
+    run = PipelineRun(
+        run_id="run-1",
+        site_title="Alpha Keller",
+        site_id="site-1",
+        started_at="2026-05-14T00:00:00+00:00",
+        ended_at="2026-05-14T00:00:02+00:00",
+        final_status="report_created",
+        steps=[
+            StepResult(
+                run_id="run-1",
+                step="report.validate",
+                status="succeeded",
+                started_at="2026-05-14T00:00:00+00:00",
+                ended_at="2026-05-14T00:00:01+00:00",
+                duration_ms=100,
+                artifacts=[
+                    ArtifactRef(
+                        kind="google_doc",
+                        name="DD report",
+                        uri="https://docs.google.com/document/d/doc123",
+                        drive_file_id="doc123",
+                    )
+                ],
+            )
+        ],
+        quality=RunQualityReport(
+            score=100,
+            band="green",
+            checks=[QualityCheck("step_observability", "passed", 25, 25)],
+        ),
+    )
+
+    parsed = json.loads(json.dumps(run.to_dict()))
+
+    assert parsed["run_id"] == "run-1"
+    assert parsed["steps"][0]["artifacts"][0]["drive_file_id"] == "doc123"
+    assert parsed["quality"]["score"] == 100
+
+
+def test_quality_caps_failed_step_without_operator_action() -> None:
+    run = PipelineRun(
+        run_id="run-1",
+        site_title="Alpha Keller",
+        site_id=None,
+        started_at="2026-05-14T00:00:00+00:00",
+        ended_at="2026-05-14T00:00:01+00:00",
+        final_status="generation_failed",
+        steps=[_step("failed", step="report.generate")],
+    )
+
+    quality = evaluate_run_quality(run, manifest_persisted=True)
+
+    assert quality.score <= 70
+    assert "failed_or_blocked_without_operator_action" in quality.caps_applied
+
+
+def test_waiting_on_docs_can_score_high_when_actionable() -> None:
+    err = PipelineError(
+        code="missing_required_documents",
+        message="SIR",
+        retryable=False,
+        operator_action="ddr rerun --run-id run-1 --step readiness.check",
+    )
+    run = PipelineRun(
+        run_id="run-1",
+        site_title="Alpha Keller",
+        site_id=None,
+        started_at="2026-05-14T00:00:00+00:00",
+        ended_at="2026-05-14T00:00:01+00:00",
+        final_status="waiting_on_docs",
+        steps=[_step("blocked", step="readiness.check", error=err)],
+    )
+
+    quality = evaluate_run_quality(run, manifest_persisted=True)
+
+    assert quality.score >= 70
+    assert quality.band in {"green", "yellow"}
+
+
+def test_manifest_secret_detection_rejects_sensitive_keys() -> None:
+    payload = {
+        "run_id": "run-1",
+        "steps": [
+            {
+                "step": "bad",
+                "metadata": {"access_token": "ya29.this-is-a-secret-looking-value"},
+            }
+        ],
+    }
+
+    assert manifest_has_secret_like_value(payload) is True
+
+
+def test_manifest_secret_detection_allows_unresolved_tokens_label() -> None:
+    payload = {
+        "run_id": "run-1",
+        "unresolved_tokens": ["exec.c_answer"],
+    }
+
+    assert manifest_has_secret_like_value(payload) is False

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -141,6 +141,10 @@ class TestProcessSitePipeline:
         assert result.status == "waiting_on_docs"
         assert "Building Inspection" in result.missing_docs
         assert "SIR" not in result.missing_docs
+        readiness_step = next(step for step in result.steps if step.step == "readiness.check")
+        assert readiness_step.status == "blocked"
+        assert result.failed_step == "readiness.check"
+        assert result.quality_score is not None
 
     @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
     def test_report_exists(self, mock_readiness):
@@ -159,6 +163,38 @@ class TestProcessSitePipeline:
         )
 
         assert result.status == "report_exists"
+
+    @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
+    def test_records_sir_learning_review_candidate(self, mock_readiness):
+        """Readiness metadata creates a non-blocking SIR learning step."""
+        mock_readiness.return_value = {
+            "sir_found": True,
+            "isp_found": False,
+            "inspection_found": True,
+            "report_exists": True,
+            "sir_learning_review": {
+                "status": "ready_for_review",
+                "reason": "AI SIR and CDS/vendor SIR are both present",
+                "ai_sir": {"name": "ai.docx", "file_id": "ai"},
+                "cds_sir": {"name": "cds.pdf", "file_id": "cds"},
+            },
+        }
+
+        result = process_site_pipeline(
+            MagicMock(),
+            "Alpha Keller",
+            "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Keller"],
+            {},
+            "system prompt",
+            _make_settings(),
+        )
+
+        assert result.status == "report_exists"
+        assert result.sir_review_status == "ready_for_review"
+        review_step = next(step for step in result.steps if step.step == "sir.learning_review")
+        assert review_step.status == "succeeded"
+        assert review_step.artifacts[0].metadata["cds_sir"]["file_id"] == "cds"
 
     @patch("due_diligence_reporter.server.check_report_completeness")
     @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
@@ -277,6 +313,10 @@ class TestProcessSitePipeline:
 
         assert result.status == "generation_failed"
         assert result.error == "ANTHROPIC_API_KEY not set"
+        assert result.run_id
+        assert result.failed_step == "report.generate"
+        assert result.quality_score is not None
+        assert any(step.step == "report.generate" for step in result.steps)
 
     @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
     def test_readiness_error(self, mock_readiness):
@@ -291,6 +331,7 @@ class TestProcessSitePipeline:
 
         assert result.status == "error"
         assert "Drive API error" in result.error
+        assert result.failed_step == "readiness.check"
 
     @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
     def test_readiness_payload_error(self, mock_readiness):
@@ -373,6 +414,7 @@ class TestProcessSitePipeline:
         assert result.status == "error"
         assert result.doc_id == "doc123"
         assert "export broke" in (result.error or "")
+        assert result.failed_step == "report.validate"
 
     @patch("due_diligence_reporter.report_pipeline.publish_to_dashboard")
     @patch("due_diligence_reporter.server.check_report_completeness")
@@ -439,6 +481,8 @@ class TestProcessSitePipeline:
         assert result.status == "report_incomplete"
         assert result.doc_id == "doc123"
         assert result.error == "Report NOT ready to send. 1 raw template token(s)."
+        assert result.failed_step == "report.validate"
+        assert result.quality_score is not None
         # The HTTP publish must fire on the incomplete branch.
         mock_publish.assert_called_once()
         kwargs = mock_publish.call_args.kwargs
@@ -573,6 +617,9 @@ class TestProcessSitePipeline:
         )
 
         assert result.status == "report_created"
+        assert result.run_id
+        assert result.failed_step is None
+        assert result.quality_band in {"green", "yellow", "orange", "red"}
         mock_publish.assert_called_once()
         # The success path leaves dd_status unset so the publisher's
         # auto-stamp logic still fires ("complete").

--- a/tests/test_sir_learning.py
+++ b/tests/test_sir_learning.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from due_diligence_reporter.provenance import ProvenanceVerdict
+from due_diligence_reporter.sir_learning import build_sir_learning_review
+
+
+def _verdict(label: str) -> ProvenanceVerdict:
+    return ProvenanceVerdict(label, 0.95, "test", f"{label} test verdict")
+
+
+def test_builds_ready_review_when_ai_and_cds_sirs_exist() -> None:
+    files = [
+        {
+            "id": "ai",
+            "name": "alpha-keller_2026-05-14_SIR.docx",
+            "doc_type": "sir",
+            "modifiedTime": "2026-05-14T10:00:00Z",
+        },
+        {
+            "id": "cds",
+            "name": "Alpha Keller CDS SIR.pdf",
+            "doc_type": "sir",
+            "modifiedTime": "2026-05-15T10:00:00Z",
+        },
+    ]
+
+    def fake_classify(file_info, *_args, **_kwargs):
+        return _verdict("ai_generated" if file_info["id"] == "ai" else "vendor")
+
+    with patch("due_diligence_reporter.sir_learning.classify_provenance", fake_classify):
+        review = build_sir_learning_review(files, gc=None)
+
+    data = review.to_dict()
+    assert data["status"] == "ready_for_review"
+    assert data["ai_sir"]["file_id"] == "ai"
+    assert data["cds_sir"]["file_id"] == "cds"
+    assert "source retrieval gap" in data["review_dimensions"]
+
+
+def test_waits_for_cds_sir_when_only_ai_sir_exists() -> None:
+    files = [
+        {
+            "id": "ai",
+            "name": "alpha-keller_2026-05-14_SIR.docx",
+            "doc_type": "sir",
+        }
+    ]
+
+    with patch(
+        "due_diligence_reporter.sir_learning.classify_provenance",
+        return_value=_verdict("ai_generated"),
+    ):
+        review = build_sir_learning_review(files, gc=None)
+
+    assert review.status == "waiting_for_cds_sir"
+    assert review.ai_sir is not None
+    assert review.cds_sir is None


### PR DESCRIPTION
## Summary
- add a documented AI/CDS SIR comparison process and learning-loop taxonomy
- record non-blocking `sir.learning_review` status in pipeline manifests and chat/status output
- add pipeline run manifest, quality scoring, and `ddr` status/trace/rerun inspection support
- add tests for SIR review detection, manifest serialization, quality scoring, and CLI output

## Test plan
- `uv run ruff check src/due_diligence_reporter/sir_learning.py src/due_diligence_reporter/pipeline_contracts.py src/due_diligence_reporter/report_pipeline.py src/due_diligence_reporter/ddr_cli.py tests/test_sir_learning.py tests/test_report_pipeline.py tests/test_pipeline_contracts.py tests/test_ddr_cli.py`
- `uv run mypy src/due_diligence_reporter/sir_learning.py src/due_diligence_reporter/pipeline_contracts.py src/due_diligence_reporter/report_pipeline.py src/due_diligence_reporter/ddr_cli.py`
- `uv run pytest tests/test_sir_learning.py tests/test_report_pipeline.py tests/test_pipeline_contracts.py tests/test_ddr_cli.py`
- `uv run pytest tests --ignore=tests/_tmp`

## Notes
- `tests/_tmp` is ignored in the full-suite command because the checkout contains an existing unreadable pytest cache directory there.