### PR TITLE
[codex] Add continuous SIR review workflow

### DIFF
--- a/docs/process/sir-learning-loop.md
+++ b/docs/process/sir-learning-loop.md
@@ -61,6 +61,31 @@ sees SIR candidates. `process_site_pipeline()` records a non-blocking
 The step is observable in the local run manifest, uploaded manifest, Google
 Chat pipeline lines, and `ddr status --run-id ...`.
 
+## Weekly Review Queue
+
+Use the queue command to find recent SIR pairs that are ready for claim-level
+review:
+
+```bash
+ddr sir-review queue
+```
+
+By default, the queue scans local `.ddr-runs/*.json` manifests, shows only
+`ready_for_review` pairs, deduplicates repeated manifests for the same site/SIR
+pair, and hides pairs that already have matching outcomes in
+`.ddr-runs/sir-review-outcomes.jsonl`.
+
+Useful options:
+
+```bash
+ddr sir-review queue --status all
+ddr sir-review queue --include-reviewed
+ddr sir-review queue --limit 25
+```
+
+Treat Gmail as a discovery fallback only. The operating queue should come from
+pipeline manifests and the site/Drive/LocationOS record.
+
 ## Outcome Capture
 
 After a reviewer adjudicates one issue, record it as structured data:
@@ -94,6 +119,15 @@ This reports SIR pairs reviewed, issue counts, AI misses per SIR, unsupported
 AI claims per SIR, CDS misses per SIR, DDR-impacting findings, high/material
 findings, repeated section/category issues, and accepted learning actions.
 
+For a monthly operating memo, use:
+
+```bash
+ddr sir-monthly-summary --since 30d
+```
+
+This prints a short markdown summary with review volume, reliability signals,
+repeat patterns, accepted learning actions, and monthly decision prompts.
+
 ## Fit With DDR Improvements
 
 This loop plugs into the broader DDR quality work from the run manifest effort:
@@ -121,3 +155,16 @@ Track:
 - CDS/vendor corrections that changed DDR output
 - learning actions implemented
 - repeat issues after implementation
+
+Recommended continuous loop:
+
+1. Weekly: run `ddr sir-review queue` and select 3-5 unreviewed
+   `ready_for_review` pairs.
+2. During review: record only adjudicated issue rows with
+   `ddr sir-review add`.
+3. Weekly or biweekly: run `ddr sir-trends --since 30d` to watch repeat
+   categories and sections.
+4. Monthly: run `ddr sir-monthly-summary --since 30d`, decide the 2-3 process
+   updates to make, and assign each to the narrowest owner.
+5. After implementation: keep the same categories stable so the next 30-day
+   window shows whether the repeat issue actually declines.

