### PR TITLE
[codex] Auto-resolve Rhodes inbox matches

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -847,3 +847,47 @@ Important operational lesson:
 Global lesson note added:
 
 - `C:\Users\foote\.codex\memories\extensions\ad_hoc\notes\20260521-203015-google-workspace-mcp-auth-loopback.md`
+
+## 2026-05-27 - Inbox Scanner Rhodes Auto-Resolve Follow-Up
+
+Greg reviewed a manual-review list where most `unmatched_site` rows had real Rhodes
+sites. Summer-camp SIRs should not create/manual-review Rhodes work because summer
+camps do not have Rhodes entries.
+
+What changed:
+
+- `scripts/scan_inbox.py` now loads Rhodes site records with `status=None`, so
+  cancelled/historical Rhodes sites are eligible for inbox matching. This is
+  needed for rows like `Alpha Torrance 22600 Crenshaw Blvd`, which exists in
+  Rhodes but is not active.
+- `process_email()` skips recognized summer-camp documents when no site matches
+  instead of adding them to `manual_review`.
+- Unmatched supported PDFs now get one fallback site-match pass using extracted
+  PDF text. This lets address text inside inspections/permit forms disambiguate
+  otherwise generic subjects such as `May 8 Alpha Miami Beach Building Inspection`.
+- Shared site-match terms now include the street-address line and street tokens,
+  so PDF text like `1021 Biarritz Dr` or `4260 El Camino Real` contributes to the
+  deterministic score.
+
+Files changed:
+
+- `scripts/scan_inbox.py`
+- `src/due_diligence_reporter/inbox_scanner.py`
+- `src/due_diligence_reporter/rhodes.py`
+- `src/due_diligence_reporter/utils.py`
+- `tests/test_inbox_scanner.py`
+- `tests/test_scan_inbox_e2e.py`
+
+Verification:
+
+```powershell
+uv run pytest tests/test_inbox_scanner.py tests/test_rhodes.py tests/test_scan_inbox_e2e.py -q
+uv run ruff check src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\utils.py scripts\scan_inbox.py tests\test_inbox_scanner.py tests\test_scan_inbox_e2e.py
+uv run mypy src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\utils.py
+```
+
+Results:
+
+- Focused pytest: 86 passed.
+- Ruff: all checks passed.
+- Mypy: success for 3 touched source files.

--- a/scripts/scan_inbox.py
+++ b/scripts/scan_inbox.py
@@ -109,8 +109,8 @@ def main(dry_run: bool = False, scan_only: bool = False) -> None:
     )
 
     try:
