### PR TITLE
Add SIR trend capture

### DIFF
--- a/docs/process/sir-learning-loop.md
+++ b/docs/process/sir-learning-loop.md
@@ -61,6 +61,39 @@ sees SIR candidates. `process_site_pipeline()` records a non-blocking
 The step is observable in the local run manifest, uploaded manifest, Google
 Chat pipeline lines, and `ddr status --run-id ...`.
 
+## Outcome Capture
+
+After a reviewer adjudicates one issue, record it as structured data:
+
+```bash
+ddr sir-review add \
+  --site "Alpha Keller" \
+  --section "Zoning" \
+  --gap-category "AI missed item" \
+  --severity "material" \
+  --ddr-impact "exec.c_zoning" \
+  --evidence-checked "city code section / AHJ email / source doc" \
+  --learning-action "retrieval rule" \
+  --status "accepted" \
+  --ai-sir "AI SIR file id or link" \
+  --cds-sir "CDS SIR file id or link"
+```
+
+The CLI appends each issue to `.ddr-runs/sir-review-outcomes.jsonl`. That file
+is local runtime state and is ignored by Git.
+
+## 30-Day Trend Review
+
+Use a 30-day window by default:
+
+```bash
+ddr sir-trends --since 30d
+```
+
+This reports SIR pairs reviewed, issue counts, AI misses per SIR, unsupported
+AI claims per SIR, CDS misses per SIR, DDR-impacting findings, high/material
+findings, repeated section/category issues, and accepted learning actions.
+
 ## Fit With DDR Improvements
 
 This loop plugs into the broader DDR quality work from the run manifest effort:
@@ -76,7 +109,10 @@ This loop plugs into the broader DDR quality work from the run manifest effort:
 
 ## Operating Cadence
 
-Run a weekly sample of recent review-ready sites until the gap rate stabilizes.
+Run a weekly sample of recent review-ready sites and use the 30-day trend view
+to decide process updates. Do not update the process after every individual SIR
+unless the finding is blocking or materially risky.
+
 Track:
 
 - number of SIR pairs reviewed

--- a/src/due_diligence_reporter/ddr_cli.py
+++ b/src/due_diligence_reporter/ddr_cli.py
@@ -3,9 +3,18 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 from typing import Any
 
 from .pipeline_manifest import load_run_manifest
+from .sir_trends import (
+    DEFAULT_SINCE,
+    append_review_outcome,
+    load_review_outcomes,
+    make_review_outcome,
+    parse_since,
+    summarize_sir_trends,
+)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -26,6 +35,27 @@ def main(argv: list[str] | None = None) -> None:
     diagnose_parser = subparsers.add_parser("diagnose", help="Print diagnostic command")
     diagnose_parser.add_argument("--site", required=True)
 
+    review_parser = subparsers.add_parser("sir-review", help="Record SIR review outcomes")
+    review_subparsers = review_parser.add_subparsers(dest="sir_review_command", required=True)
+    review_add = review_subparsers.add_parser("add", help="Add one adjudicated SIR issue")
+    review_add.add_argument("--site", required=True)
+    review_add.add_argument("--section", required=True)
+    review_add.add_argument("--gap-category", required=True)
+    review_add.add_argument("--severity", required=True)
+    review_add.add_argument("--ddr-impact", required=True)
+    review_add.add_argument("--evidence-checked", required=True)
+    review_add.add_argument("--learning-action", required=True)
+    review_add.add_argument("--status", required=True)
+    review_add.add_argument("--ai-sir", default="")
+    review_add.add_argument("--cds-sir", default="")
+    review_add.add_argument("--notes", default="")
+    review_add.add_argument("--created-at", default=None)
+    review_add.add_argument("--store", default=None)
+
+    trends_parser = subparsers.add_parser("sir-trends", help="Summarize SIR review trends")
+    trends_parser.add_argument("--since", default=DEFAULT_SINCE)
+    trends_parser.add_argument("--store", default=None)
+
     args = parser.parse_args(argv)
     if args.command == "status":
         _print_status(load_run_manifest(args.run_id))
