### PR TITLE
[codex] Add repo instructions and ignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ oauth_response.json
 *.docx
 *.zip
 *.png
+reports/
+* Report Trace - *.json
+/Site_DD_Report_Template_V2.md
+/Resolving an address to a REBL site_id.md
 
 # Tool caches
 .ruff_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project Instructions
+
+## Validation
+
+- Test: `uv run pytest`
+- Lint: `uv run ruff check .`
+- Typecheck: `uv run mypy src/`
+
+## Notes
+
+- Runtime secrets live outside the repo. Do not read or commit `.env`, OAuth tokens, or credential files.
+- Use `uv` for all Python commands.


### PR DESCRIPTION
## Summary
- Add root `AGENTS.md` with the repo's validation commands and runtime-secret guidance.
- Ignore local DDR artifacts that should not be committed: generated `reports/`, report trace JSONs, the stale root V2 template copy, and the local REBL scratch note.

## Validation
- `git diff --cached --check`