--- a/src/due_diligence_reporter/ddr_cli.py
+++ b/src/due_diligence_reporter/ddr_cli.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from .pipeline_manifest import load_run_manifest
+from .sir_review_queue import QUEUE_STATUSES, READY_STATUS, load_sir_review_queue
 from .sir_trends import (
     DEFAULT_SINCE,
     append_review_outcome,
+    format_monthly_learning_summary,
     load_review_outcomes,
     make_review_outcome,
     parse_since,
@@ -51,10 +53,27 @@ def main(argv: list[str] | None = None) -> None:
     review_add.add_argument("--notes", default="")
     review_add.add_argument("--created-at", default=None)
     review_add.add_argument("--store", default=None)
+    review_queue = review_subparsers.add_parser("queue", help="List SIR pairs ready for review")
+    review_queue.add_argument(
+        "--status",
+        choices=[*QUEUE_STATUSES, "all"],
+        default=READY_STATUS,
+    )
+    review_queue.add_argument("--limit", type=int, default=10)
+    review_queue.add_argument("--include-reviewed", action="store_true")
+    review_queue.add_argument("--manifest-dir", default=None)
+    review_queue.add_argument("--store", default=None)
 
     trends_parser = subparsers.add_parser("sir-trends", help="Summarize SIR review trends")
     trends_parser.add_argument("--since", default=DEFAULT_SINCE)
     trends_parser.add_argument("--store", default=None)
+
+    monthly_parser = subparsers.add_parser(
+        "sir-monthly-summary",
+        help="Print a monthly SIR learning summary",
+    )
+    monthly_parser.add_argument("--since", default=DEFAULT_SINCE)
+    monthly_parser.add_argument("--store", default=None)
 
     args = parser.parse_args(argv)
     if args.command == "status":
@@ -66,9 +85,11 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "diagnose":
         print(f"uv run python scripts/daily_dd_check.py --site \"{args.site}\"")
     elif args.command == "sir-review":
-        _record_sir_review(args)
+        _handle_sir_review(args)
     elif args.command == "sir-trends":
         _print_sir_trends(args)
+    elif args.command == "sir-monthly-summary":
+        _print_sir_monthly_summary(args)
 
 
 def _print_status(manifest: dict[str, Any]) -> None:
@@ -104,6 +125,13 @@ def _print_rerun(manifest: dict[str, Any], step_name: str) -> None:
     print(f"Unknown step: {step_name}")
 
 
+def _handle_sir_review(args: argparse.Namespace) -> None:
+    if args.sir_review_command == "add":
+        _record_sir_review(args)
+    elif args.sir_review_command == "queue":
+        _print_sir_review_queue(args)
+
+
 def _record_sir_review(args: argparse.Namespace) -> None:
     outcome = make_review_outcome(
         site=args.site,
@@ -124,6 +152,32 @@ def _record_sir_review(args: argparse.Namespace) -> None:
     print(f"Store: {path}")
 
 
+def _print_sir_review_queue(args: argparse.Namespace) -> None:
+    statuses = QUEUE_STATUSES if args.status == "all" else (args.status,)
+    queue = load_sir_review_queue(
+        manifest_dir=_path_arg(args.manifest_dir),
+        outcomes=load_review_outcomes(path=_store_path(args.store)),
+        statuses=statuses,
+        include_reviewed=args.include_reviewed,
+        limit=args.limit,
+    )
+    reviewed_note = "including reviewed" if args.include_reviewed else "unreviewed only"
+    print(f"SIR Review Queue ({args.status}, {reviewed_note})")
+    print(f"Items: {len(queue)}")
+    if not queue:
+        return
+    for index, item in enumerate(queue, 1):
+        print(f"{index}. {item.site_title}")
+        print(f"   Status: {item.status}")
+        if item.reason:
+            print(f"   Reason: {item.reason}")
+        print(f"   AI SIR: {_doc_label(item.ai_sir_name, item.ai_sir_file_id, item.ai_sir_uri)}")
+        print(f"   CDS SIR: {_doc_label(item.cds_sir_name, item.cds_sir_file_id, item.cds_sir_uri)}")
+        print(f"   Reviewed: {'yes' if item.reviewed else 'no'}")
+        print(f"   Run: {item.run_id}")
+        print(f"   Manifest: {item.manifest_path}")
+
+
 def _print_sir_trends(args: argparse.Namespace) -> None:
     since = parse_since(args.since)
     summary = summarize_sir_trends(
@@ -142,7 +196,17 @@ def _print_sir_trends(args: argparse.Namespace) -> None:
     _print_counter("Top categories", summary["by_category"])
     _print_counter("Top sections", summary["by_section"])
     _print_counter("Learning actions", summary["by_learning_action"])
+    _print_counter("Accepted learning actions", summary["accepted_learning_actions"])
     _print_counter("Repeat issues", summary["repeat_issues"])
+
+
+def _print_sir_monthly_summary(args: argparse.Namespace) -> None:
+    since = parse_since(args.since)
+    summary = summarize_sir_trends(
+        load_review_outcomes(path=_store_path(args.store)),
+        since=since,
+    )
+    print(format_monthly_learning_summary(summary, since_label=args.since))
 
 
 def _print_counter(title: str, values: dict[str, int]) -> None:
@@ -156,6 +220,19 @@ def _print_counter(title: str, values: dict[str, int]) -> None:
 
 def _store_path(value: str | None) -> Path | None:
     return Path(value) if value else None
+
+
+def _path_arg(value: str | None) -> Path | None:
+    return Path(value) if value else None
+
+
+def _doc_label(name: str, file_id: str, uri: str) -> str:
+    label = name or file_id or uri
+    if not label:
+        return "(missing)"
+    if file_id and name:
+        return f"{name} ({file_id})"
+    return label
 
 
 if __name__ == "__main__":

--- a/src/due_diligence_reporter/sir_review_queue.py
+++ b/src/due_diligence_reporter/sir_review_queue.py
@@ -1,0 +1,185 @@
+"""SIR review queue helpers built from local pipeline manifests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from .pipeline_manifest import RUN_MANIFEST_DIR
+
+READY_STATUS = "ready_for_review"
+WAITING_STATUSES = ("waiting_for_cds_sir", "waiting_for_ai_sir")
+QUEUE_STATUSES = (READY_STATUS, *WAITING_STATUSES)
+
+
+@dataclass(frozen=True)
+class SirReviewQueueItem:
+    """One site/run that has SIR learning-review metadata."""
+
+    run_id: str
+    site_title: str
+    status: str
+    reason: str
+    started_at: str
+    manifest_path: str
+    ai_sir_name: str
+    ai_sir_file_id: str
+    ai_sir_uri: str
+    cds_sir_name: str
+    cds_sir_file_id: str
+    cds_sir_uri: str
+    reviewed: bool
+
+
+def load_sir_review_queue(
+    *,
+    manifest_dir: Path | None = None,
+    outcomes: list[dict[str, Any]] | None = None,
+    statuses: tuple[str, ...] = (READY_STATUS,),
+    include_reviewed: bool = False,
+    limit: int | None = None,
+) -> list[SirReviewQueueItem]:
+    """Load SIR review candidates from pipeline manifests."""
+    base = manifest_dir or RUN_MANIFEST_DIR
+    if not base.exists():
+        return []
+
+    review_outcomes = outcomes or []
+    items = [
+        item
+        for path in base.glob("*.json")
+        if (item := _item_from_manifest_path(path, review_outcomes)) is not None
+        and item.status in statuses
+    ]
+    deduped = _dedupe_latest(items)
+    if not include_reviewed:
+        deduped = [item for item in deduped if not item.reviewed]
+    ordered = sorted(deduped, key=_queue_sort_key, reverse=True)
+    return ordered[:limit] if limit is not None else ordered
+
+
+def _item_from_manifest_path(
+    path: Path,
+    outcomes: list[dict[str, Any]],
+) -> SirReviewQueueItem | None:
+    try:
+        payload = cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return None
+    review = payload.get("sir_learning_review")
+    if not isinstance(review, dict):
+        return None
+    status = str(review.get("status") or "").strip()
+    if not status:
+        return None
+    ai_sir = _candidate(review.get("ai_sir"))
+    cds_sir = _candidate(review.get("cds_sir"))
+    item = SirReviewQueueItem(
+        run_id=str(payload.get("run_id") or path.stem),
+        site_title=str(payload.get("site_title") or "(unknown site)"),
+        status=status,
+        reason=str(review.get("reason") or ""),
+        started_at=str(payload.get("started_at") or ""),
+        manifest_path=str(path),
+        ai_sir_name=ai_sir["name"],
+        ai_sir_file_id=ai_sir["file_id"],
+        ai_sir_uri=ai_sir["uri"],
+        cds_sir_name=cds_sir["name"],
+        cds_sir_file_id=cds_sir["file_id"],
+        cds_sir_uri=cds_sir["uri"],
+        reviewed=False,
+    )
+    return _mark_reviewed(item, outcomes)
+
+
+def _candidate(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {"name": "", "file_id": "", "uri": ""}
+    return {
+        "name": str(value.get("name") or ""),
+        "file_id": str(value.get("file_id") or ""),
+        "uri": str(value.get("uri") or ""),
+    }
+
+
+def _mark_reviewed(
+    item: SirReviewQueueItem,
+    outcomes: list[dict[str, Any]],
+) -> SirReviewQueueItem:
+    reviewed = any(_matches_outcome(item, outcome) for outcome in outcomes)
+    return SirReviewQueueItem(
+        run_id=item.run_id,
+        site_title=item.site_title,
+        status=item.status,
+        reason=item.reason,
+        started_at=item.started_at,
+        manifest_path=item.manifest_path,
+        ai_sir_name=item.ai_sir_name,
+        ai_sir_file_id=item.ai_sir_file_id,
+        ai_sir_uri=item.ai_sir_uri,
+        cds_sir_name=item.cds_sir_name,
+        cds_sir_file_id=item.cds_sir_file_id,
+        cds_sir_uri=item.cds_sir_uri,
+        reviewed=reviewed,
+    )
+
+
+def _matches_outcome(item: SirReviewQueueItem, outcome: dict[str, Any]) -> bool:
+    ai_value = _normalize(str(outcome.get("ai_sir") or ""))
+    cds_value = _normalize(str(outcome.get("cds_sir") or ""))
+    site_value = _normalize(str(outcome.get("site") or ""))
+    ai_matches = not ai_value or ai_value in _sir_keys(
+        item.ai_sir_name,
+        item.ai_sir_file_id,
+        item.ai_sir_uri,
+    )
+    cds_matches = not cds_value or cds_value in _sir_keys(
+        item.cds_sir_name,
+        item.cds_sir_file_id,
+        item.cds_sir_uri,
+    )
+    site_matches = not site_value or site_value == _normalize(item.site_title)
+    has_match_value = bool(ai_value or cds_value or site_value)
+    return site_matches and ai_matches and cds_matches and has_match_value
+
+
+def _sir_keys(*values: str) -> set[str]:
+    return {_normalize(value) for value in values if _normalize(value)}
+
+
+def _dedupe_latest(items: list[SirReviewQueueItem]) -> list[SirReviewQueueItem]:
+    latest: dict[tuple[str, str, str, str], SirReviewQueueItem] = {}
+    for item in items:
+        key = (
+            _normalize(item.status),
+            _normalize(item.site_title),
+            _normalize(item.ai_sir_file_id or item.ai_sir_name),
+            _normalize(item.cds_sir_file_id or item.cds_sir_name),
+        )
+        existing = latest.get(key)
+        if existing is None or _parse_timestamp(item.started_at) > _parse_timestamp(
+            existing.started_at
+        ):
+            latest[key] = item
+    return list(latest.values())
+
+
+def _queue_sort_key(item: SirReviewQueueItem) -> tuple[datetime, str]:
+    return (_parse_timestamp(item.started_at), item.site_title)
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _normalize(value: str) -> str:
+    return " ".join(value.strip().lower().split())

--- a/src/due_diligence_reporter/sir_trends.py
+++ b/src/due_diligence_reporter/sir_trends.py
@@ -144,6 +144,11 @@ def summarize_sir_trends(
 ) -> dict[str, Any]:
     """Aggregate review outcomes since the supplied timestamp."""
     filtered = [outcome for outcome in outcomes if _created_at(outcome) >= since]
+    accepted = [
+        outcome
+        for outcome in filtered
+        if str(outcome.get("status", "")).strip().lower() == "accepted"
+    ]
     sites = {str(item.get("site", "")).strip() for item in filtered if item.get("site")}
     pair_keys = {
         (
@@ -187,8 +192,52 @@ def summarize_sir_trends(
         "by_severity": dict(_counter(filtered, "severity")),
         "by_status": dict(_counter(filtered, "status")),
         "by_learning_action": dict(_counter(filtered, "learning_action")),
+        "accepted_learning_actions": dict(_counter(accepted, "learning_action")),
         "repeat_issues": repeat_issues,
     }
+
+
+def format_monthly_learning_summary(
+    summary: dict[str, Any],
+    *,
+    since_label: str = DEFAULT_SINCE,
+) -> str:
+    """Format a lightweight monthly SIR learning memo from a trend summary."""
+    lines = [
+        f"# SIR Learning Summary ({since_label})",
+        "",
+        "## Review Volume",
+        f"- Issues reviewed: {summary['total_issues']}",
+        f"- Sites reviewed: {summary['sites_reviewed']}",
+        f"- SIR pairs reviewed: {summary['sir_pairs_reviewed']}",
+        f"- DDR-impacting findings: {summary['ddr_impacting_findings']}",
+        f"- Blocking/material findings: {summary['blocking_or_material_findings']}",
+        "",
+        "## Reliability Signals",
+        f"- AI missed items per SIR: {summary['ai_missed_items_per_sir']}",
+        f"- AI unsupported claims per SIR: {summary['ai_unsupported_claims_per_sir']}",
+        f"- CDS missed items per SIR: {summary['cds_missed_items_per_sir']}",
+        "",
+        "## Top Repeat Patterns",
+        *_counter_lines(summary.get("repeat_issues", {})),
+        "",
+        "## Top Categories",
+        *_counter_lines(summary.get("by_category", {})),
+        "",
+        "## Top Affected Sections",
+        *_counter_lines(summary.get("by_section", {})),
+        "",
+        "## Accepted Learning Actions",
+        *_counter_lines(summary.get("accepted_learning_actions", {})),
+        "",
+        "## Monthly Decisions",
+        "- Promote repeated source-retrieval misses into retrieval rules.",
+        "- Promote repeated reasoning failures into SIR prompt guidance.",
+        "- Promote repeated formatting or missing sections into the SIR template.",
+        "- Promote vendor-only gaps into CDS/vendor task cards.",
+        "- Promote repeated DDR token impact into DDR mapping or prompt changes.",
+    ]
+    return "\n".join(lines)
 
 
 def _required(value: str, field_name: str) -> str:
@@ -214,6 +263,18 @@ def _counter(outcomes: list[dict[str, Any]], field: str) -> Counter[str]:
         str(item.get(field, "")).strip() or "(blank)"
         for item in outcomes
     )
+
+
+def _counter_lines(values: Any, *, limit: int = 5) -> list[str]:
+    if not isinstance(values, dict) or not values:
+        return ["- None"]
+    return [
+        f"- {key}: {count}"
+        for key, count in sorted(
+            values.items(),
+            key=lambda item: (-int(item[1]), str(item[0])),
+        )[:limit]
+    ]
 
 
 def _rate(count: int, denominator: int) -> float:

--- a/tests/test_ddr_cli.py
+++ b/tests/test_ddr_cli.py
@@ -102,3 +102,86 @@ def test_ddr_sir_trends_defaults_to_30d(tmp_path, capsys) -> None:
     assert "SIR Trends since 30d" in out
     assert "Issues: 1" in out
     assert "AI missed items/SIR: 1.0" in out
+
+
+def test_ddr_sir_review_queue_lists_ready_pairs(tmp_path, capsys) -> None:
+    manifest = {
+        "run_id": "run-ready",
+        "site_title": "Alpha Keller",
+        "started_at": "2026-05-15T00:00:00+00:00",
+        "sir_learning_review": {
+            "status": "ready_for_review",
+            "reason": "AI SIR and CDS/vendor SIR are both present",
+            "ai_sir": {"name": "ai.docx", "file_id": "ai-id"},
+            "cds_sir": {"name": "cds.pdf", "file_id": "cds-id"},
+        },
+    }
+    (tmp_path / "run-ready.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    ddr_cli.main(["sir-review", "queue", "--manifest-dir", str(tmp_path)])
+
+    out = capsys.readouterr().out
+    assert "SIR Review Queue" in out
+    assert "Alpha Keller" in out
+    assert "AI SIR: ai.docx (ai-id)" in out
+    assert "Reviewed: no" in out
+
+
+def test_ddr_sir_review_queue_omits_reviewed_pairs_by_default(tmp_path, capsys) -> None:
+    manifest = {
+        "run_id": "run-ready",
+        "site_title": "Alpha Keller",
+        "started_at": "2026-05-15T00:00:00+00:00",
+        "sir_learning_review": {
+            "status": "ready_for_review",
+            "ai_sir": {"name": "ai.docx", "file_id": "ai-id"},
+            "cds_sir": {"name": "cds.pdf", "file_id": "cds-id"},
+        },
+    }
+    store = tmp_path / "sir-review-outcomes.jsonl"
+    store.write_text(
+        (
+            '{"created_at":"2099-01-01T00:00:00+00:00","site":"Alpha Keller",'
+            '"ai_sir":"ai-id","cds_sir":"cds-id","section":"Zoning",'
+            '"gap_category":"AI missed item","severity":"material",'
+            '"ddr_impact":"exec.c_zoning","learning_action":"retrieval rule",'
+            '"status":"accepted"}'
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "run-ready.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    ddr_cli.main([
+        "sir-review",
+        "queue",
+        "--manifest-dir",
+        str(tmp_path),
+        "--store",
+        str(store),
+    ])
+
+    out = capsys.readouterr().out
+    assert "Items: 0" in out
+
+
+def test_ddr_sir_monthly_summary_prints_decision_template(tmp_path, capsys) -> None:
+    store = tmp_path / "sir-review-outcomes.jsonl"
+    store.write_text(
+        "\n".join([
+            (
+                '{"created_at":"2099-01-01T00:00:00+00:00","site":"Alpha Keller",'
+                '"ai_sir":"ai","cds_sir":"cds","section":"Zoning",'
+                '"gap_category":"AI missed item","severity":"material",'
+                '"ddr_impact":"exec.c_zoning","learning_action":"retrieval rule",'
+                '"status":"accepted"}'
+            )
+        ]),
+        encoding="utf-8",
+    )
+
+    ddr_cli.main(["sir-monthly-summary", "--store", str(store)])
+
+    out = capsys.readouterr().out
+    assert "# SIR Learning Summary (30d)" in out
+    assert "## Monthly Decisions" in out
+    assert "retrieval rule: 1" in out


### PR DESCRIPTION
## What changed

- Added `ddr sir-review queue` to surface unreviewed `ready_for_review` AI/CDS SIR pairs from local pipeline manifests.
- Added `ddr sir-monthly-summary --since 30d` to turn review outcomes into a recurring operating memo.
- Extended SIR trend summaries with accepted learning actions and documented the weekly/monthly cadence.

## Why

The SIR learning loop already captures adjudicated AI/CDS findings, but it needed a repeatable way to find review candidates and translate 30-day trends into monthly process decisions.

## Validation

- `uv run pytest tests/test_ddr_cli.py tests/test_sir_trends.py tests/test_sir_learning.py`
- `uv run ruff check src\due_diligence_reporter\ddr_cli.py src\due_diligence_reporter\sir_trends.py src\due_diligence_reporter\sir_review_queue.py tests\test_ddr_cli.py`
- `uv run mypy src\due_diligence_reporter\ddr_cli.py src\due_diligence_reporter\sir_trends.py src\due_diligence_reporter\sir_review_queue.py`
- `uv run ddr sir-review queue --limit 5 --include-reviewed`
- `uv run ddr sir-monthly-summary --since 30d`