@@ -35,6 +65,10 @@ def main(argv: list[str] | None = None) -> None:
         _print_rerun(load_run_manifest(args.run_id), args.step)
     elif args.command == "diagnose":
         print(f"uv run python scripts/daily_dd_check.py --site \"{args.site}\"")
+    elif args.command == "sir-review":
+        _record_sir_review(args)
+    elif args.command == "sir-trends":
+        _print_sir_trends(args)
 
 
 def _print_status(manifest: dict[str, Any]) -> None:
@@ -68,6 +102,60 @@ def _print_rerun(manifest: dict[str, Any], step_name: str) -> None:
             print(step.get("rerun_command") or f"ddr rerun --run-id {manifest.get('run_id')} --step {step_name}")
             return
     print(f"Unknown step: {step_name}")
+
+
+def _record_sir_review(args: argparse.Namespace) -> None:
+    outcome = make_review_outcome(
+        site=args.site,
+        ai_sir=args.ai_sir,
+        cds_sir=args.cds_sir,
+        section=args.section,
+        gap_category=args.gap_category,
+        severity=args.severity,
+        ddr_impact=args.ddr_impact,
+        evidence_checked=args.evidence_checked,
+        learning_action=args.learning_action,
+        status=args.status,
+        notes=args.notes,
+        created_at=args.created_at,
+    )
+    path = append_review_outcome(outcome, path=_store_path(args.store))
+    print(f"Recorded SIR review issue: {outcome.review_id}")
+    print(f"Store: {path}")
+
+
+def _print_sir_trends(args: argparse.Namespace) -> None:
+    since = parse_since(args.since)
+    summary = summarize_sir_trends(
+        load_review_outcomes(path=_store_path(args.store)),
+        since=since,
+    )
+    print(f"SIR Trends since {args.since}")
+    print(f"Issues: {summary['total_issues']}")
+    print(f"Sites reviewed: {summary['sites_reviewed']}")
+    print(f"SIR pairs reviewed: {summary['sir_pairs_reviewed']}")
+    print(f"AI missed items/SIR: {summary['ai_missed_items_per_sir']}")
+    print(f"AI unsupported claims/SIR: {summary['ai_unsupported_claims_per_sir']}")
+    print(f"CDS missed items/SIR: {summary['cds_missed_items_per_sir']}")
+    print(f"DDR-impacting findings: {summary['ddr_impacting_findings']}")
+    print(f"Blocking/material findings: {summary['blocking_or_material_findings']}")
+    _print_counter("Top categories", summary["by_category"])
+    _print_counter("Top sections", summary["by_section"])
+    _print_counter("Learning actions", summary["by_learning_action"])
+    _print_counter("Repeat issues", summary["repeat_issues"])
+
+
+def _print_counter(title: str, values: dict[str, int]) -> None:
+    print(f"{title}:")
+    if not values:
+        print("  (none)")
+        return
+    for key, count in sorted(values.items(), key=lambda item: (-item[1], item[0]))[:10]:
+        print(f"  {key}: {count}")
+
+
+def _store_path(value: str | None) -> Path | None:
+    return Path(value) if value else None
 
 
 if __name__ == "__main__":

