### PR TITLE
[codex] Improve Rhodes roster performance

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,47 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-27 - Rhodes Roster Performance: Hydration and Callback Fast Path
+
+Started the deferred performance slice from the DDR remediation plan on branch
+`codex/rhodes-performance-roster`.
+
+Current behavior:
+
+- `list_rhodes_site_records()` now skips the per-site `getSite` hydration call
+  when a `listSites` summary already includes the fields full-roster callers
+  need: site ID, name, address, Drive folder URL, and P1 owner context.
+- `list_rhodes_site_records(site_ids=[...])` can load specific Rhodes site IDs
+  directly with `getSite`, bypassing the full `listSites` inventory.
+- `scripts/raycon_followup.py` uses the direct site-ID path for callback runs
+  (`--site-id`) before falling back to the full inventory. The fallback remains
+  in place so legacy callback values that are Drive folder IDs can still match
+  through the existing full-roster identity check.
+- RayCon per-site processing now lists the M1 folder once and reuses that file
+  list for Block Plan detection, `raycon_scenario.json` lookup, and published
+  RayCon Scenario Doc freshness checks.
+- Full-roster behavior remains unchanged for daily DD, vendor sweeps, inbox
+  scans, and RayCon cron sweeps when no callback site ID is provided.
+
+Verification completed so far:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-performance-roster tests/test_rhodes.py tests/test_raycon_followup.py tests/test_daily_dd_check.py tests/test_vendor_doc_sweep.py -q
+uv run pytest --basetemp C:\tmp\ddr-performance-raycon tests/test_raycon_client.py tests/test_raycon_followup.py tests/test_rhodes.py -q
+uv run pytest --basetemp C:\tmp\ddr-performance-affected tests/test_rhodes.py tests/test_raycon_followup.py tests/test_raycon_client.py tests/test_daily_dd_check.py tests/test_vendor_doc_sweep.py tests/test_scan_inbox_e2e.py tests/test_inbox_scanner.py -q
+uv run ruff check src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\raycon_client.py scripts\raycon_followup.py tests\test_rhodes.py tests\test_raycon_followup.py tests\test_raycon_client.py tests\test_daily_dd_check.py tests\test_vendor_doc_sweep.py
+uv run mypy src/
+git diff --check
+```
+
+Results:
+
+- Focused roster/RayCon/daily/vendor tests: 68 passed.
+- Focused RayCon client/follow-up/Rhodes tests: 122 passed.
+- Broader affected inbox/Rhodes/RayCon suite: 207 passed.
+- Focused Ruff: all checks passed.
+- Full source Mypy: no issues in 31 source files.
+- `git diff --check`: no whitespace errors; only Windows LF-to-CRLF warnings.
+
 ## 2026-05-27 - DDR Remediation: Workflow Safety, Rhodes Retry, and Source-of-Truth Fixes
 
 Implemented the first remediation pass from the `$check` / `$qplan` review on

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -378,7 +378,37 @@ def _site_id_matches(site_summary: dict[str, Any], target_id: str) -> bool:
 def _load_site_summaries(
     gc: GoogleClient,
     google_drive_root_folder_id: str,
+    *,
+    target_site_id: str | None = None,
 ) -> list[dict[str, Any]]:
+    if target_site_id:
+        try:
+            rhodes_records = list_rhodes_site_records(site_ids=[target_site_id])
+        except RhodesError as exc:
+            logger.warning(
+                "Direct Rhodes lookup failed for RayCon callback site_id=%s; "
+                "falling back to full inventory: %s",
+                target_site_id,
+                exc,
+            )
+        else:
+            summaries = [
+                _site_summary_from_rhodes_record(record)
+                for record in rhodes_records
+                if str(record.get("drive_folder_url") or "").strip()
+            ]
+            if summaries:
+                logger.info(
+                    "Loaded Rhodes site record for RayCon callback site_id=%s",
+                    target_site_id,
+                )
+                return summaries
+            logger.warning(
+                "Direct Rhodes lookup for RayCon callback site_id=%s returned "
+                "no Drive-linked site; falling back to full inventory",
+                target_site_id,
+            )
+
     try:
         rhodes_records = list_rhodes_site_records()
     except RhodesError as exc:
@@ -408,10 +438,16 @@ def _load_site_summaries(
     return [_site_summary_from_folder(folder) for folder in site_folders]
 
 
-def _find_block_plan(gc: GoogleClient, m1_folder_id: str) -> dict[str, Any] | None:
+def _find_block_plan(
+    gc: GoogleClient,
+    m1_folder_id: str,
+    *,
+    m1_files: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
     """Return the most recently modified Block Plan PDF in M1, or None."""
     candidate: dict[str, Any] | None = None
-    for f in gc.list_files_in_folder(m1_folder_id):
+    files = m1_files if m1_files is not None else gc.list_files_in_folder(m1_folder_id)
+    for f in files:
         name = str(f.get("name", "")).lower()
         if not _filename_matches_block_plan(name):
             continue
@@ -422,10 +458,17 @@ def _find_block_plan(gc: GoogleClient, m1_folder_id: str) -> dict[str, Any] | No
     return candidate
 
 
-def _find_published_doc(gc: GoogleClient, m1_folder_id: str, site_name: str) -> dict[str, Any] | None:
+def _find_published_doc(
+    gc: GoogleClient,
+    m1_folder_id: str,
+    site_name: str,
+    *,
+    m1_files: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
     """Return the existing RayCon Scenario Doc for a site, or None."""
     target = f"{PUBLISHED_DOC_PREFIX} - {site_name}"
-    for f in gc.list_files_in_folder(m1_folder_id):
+    files = m1_files if m1_files is not None else gc.list_files_in_folder(m1_folder_id)
+    for f in files:
         if str(f.get("name", "")).strip() == target:
             return f
     return None
@@ -874,12 +917,19 @@ def _process_site(
     if not m1_folder_id:
         return {"site": site_name, "skipped": "no M1 folder"}
 
-    block_plan = _find_block_plan(gc, m1_folder_id)
+    m1_files = gc.list_files_in_folder(m1_folder_id)
+
+    block_plan = _find_block_plan(gc, m1_folder_id, m1_files=m1_files)
     if block_plan is None:
         return {"site": site_name, "skipped": "no block plan in M1"}
 
     try:
-        scenario = read_raycon_scenario_from_m1(gc, drive_folder_url)
+        scenario = read_raycon_scenario_from_m1(
+            gc,
+            drive_folder_url,
+            m1_folder_id=m1_folder_id,
+            m1_files=m1_files,
+        )
     except RayConSchemaError as e:
         logger.error("[%s] %s", site_name, e)
         return {"site": site_name, "error": f"schema error: {e}"}
@@ -1005,7 +1055,7 @@ def _process_site(
             "error": "missing Rhodes site identity/address for RayCon scenario publish",
         }
 
-    published = _find_published_doc(gc, m1_folder_id, site_name)
+    published = _find_published_doc(gc, m1_folder_id, site_name, m1_files=m1_files)
     json_modified = scenario.get("_drive_modified_time", "")
     doc_modified = (published or {}).get("modifiedTime", "") if published else ""
     json_modified_dt = _parse_iso(str(json_modified))
@@ -1182,7 +1232,11 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("GOOGLE_DRIVE_ROOT_FOLDER_ID is required for RayCon follow-up")
         return 1
 
-    summaries = _load_site_summaries(gc, settings.google_drive_root_folder_id)
+    summaries = _load_site_summaries(
+        gc,
+        settings.google_drive_root_folder_id,
+        target_site_id=args.site_id,
+    )
     summaries = [s for s in summaries if _site_filter(s, args.site)]
 
     # Rec. 2: when the RayCon callback supplies a site_id, scope the run

--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -536,6 +536,9 @@ def post_raycon_folder_ping(
 def read_raycon_scenario_from_m1(
     gc: GoogleClient,
     drive_folder_url: str,
+    *,
+    m1_folder_id: str | None = None,
+    m1_files: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     """Return the parsed ``raycon_scenario.json`` from the site's M1 folder.
 
@@ -546,12 +549,14 @@ def read_raycon_scenario_from_m1(
     """
     if not drive_folder_url:
         return None
-    m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
+    if m1_folder_id is None:
+        m1_folder_id, _ = _resolve_m1_folder(gc, drive_folder_url)
     if not m1_folder_id:
         return None
 
     candidate = None
-    for file_info in gc.list_files_in_folder(m1_folder_id):
+    files = m1_files if m1_files is not None else gc.list_files_in_folder(m1_folder_id)
+    for file_info in files:
         name = str(file_info.get("name", "")).strip()
         if name == RAYCON_SCENARIO_FILENAME:
             # Pick the most recently modified copy if there's somehow more

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -310,6 +311,72 @@ def _extract_drive_folder(site: dict[str, Any]) -> tuple[str, str]:
     if folder_url and not folder_id and DRIVE_FOLDER_URL_PREFIX in folder_url:
         folder_id = folder_url.rsplit("/", 1)[-1].split("?", 1)[0].strip()
     return folder_id, folder_url
+
+
+def _site_created_date(site: dict[str, Any], summary: dict[str, Any]) -> str:
+    return str(site.get("createdDate") or summary.get("createdDate") or "")
+
+
+def _site_status(
+    site: dict[str, Any],
+    summary: dict[str, Any],
+    fallback_status: str | None,
+) -> str:
+    return str(site.get("status") or summary.get("status") or fallback_status or "")
+
+
+def _site_custom_fields(site: dict[str, Any]) -> list[Any]:
+    custom_fields = site.get("customFields")
+    return custom_fields if isinstance(custom_fields, list) else []
+
+
+def _site_summary_is_drive_ready(summary: dict[str, Any]) -> bool:
+    """Return True when a listSites row already has the fields callers need.
+
+    This avoids paying a getSite call for APIs that already return rich site
+    summaries while preserving hydration for older/leaner listSites payloads.
+    """
+    _folder_id, folder_url = _extract_drive_folder(summary)
+    owner = _extract_p1_dri(summary)
+    return bool(
+        _site_id(summary)
+        and _site_name(summary)
+        and _site_address(summary)
+        and folder_url
+        and (owner.get("name") or owner.get("email"))
+    )
+
+
+def _record_from_site_payload(
+    site: dict[str, Any],
+    *,
+    summary: dict[str, Any] | None = None,
+    status: str | None,
+) -> dict[str, Any] | None:
+    summary = summary or {}
+    site_id = _site_id(site) or _site_id(summary)
+    name = _site_name(site) or _site_name(summary)
+    if not site_id or not name:
+        return None
+    drive_folder_id, drive_folder_url = _extract_drive_folder(site)
+    owner = _extract_p1_dri(site)
+    return {
+        "id": site_id,
+        "site_id": site_id,
+        "title": name,
+        "name": name,
+        "slug": site.get("slug") or summary.get("slug") or "",
+        "address": _site_address(site) or _site_address(summary),
+        "drive_folder_id": drive_folder_id,
+        "drive_folder_url": drive_folder_url,
+        "p1_assignee_name": owner.get("name", ""),
+        "p1_assignee_email": owner.get("email", ""),
+        "p1_assignee_user_id": owner.get("userId", ""),
+        "created_date": _site_created_date(site, summary),
+        "status": _site_status(site, summary, status),
+        "rhodes_status": site.get("status") or summary.get("status") or "",
+        "customFields": _site_custom_fields(site),
+    }
 
 
 class RhodesClient:
@@ -759,6 +826,7 @@ def _build_registration_notes(
 def list_rhodes_site_records(
     *,
     status: str | None = "active",
+    site_ids: Iterable[str] | None = None,
     client: RhodesClient | None = None,
 ) -> list[dict[str, Any]]:
     """Return Rhodes site records shaped for inbox attachment matching.
@@ -772,7 +840,17 @@ def list_rhodes_site_records(
     """
     try:
         rhodes = client or RhodesClient()
-        site_summaries = rhodes.list_sites(status=status)
+        target_site_ids = [
+            str(site_id).strip()
+            for site_id in (site_ids or [])
+            if str(site_id).strip()
+        ]
+        if target_site_ids:
+            site_summaries = [
+                rhodes.get_site(site_id=site_id) for site_id in target_site_ids
+            ]
+        else:
+            site_summaries = rhodes.list_sites(status=status)
     except RhodesError:
         raise
 
@@ -781,10 +859,12 @@ def list_rhodes_site_records(
         site_id = _site_id(summary)
         if not site_id:
             continue
-        try:
-            site = rhodes.get_site(site_id=site_id)
-        except RhodesError:
-            site = summary
+        site = summary
+        if not target_site_ids and not _site_summary_is_drive_ready(summary):
+            try:
+                site = rhodes.get_site(site_id=site_id)
+            except RhodesError:
+                site = summary
 
         drive_folder_id, drive_folder_url = _extract_drive_folder(site)
         if not drive_folder_url:
@@ -796,27 +876,13 @@ def list_rhodes_site_records(
                 drive_folder_id = drive_folder_id or ""
                 drive_folder_url = ""
 
-        name = _site_name(site) or _site_name(summary)
-        if not name:
+        enriched_site = dict(site)
+        if drive_folder_id:
+            enriched_site.setdefault("driveFolderId", drive_folder_id)
+        if drive_folder_url:
+            enriched_site.setdefault("driveFolderUrl", drive_folder_url)
+        record = _record_from_site_payload(enriched_site, summary=summary, status=status)
+        if record is None:
             continue
-        owner = _extract_p1_dri(site)
-        records.append(
-            {
-                "id": site_id,
-                "site_id": site_id,
-                "title": name,
-                "name": name,
-                "slug": site.get("slug") or summary.get("slug") or "",
-                "address": _site_address(site) or _site_address(summary),
-                "drive_folder_id": drive_folder_id,
-                "drive_folder_url": drive_folder_url,
-                "p1_assignee_name": owner.get("name", ""),
-                "p1_assignee_email": owner.get("email", ""),
-                "p1_assignee_user_id": owner.get("userId", ""),
-                "created_date": str(site.get("createdDate") or summary.get("createdDate") or ""),
-                "status": str(site.get("status") or summary.get("status") or status),
-                "rhodes_status": site.get("status") or summary.get("status") or "",
-                "customFields": site.get("customFields") if isinstance(site.get("customFields"), list) else [],
-            }
-        )
+        records.append(record)
     return records

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -709,6 +709,29 @@ class TestReadRayConScenarioFromM1:
         assert result["_drive_file_id"] == "f1"
         assert result["_drive_modified_time"] == "2026-04-30T10:00:00Z"
 
+    def test_uses_prelisted_m1_files_without_relisting_folder(self) -> None:
+        payload = {"schema_version": "1.0"}
+        gc = MagicMock()
+        gc.download_file_bytes.return_value = json.dumps(payload).encode("utf-8")
+
+        result = read_raycon_scenario_from_m1(
+            gc,
+            "https://drive.google.com/folder/abc",
+            m1_folder_id="m1-id",
+            m1_files=[
+                {
+                    "id": "f1",
+                    "name": RAYCON_SCENARIO_FILENAME,
+                    "modifiedTime": "2026-04-30T10:00:00Z",
+                }
+            ],
+        )
+
+        assert result is not None
+        assert result["_drive_file_id"] == "f1"
+        gc.list_files_in_folder.assert_not_called()
+        gc.download_file_bytes.assert_called_once_with("f1")
+
     def test_unsupported_schema_version_raises(self) -> None:
         payload = {"schema_version": "9.9", "fastest_open": {}}
         gc = MagicMock()

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 from scripts.raycon_followup import (
     _dispatch_raycon_job,
     _filter_dedup_alerts,
+    _find_block_plan,
+    _find_published_doc,
     _load_site_summaries,
     _process_site,
     _republish_dd_report_if_present,
@@ -96,6 +98,66 @@ def test_load_site_summaries_prefers_rhodes_records_with_site_address(mock_recor
     gc.list_subfolders.assert_not_called()
 
 
+@patch("scripts.raycon_followup.list_rhodes_site_records")
+def test_load_site_summaries_uses_direct_rhodes_lookup_for_callback_site_id(
+    mock_records,
+):
+    mock_records.return_value = [
+        {
+            "id": "rhodes-site-1",
+            "site_id": "rhodes-site-1",
+            "title": "Alpha Keller",
+            "address": "123 Main St, Keller, TX 76248",
+            "drive_folder_id": "drive-root-1",
+            "drive_folder_url": "https://drive.google.com/drive/folders/drive-root-1",
+        }
+    ]
+
+    gc = MagicMock()
+    summaries = _load_site_summaries(
+        gc,
+        "all-locations-root",
+        target_site_id="rhodes-site-1",
+    )
+
+    assert summaries[0]["id"] == "rhodes-site-1"
+    mock_records.assert_called_once_with(site_ids=["rhodes-site-1"])
+    gc.list_subfolders.assert_not_called()
+
+
+@patch("scripts.raycon_followup.list_rhodes_site_records")
+def test_load_site_summaries_falls_back_to_full_inventory_for_drive_folder_id(
+    mock_records,
+):
+    mock_records.side_effect = [
+        [],
+        [
+            {
+                "id": "rhodes-site-1",
+                "site_id": "rhodes-site-1",
+                "title": "Alpha Keller",
+                "address": "123 Main St, Keller, TX 76248",
+                "drive_folder_id": "drive-root-1",
+                "drive_folder_url": (
+                    "https://drive.google.com/drive/folders/drive-root-1"
+                ),
+            }
+        ],
+    ]
+
+    gc = MagicMock()
+    summaries = _load_site_summaries(
+        gc,
+        "all-locations-root",
+        target_site_id="drive-root-1",
+    )
+
+    assert summaries[0]["drive_folder_id"] == "drive-root-1"
+    assert mock_records.call_args_list[0].kwargs == {"site_ids": ["drive-root-1"]}
+    assert mock_records.call_args_list[1].kwargs == {}
+    gc.list_subfolders.assert_not_called()
+
+
 def test_site_id_matches_rhodes_site_id_or_drive_folder_id():
     summary = {
         "id": "rhodes-site-1",
@@ -107,6 +169,41 @@ def test_site_id_matches_rhodes_site_id_or_drive_folder_id():
     assert _site_id_matches(summary, "rhodes-site-1") is True
     assert _site_id_matches(summary, "drive-root-1") is True
     assert _site_id_matches(summary, "other") is False
+
+
+def test_m1_file_helpers_use_prelisted_files_without_drive_relist():
+    gc = MagicMock()
+    files = [
+        {
+            "id": "older-bp",
+            "name": "Block Plan old.pdf",
+            "modifiedTime": "2026-05-27T08:00:00Z",
+        },
+        {
+            "id": "newer-bp",
+            "name": "Block Plan current.pdf",
+            "modifiedTime": "2026-05-27T09:00:00Z",
+        },
+        {
+            "id": "published-doc",
+            "name": "RayCon Scenario Assessment - Alpha Keller",
+            "modifiedTime": "2026-05-27T10:00:00Z",
+        },
+    ]
+
+    block_plan = _find_block_plan(gc, "m1-id", m1_files=files)
+    published = _find_published_doc(
+        gc,
+        "m1-id",
+        "Alpha Keller",
+        m1_files=files,
+    )
+
+    assert block_plan is not None
+    assert block_plan["id"] == "newer-bp"
+    assert published is not None
+    assert published["id"] == "published-doc"
+    gc.list_files_in_folder.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -33,7 +33,7 @@ class FakeRhodesClient:
         self.calls.append(("get_site", {"site_id": site_id or "", "slug": slug or ""}))
         return self.site
 
-    def list_sites(self, *, status: str = "active") -> list[dict[str, Any]]:
+    def list_sites(self, *, status: str | None = "active") -> list[dict[str, Any]]:
         self.calls.append(("list_sites", {"status": status}))
         return self.sites
 
@@ -250,6 +250,56 @@ def test_list_rhodes_site_records_returns_drive_ready_inbox_records() -> None:
         ("list_sites", {"status": "active"}),
         ("get_site", {"site_id": "SITE1", "slug": ""}),
     ]
+
+
+def test_list_rhodes_site_records_skips_hydration_for_complete_summaries() -> None:
+    client = FakeRhodesClient(
+        sites=[
+            {
+                "_id": "SITE1",
+                "name": "Alpha Keller",
+                "slug": "alpha-keller",
+                "address": "123 Main St, Keller, TX 76248",
+                "status": "active",
+                "createdDate": "2026-05-20",
+                "p1Dri": {"name": "Devin Bates", "email": "devin.bates@trilogy.com"},
+                "driveFolderUrl": "https://drive.google.com/drive/folders/drive-root-1",
+            }
+        ],
+    )
+
+    records = list_rhodes_site_records(client=client)  # type: ignore[arg-type]
+
+    assert records[0]["id"] == "SITE1"
+    assert records[0]["address"] == "123 Main St, Keller, TX 76248"
+    assert records[0]["drive_folder_id"] == "drive-root-1"
+    assert records[0]["drive_folder_url"].endswith("/drive-root-1")
+    assert records[0]["p1_assignee_email"] == "devin.bates@trilogy.com"
+    assert client.calls == [("list_sites", {"status": "active"})]
+
+
+def test_list_rhodes_site_records_can_load_specific_site_ids_without_listing() -> None:
+    client = FakeRhodesClient(
+        {
+            "_id": "SITE1",
+            "name": "Alpha Keller",
+            "slug": "alpha-keller",
+            "address": "123 Main St, Keller, TX 76248",
+            "status": "active",
+            "createdDate": "2026-05-20",
+            "p1Dri": {"name": "Devin Bates", "email": "devin.bates@trilogy.com"},
+            "driveFolderId": "drive-root-1",
+        },
+    )
+
+    records = list_rhodes_site_records(
+        site_ids=["SITE1"],
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert records[0]["id"] == "SITE1"
+    assert records[0]["drive_folder_url"].endswith("/drive-root-1")
+    assert client.calls == [("get_site", {"site_id": "SITE1", "slug": ""})]
 
 
 def test_ddr_doc_type_mapping_covers_inbox_supported_docs() -> None:


### PR DESCRIPTION
## Summary
- Reduce Rhodes roster overhead by skipping per-site `getSite` hydration when `listSites` already returns complete roster fields.
- Add targeted `list_rhodes_site_records(site_ids=[...])` lookup for callback-style workflows that only need one site.
- Use the targeted Rhodes path in RayCon callback runs before falling back to the full inventory, and reuse a single M1 file listing for block plan, scenario JSON, and published-doc checks.

## Why
The prior remediation pass intentionally kept performance separate. This first slice addresses the highest-impact repeated calls without changing the source-of-truth contract: Rhodes remains authoritative, full-roster behavior is preserved, and legacy callback values that are Drive folder IDs still fall back to full inventory matching.

## Validation
- `uv run pytest --basetemp C:\tmp\ddr-performance-roster tests/test_rhodes.py tests/test_raycon_followup.py tests/test_daily_dd_check.py tests/test_vendor_doc_sweep.py -q` - 68 passed
- `uv run pytest --basetemp C:\tmp\ddr-performance-raycon tests/test_raycon_client.py tests/test_raycon_followup.py tests/test_rhodes.py -q` - 122 passed
- `uv run pytest --basetemp C:\tmp\ddr-performance-affected tests/test_rhodes.py tests/test_raycon_followup.py tests/test_raycon_client.py tests/test_daily_dd_check.py tests/test_vendor_doc_sweep.py tests/test_scan_inbox_e2e.py tests/test_inbox_scanner.py -q` - 207 passed
- `uv run ruff check src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\raycon_client.py scripts\raycon_followup.py tests\test_rhodes.py tests\test_raycon_followup.py tests\test_raycon_client.py tests\test_daily_dd_check.py tests\test_vendor_doc_sweep.py` - passed
- `uv run mypy src/` - passed
- `git diff --check` - passed; Windows line-ending warnings only