-        site_records = list_rhodes_site_records()
-        logger.info("Loaded %d active Rhodes site record(s) for inbox matching", len(site_records))
+        site_records = list_rhodes_site_records(status=None)
+        logger.info("Loaded %d Rhodes site record(s) for inbox matching", len(site_records))
     except RhodesError as e:
         logger.warning("Could not load Rhodes site records for inbox matching: %s", e)
         site_records = []

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -25,8 +25,8 @@ from .m1_lookup import (
 from .rhodes import register_rhodes_document_for_upload
 from .utils import (
     escape_html_text,
-    extract_city_from_address,
     extract_text_from_pdf_bytes,
+    score_site_match_strength,
     send_email,
 )
 
@@ -54,6 +54,8 @@ AUTO_FILE_CONFIDENCE = 0.7
 
 # Doc types we handle (others are skipped silently)
 SUPPORTED_DOC_TYPES = {"sir", "building_inspection", "isp", "block_plan"}
+
+SITE_MATCH_TEXT_LIMIT = 12_000
 
 # Legacy: doc_type -> Settings attr for the dedicated shared Drive folder.
 # As of the M1-routing change, the live scanner uploads all supported doc
@@ -629,6 +631,31 @@ def _classify_inbox_attachment(
     return doc_type, confidence, file_bytes
 
 
+def _is_summer_camp_document(filename: str, metadata: EmailMetadata) -> bool:
+    haystack = f"{filename} {metadata.subject} {metadata.body_snippet}".lower()
+    return "summer camp" in haystack
+
+
+def _extract_attachment_text_for_site_match(
+    gc: GoogleClient,
+    message_id: str,
+    attachment: dict[str, Any],
+    file_bytes: bytes | None,
+) -> tuple[str, bytes | None]:
+    """Return PDF text for fallback site matching without failing the scan."""
+    filename = str(attachment.get("filename") or "")
+    if not filename.lower().endswith(".pdf"):
+        return "", file_bytes
+    try:
+        if file_bytes is None:
+            file_bytes = _get_attachment_bytes(gc, message_id, attachment)
+        text = extract_text_from_pdf_bytes(file_bytes)
+    except Exception as e:
+        logger.warning("Inbox PDF site-match text extraction failed for '%s': %s", filename, e)
+        return "", file_bytes
+    return text[:SITE_MATCH_TEXT_LIMIT], file_bytes
+
+
 def scan_inbox(
     gc: GoogleClient,
     site_records: list[dict[str, Any]] | None,
@@ -857,6 +884,31 @@ def process_email(
             skipped += 1
             review_needed = True
             continue
+
+        if matched_record is None and _is_summer_camp_document(filename, metadata):
+            logger.info(
+                "Skipping summer camp document '%s' - summer camps do not have Rhodes sites",
+                filename,
+            )
+            skipped += 1
+            continue
+
+        if matched_record is None:
+            attachment_text, file_bytes = _extract_attachment_text_for_site_match(
+                gc,
+                message_id,
+                att,
+                file_bytes,
+            )
+            if attachment_text:
+                matched_record = _match_attachment_to_site(
+                    filename,
+                    metadata,
+                    site_records,
+                    attachment_text=attachment_text,
+                )
+                site_title = matched_record.get("title") if matched_record else None
+                matched_site_id = matched_record.get("id") if matched_record else None
 
         if matched_record is None:
             logger.warning(
@@ -1226,46 +1278,29 @@ def _prefix_original_filename(filename: str) -> str:
     return f"{date_str} - {filename}"
 
 
-# _extract_city_from_address moved to utils.py (imported above)
-
-
-def _site_match_score(filename: str, subject: str, record: dict[str, Any]) -> int:
+def _site_match_score(
+    filename: str,
+    subject: str,
+    record: dict[str, Any],
+    *,
+    body_snippet: str = "",
+    attachment_text: str = "",
+) -> int:
     """Compute a deterministic match score between an attachment and a site record."""
-    haystack = f"{filename} {subject}".lower()
+    haystack = f"{filename} {subject} {body_snippet} {attachment_text}"
     title = str(record.get("title") or record.get("name") or "").strip()
     if not title:
         return 0
-
-    score = 0
-    title_lower = title.lower()
-    if title_lower in haystack:
-        score += 100
-
     address = _record_address(record)
-    city = extract_city_from_address(address)
-    if city and city.lower() in haystack:
-        score += 25
-
-    stop_words = {"alpha", "school", "campus", "microschool"}
-    for word in title_lower.replace("/", " ").split():
-        token = word.strip(",.()")
-        if len(token) < 3 or token in stop_words:
-            continue
-        if token in haystack:
-            score += 12
-
-    if address:
-        zip_match = address.strip().split()[-1]
-        if zip_match.isdigit() and zip_match in haystack:
-            score += 10
-
-    return score
+    return score_site_match_strength(haystack, title, address)
 
 
 def _match_attachment_to_site(
     filename: str,
     metadata: EmailMetadata,
     site_records: list[dict[str, Any]],
+    *,
+    attachment_text: str = "",
 ) -> dict[str, Any] | None:
     """Match an attachment to a site summary using deterministic rules."""
     if not site_records:
@@ -1273,7 +1308,13 @@ def _match_attachment_to_site(
 
     scored: list[tuple[int, dict[str, Any]]] = []
     for record in site_records:
-        score = _site_match_score(filename, metadata.subject, record)
+        score = _site_match_score(
+            filename,
+            metadata.subject,
+            record,
+            body_snippet=metadata.body_snippet,
+            attachment_text=attachment_text,
+        )
         if score > 0:
             scored.append((score, record))
     scored.sort(key=lambda item: item[0], reverse=True)

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -758,15 +758,17 @@ def _build_registration_notes(
 
 def list_rhodes_site_records(
     *,
-    status: str = "active",
+    status: str | None = "active",
     client: RhodesClient | None = None,
 ) -> list[dict[str, Any]]:
     """Return Rhodes site records shaped for inbox attachment matching.
 
     The inbox scanner needs a compact local list to match filenames and email
-    subjects before it uploads vendor documents. Each returned record includes
-    the Rhodes site ID, title, address when available, and the linked Rhodes
-    Google Drive root folder URL.
+    subjects before it uploads vendor documents. By default this returns active
+    sites; pass ``status=None`` when historical/cancelled Rhodes records should
+    also be eligible for matching. Each returned record includes the Rhodes site
+    ID, title, address when available, and the linked Rhodes Google Drive root
+    folder URL.
     """
     try:
         rhodes = client or RhodesClient()

--- a/src/due_diligence_reporter/utils.py
+++ b/src/due_diligence_reporter/utils.py
@@ -415,7 +415,8 @@ def build_site_match_terms(
     Returns terms ordered most-specific first:
       1. Full site title (backward compat)
       2. City extracted from address
-      3. Significant words from title (excluding stop words, short words, small numbers)
+      3. Street-address line and tokens
+      4. Significant words from title (excluding stop words, short words, small numbers)
     """
     stop_words = {"alpha", "school", "the", "a", "an"}
     terms: list[str] = []
@@ -433,6 +434,21 @@ def build_site_match_terms(
     city = extract_city_from_address(address)
     if city:
         _add(city)
+
+    if address:
+        street_line = address.split(",", 1)[0].strip()
+        if street_line:
+            _add(street_line)
+            for word in street_line.split():
+                token = word.strip(",.()#")
+                low = token.lower()
+                if not low:
+                    continue
+                if low in {"street", "st", "avenue", "ave", "road", "rd", "drive", "dr"}:
+                    continue
+                if len(low) < 3 and not low.isdigit():
+                    continue
+                _add(token)
 
     for word in site_title.split():
         w = word.strip()

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -437,6 +437,119 @@ class TestClassification:
         # The scanner must NOT have tried to upload anything when site is unmatched.
         gc.upload_file_to_folder.assert_not_called()
 
+    @patch("due_diligence_reporter.inbox_scanner.extract_text_from_pdf_bytes")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_unmatched_summer_camp_is_skipped_without_review(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_pdf_text,
+    ):
+        mock_extract.return_value = MagicMock(
+            message_id="msg_summer_camp",
+            subject="Chicago, IL Summer Camp SIR",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="",
+            attachments=[
+                {
+                    "filename": "Alpha School (Summer Camp) - Chicago, IL SIR.pdf",
+                    "attachment_id": "sc1",
+                    "mime_type": "application/pdf",
+                }
+            ],
+        )
+        mock_classify.return_value = ("sir", 0.95)
+
+        gc = MagicMock()
+        result = process_email(gc, "msg_summer_camp", MagicMock(), "label_123", "review_123")
+
+        assert result["uploaded"] == []
+        assert result["skipped"] == 1
+        assert result["manual_review"] == []
+        assert result["low_confidence"] == []
+        assert result["marked"] is True
+        mock_pdf_text.assert_not_called()
+        gc.upload_file_to_folder.assert_not_called()
+
+    @patch("due_diligence_reporter.inbox_scanner._register_uploaded_document_in_rhodes")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner.extract_text_from_pdf_bytes")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_pdf_text_fallback_can_resolve_ambiguous_site(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_resolve_m1,
+        mock_pdf_text,
+        mock_ping,
+        mock_register,
+    ):
+        mock_extract.return_value = MagicMock(
+            message_id="msg_bi_ambiguous",
+            subject="May 8 Alpha Miami Beach Building Inspection",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="",
+            attachments=[
+                {
+                    "filename": "May 8 Alpha Miami Beach Building Inspection.pdf",
+                    "attachment_id": "bi_mb",
+                    "mime_type": "application/pdf",
+                }
+            ],
+        )
+        mock_classify.return_value = ("building_inspection", 0.95)
+        mock_pdf_text.return_value = "Inspection address: 1021 Biarritz Dr, Miami Beach, FL"
+        mock_resolve_m1.return_value = ("m1_folder_id", "https://drive.google.com/drive/folders/m1")
+        mock_ping.return_value = {"status": "accepted"}
+        mock_register.return_value = {"status": "registered"}
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = False
+        gc.gmail_get_attachment.return_value = b"%PDF-fake"
+        gc.upload_file_to_folder.return_value = {
+            "id": "bi_drive_id",
+            "webViewLink": "https://drive.google.com/file/d/bi_drive_id",
+        }
+
+        site_records = [
+            {
+                "id": "SITE300",
+                "title": "Alpha Miami Beach 300 71st St",
+                "address": "300 71st St, Miami Beach, FL",
+                "drive_folder_url": "https://drive.google.com/drive/folders/site300",
+                "customFields": [],
+            },
+            {
+                "id": "SITE1021",
+                "title": "Alpha Miami Beach 1021 Biarritz Dr",
+                "address": "1021 Biarritz Dr, Miami Beach, FL",
+                "drive_folder_url": "https://drive.google.com/drive/folders/site1021",
+                "customFields": [],
+            },
+        ]
+
+        result = process_email(
+            gc,
+            "msg_bi_ambiguous",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=site_records,
+        )
+
+        assert result["manual_review"] == []
+        assert len(result["uploaded"]) == 1
+        assert result["uploaded"][0]["site_title"] == "Alpha Miami Beach 1021 Biarritz Dr"
+        assert result["uploaded"][0]["matched_site_id"] == "SITE1021"
+        assert result["uploaded"][0]["drive_filename"].endswith(
+            "Alpha Miami Beach 1021 Biarritz Dr Building Inspection Report.pdf"
+        )
+
     @patch("due_diligence_reporter.inbox_scanner._build_site_summary")
     @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
     @patch("due_diligence_reporter.inbox_scanner.classify_document")

--- a/tests/test_scan_inbox_e2e.py
+++ b/tests/test_scan_inbox_e2e.py
@@ -147,7 +147,7 @@ def _patch_externals(monkeypatch):
     monkeypatch.setenv("EMAIL_APP_PASSWORD", "apppass")
     monkeypatch.setenv("SIR_NOTIFICATION_RECIPIENTS", "team@example.com")
     monkeypatch.setenv("CDS_NOTIFICATION_RECIPIENTS", "cds@example.com")
-    monkeypatch.setattr(f"{_MODULE}.list_rhodes_site_records", lambda: [])
+    monkeypatch.setattr(f"{_MODULE}.list_rhodes_site_records", lambda status="active": [])
 
 
 # ---------------------------------------------------------------------------
@@ -184,13 +184,12 @@ class TestRhodesSiteRecords:
                 "drive_folder_url": "https://drive.google.com/drive/folders/root",
             }
         ]
-        monkeypatch.setattr(
-            f"{_MODULE}.list_rhodes_site_records",
-            lambda: rhodes_records,
-        )
+        mock_list_rhodes = MagicMock(return_value=rhodes_records)
+        monkeypatch.setattr(f"{_MODULE}.list_rhodes_site_records", mock_list_rhodes)
 
         main(scan_only=True)
 
+        mock_list_rhodes.assert_called_once_with(status=None)
         assert mock_scan.call_args.args[1] == rhodes_records
 
 


### PR DESCRIPTION
﻿## Summary
- Load all Rhodes site statuses for inbox matching, so cancelled/historical site records can resolve.
- Skip unmatched summer-camp documents without manual-review labels.
- Use PDF text fallback plus address-token scoring to disambiguate Rhodes site matches.

## Validation
- uv run pytest tests/test_inbox_scanner.py tests/test_rhodes.py tests/test_scan_inbox_e2e.py -q
- uv run ruff check src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\utils.py scripts\scan_inbox.py tests\test_inbox_scanner.py tests\test_scan_inbox_e2e.py
- uv run mypy src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\utils.py