--- a/src/due_diligence_reporter/sir_trends.py
+++ b/src/due_diligence_reporter/sir_trends.py
@@ -1,0 +1,225 @@
+"""Structured SIR review outcomes and 30-day trend summaries."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .pipeline_manifest import PROJECT_ROOT
+
+REVIEW_OUTCOME_PATH = PROJECT_ROOT / ".ddr-runs" / "sir-review-outcomes.jsonl"
+DEFAULT_SINCE = "30d"
+
+
+@dataclass(frozen=True)
+class SirReviewOutcome:
+    """One adjudicated issue from an AI/CDS SIR comparison."""
+
+    review_id: str
+    created_at: str
+    site: str
+    ai_sir: str
+    cds_sir: str
+    section: str
+    gap_category: str
+    severity: str
+    ddr_impact: str
+    evidence_checked: str
+    learning_action: str
+    status: str
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "review_id": self.review_id,
+            "created_at": self.created_at,
+            "site": self.site,
+            "ai_sir": self.ai_sir,
+            "cds_sir": self.cds_sir,
+            "section": self.section,
+            "gap_category": self.gap_category,
+            "severity": self.severity,
+            "ddr_impact": self.ddr_impact,
+            "evidence_checked": self.evidence_checked,
+            "learning_action": self.learning_action,
+            "status": self.status,
+            "notes": self.notes,
+        }
+
+
+def make_review_outcome(
+    *,
+    site: str,
+    section: str,
+    gap_category: str,
+    severity: str,
+    ddr_impact: str,
+    evidence_checked: str,
+    learning_action: str,
+    status: str,
+    ai_sir: str = "",
+    cds_sir: str = "",
+    notes: str = "",
+    created_at: str | None = None,
+) -> SirReviewOutcome:
+    """Build a review outcome with normalized, queryable fields."""
+    return SirReviewOutcome(
+        review_id=uuid4().hex,
+        created_at=created_at or datetime.now(UTC).isoformat(),
+        site=_required(site, "site"),
+        ai_sir=ai_sir.strip(),
+        cds_sir=cds_sir.strip(),
+        section=_required(section, "section"),
+        gap_category=_required(gap_category, "gap_category"),
+        severity=_required(severity, "severity"),
+        ddr_impact=_required(ddr_impact, "ddr_impact"),
+        evidence_checked=_required(evidence_checked, "evidence_checked"),
+        learning_action=_required(learning_action, "learning_action"),
+        status=_required(status, "status"),
+        notes=notes.strip(),
+    )
+
+
+def append_review_outcome(
+    outcome: SirReviewOutcome,
+    *,
+    path: Path | None = None,
+) -> Path:
+    """Append one review outcome to the JSONL store."""
+    target = path or REVIEW_OUTCOME_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(outcome.to_dict(), sort_keys=True) + "\n")
+    return target
+
+
+def load_review_outcomes(*, path: Path | None = None) -> list[dict[str, Any]]:
+    """Load review outcomes from the JSONL store."""
+    target = path or REVIEW_OUTCOME_PATH
+    if not target.exists():
+        return []
+
+    outcomes: list[dict[str, Any]] = []
+    for line_number, line in enumerate(target.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSONL at {target}:{line_number}") from exc
+        if isinstance(payload, dict):
+            outcomes.append(payload)
+    return outcomes
+
+
+def parse_since(value: str, *, now: datetime | None = None) -> datetime:
+    """Parse a relative day window like ``30d`` or an ISO timestamp."""
+    raw = value.strip() or DEFAULT_SINCE
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+
+    if raw.endswith("d") and raw[:-1].isdigit():
+        return current - timedelta(days=int(raw[:-1]))
+
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("since must be a day window like 30d or an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def summarize_sir_trends(
+    outcomes: list[dict[str, Any]],
+    *,
+    since: datetime,
+) -> dict[str, Any]:
+    """Aggregate review outcomes since the supplied timestamp."""
+    filtered = [outcome for outcome in outcomes if _created_at(outcome) >= since]
+    sites = {str(item.get("site", "")).strip() for item in filtered if item.get("site")}
+    pair_keys = {
+        (
+            str(item.get("site", "")).strip(),
+            str(item.get("ai_sir", "")).strip(),
+            str(item.get("cds_sir", "")).strip(),
+        )
+        for item in filtered
+    }
+    pair_count = len(pair_keys)
+    denominator = max(pair_count, len(sites), 1)
+
+    by_category = _counter(filtered, "gap_category")
+    repeat_issues = {
+        key: count
+        for key, count in Counter(
+            f"{item.get('section', '')} | {item.get('gap_category', '')}"
+            for item in filtered
+        ).items()
+        if count > 1
+    }
+
+    return {
+        "since": since.isoformat(),
+        "total_issues": len(filtered),
+        "sites_reviewed": len(sites),
+        "sir_pairs_reviewed": pair_count,
+        "ai_missed_items_per_sir": _rate(by_category.get("AI missed item", 0), denominator),
+        "ai_unsupported_claims_per_sir": _rate(
+            by_category.get("AI unsupported claim", 0), denominator
+        ),
+        "cds_missed_items_per_sir": _rate(by_category.get("CDS missed item", 0), denominator),
+        "ddr_impacting_findings": sum(1 for item in filtered if _has_ddr_impact(item)),
+        "blocking_or_material_findings": sum(
+            1
+            for item in filtered
+            if str(item.get("severity", "")).strip().lower() in {"blocking", "material"}
+        ),
+        "by_category": dict(by_category),
+        "by_section": dict(_counter(filtered, "section")),
+        "by_severity": dict(_counter(filtered, "severity")),
+        "by_status": dict(_counter(filtered, "status")),
+        "by_learning_action": dict(_counter(filtered, "learning_action")),
+        "repeat_issues": repeat_issues,
+    }
+
+
+def _required(value: str, field_name: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} is required")
+    return stripped
+
+
+def _created_at(outcome: dict[str, Any]) -> datetime:
+    raw = str(outcome.get("created_at", ""))
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _counter(outcomes: list[dict[str, Any]], field: str) -> Counter[str]:
+    return Counter(
+        str(item.get(field, "")).strip() or "(blank)"
+        for item in outcomes
+    )
+
+
+def _rate(count: int, denominator: int) -> float:
+    return round(count / denominator, 2)
+
+
+def _has_ddr_impact(outcome: dict[str, Any]) -> bool:
+    impact = str(outcome.get("ddr_impact", "")).strip().lower()
+    return impact not in {"", "none", "no", "n/a"}

--- a/tests/test_ddr_cli.py
+++ b/tests/test_ddr_cli.py
@@ -48,3 +48,57 @@ def test_ddr_trace_failed_only_filters_successes(monkeypatch, tmp_path, capsys) 
     out = capsys.readouterr().out
     assert "report.generate: failed" in out
     assert "readiness.check" not in out
+
+
+def test_ddr_sir_review_add_records_issue(tmp_path, capsys) -> None:
+    store = tmp_path / "sir-review-outcomes.jsonl"
+
+    ddr_cli.main([
+        "sir-review",
+        "add",
+        "--site",
+        "Alpha Keller",
+        "--section",
+        "Zoning",
+        "--gap-category",
+        "AI missed item",
+        "--severity",
+        "material",
+        "--ddr-impact",
+        "exec.c_zoning",
+        "--evidence-checked",
+        "city code",
+        "--learning-action",
+        "retrieval rule",
+        "--status",
+        "accepted",
+        "--store",
+        str(store),
+    ])
+
+    out = capsys.readouterr().out
+    assert "Recorded SIR review issue" in out
+    assert "Alpha Keller" in store.read_text(encoding="utf-8")
+
+
+def test_ddr_sir_trends_defaults_to_30d(tmp_path, capsys) -> None:
+    store = tmp_path / "sir-review-outcomes.jsonl"
+    store.write_text(
+        "\n".join([
+            (
+                '{"created_at":"2099-01-01T00:00:00+00:00","site":"Alpha Keller",'
+                '"ai_sir":"ai","cds_sir":"cds","section":"Zoning",'
+                '"gap_category":"AI missed item","severity":"material",'
+                '"ddr_impact":"exec.c_zoning","learning_action":"retrieval rule",'
+                '"status":"accepted"}'
+            )
+        ]),
+        encoding="utf-8",
+    )
+
+    ddr_cli.main(["sir-trends", "--store", str(store)])
+
+    out = capsys.readouterr().out
+    assert "SIR Trends since 30d" in out
+    assert "Issues: 1" in out
+    assert "AI missed items/SIR: 1.0" in out

--- a/tests/test_sir_trends.py
+++ b/tests/test_sir_trends.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from due_diligence_reporter.sir_trends import (
+    append_review_outcome,
+    load_review_outcomes,
+    make_review_outcome,
+    parse_since,
+    summarize_sir_trends,
+)
+
+
+def test_review_outcome_round_trips_jsonl(tmp_path) -> None:
+    store = tmp_path / "sir-review-outcomes.jsonl"
+    outcome = make_review_outcome(
+        site="Alpha Keller",
+        ai_sir="ai-doc",
+        cds_sir="cds-doc",
+        section="Zoning",
+        gap_category="AI missed item",
+        severity="material",
+        ddr_impact="exec.c_zoning",
+        evidence_checked="city code",
+        learning_action="retrieval rule",
+        status="accepted",
+        created_at="2026-05-01T00:00:00+00:00",
+    )
+
+    append_review_outcome(outcome, path=store)
+
+    loaded = load_review_outcomes(path=store)
+    assert loaded[0]["site"] == "Alpha Keller"
+    assert loaded[0]["gap_category"] == "AI missed item"
+
+
+def test_summarizes_30_day_trends() -> None:
+    outcomes = [
+        {
+            "created_at": "2026-05-01T00:00:00+00:00",
+            "site": "Alpha Keller",
+            "ai_sir": "ai-1",
+            "cds_sir": "cds-1",
+            "section": "Zoning",
+            "gap_category": "AI missed item",
+            "severity": "material",
+            "ddr_impact": "exec.c_zoning",
+            "learning_action": "retrieval rule",
+            "status": "accepted",
+        },
+        {
+            "created_at": "2026-05-02T00:00:00+00:00",
+            "site": "Alpha Keller",
+            "ai_sir": "ai-1",
+            "cds_sir": "cds-1",
+            "section": "Zoning",
+            "gap_category": "AI unsupported claim",
+            "severity": "cleanup",
+            "ddr_impact": "none",
+            "learning_action": "prompt update",
+            "status": "open",
+        },
+        {
+            "created_at": "2026-05-03T00:00:00+00:00",
+            "site": "Alpha Keller",
+            "ai_sir": "ai-1",
+            "cds_sir": "cds-1",
+            "section": "Zoning",
+            "gap_category": "AI missed item",
+            "severity": "blocking",
+            "ddr_impact": "exec.c_zoning",
+            "learning_action": "retrieval rule",
+            "status": "accepted",
+        },
+        {
+            "created_at": "2026-03-01T00:00:00+00:00",
+            "site": "Old Site",
+            "section": "Permits",
+            "gap_category": "CDS missed item",
+            "severity": "material",
+            "ddr_impact": "exec.c_permit_timeline",
+            "learning_action": "QC checklist item",
+            "status": "accepted",
+        },
+    ]
+
+    summary = summarize_sir_trends(
+        outcomes,
+        since=datetime(2026, 4, 15, tzinfo=UTC),
+    )
+
+    assert summary["total_issues"] == 3
+    assert summary["sites_reviewed"] == 1
+    assert summary["sir_pairs_reviewed"] == 1
+    assert summary["ai_missed_items_per_sir"] == 2.0
+    assert summary["ai_unsupported_claims_per_sir"] == 1.0
+    assert summary["ddr_impacting_findings"] == 2
+    assert summary["repeat_issues"]["Zoning | AI missed item"] == 2
+
+
+def test_parse_since_defaults_to_day_window() -> None:
+    now = datetime(2026, 5, 15, tzinfo=UTC)
+
+    assert parse_since("30d", now=now) == datetime(2026, 4, 15, tzinfo=UTC)


### PR DESCRIPTION
## Summary
- add JSONL-backed capture for adjudicated AI/CDS SIR review issues
- add `ddr sir-review add` for recording structured review outcomes
- add `ddr sir-trends --since 30d` as the default trend view
- document the 30-day trend cadence and capture workflow

## Test plan
- `uv run ruff check src/due_diligence_reporter/sir_trends.py src/due_diligence_reporter/sir_learning.py src/due_diligence_reporter/ddr_cli.py tests/test_sir_trends.py tests/test_sir_learning.py tests/test_ddr_cli.py`
- `uv run mypy src/due_diligence_reporter/sir_trends.py src/due_diligence_reporter/sir_learning.py src/due_diligence_reporter/ddr_cli.py`
- `uv run pytest tests/test_sir_trends.py tests/test_sir_learning.py tests/test_ddr_cli.py`
- `uv run pytest tests --ignore=tests/_tmp`

## Notes
- `tests/_tmp` is ignored in the full-suite command because the checkout contains an existing unreadable pytest cache directory there.