### PR TITLE
Reconcile duplicate Drive files with Rhodes

### DIFF
--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -195,6 +195,25 @@ def _drive_file_from_retry_entry(entry: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _find_existing_drive_file_by_name(
+    gc: GoogleClient,
+    folder_id: str,
+    file_name: str,
+) -> dict[str, Any] | None:
+    """Return the newest direct child Drive file with an exact name match."""
+    candidate: dict[str, Any] | None = None
+    for file_info in gc.list_files_in_folder(folder_id):
+        name = str(file_info.get("name") or "").strip()
+        if name != file_name:
+            continue
+        if candidate is None:
+            candidate = file_info
+            continue
+        if str(file_info.get("modifiedTime") or "") > str(candidate.get("modifiedTime") or ""):
+            candidate = file_info
+    return candidate
+
+
 def _custom_field_value(record: dict[str, Any], names: set[str]) -> str:
     for field in record.get("customFields", []) or []:
         if not isinstance(field, dict):
@@ -1197,8 +1216,89 @@ def process_email(
             continue
         if gc.file_exists_in_folder(target_folder_id, drive_filename):
             if doc_type != "block_plan":
-                logger.info("File '%s' already exists in folder - skipping upload", drive_filename)
-                skipped += 1
+                drive_file = _find_existing_drive_file_by_name(
+                    gc,
+                    target_folder_id,
+                    drive_filename,
+                )
+                if drive_file is None:
+                    error_message = "Existing Drive file could not be found in M1"
+                    errors.append(
+                        {
+                            "message_id": message_id,
+                            "filename": filename,
+                            "doc_type": doc_type,
+                            "error": error_message,
+                        }
+                    )
+                    manual_review.append(
+                        _manual_review_item(
+                            filename=filename,
+                            doc_type=doc_type,
+                            confidence=confidence,
+                            email_subject=metadata.subject,
+                            site_title=site_title,
+                            reason="existing_drive_file_missing",
+                            error=error_message,
+                        )
+                    )
+                    all_succeeded = False
+                    review_needed = True
+                    keep_unprocessed = True
+                    continue
+                logger.info(
+                    "File '%s' already exists in folder - registering existing Drive file",
+                    drive_filename,
+                )
+                uploaded.append(
+                    {
+                        "original_filename": filename,
+                        "drive_filename": drive_filename,
+                        "doc_type": doc_type,
+                        "site_title": site_title,
+                        "site_address": site_address,
+                        "matched_site_id": matched_site_id,
+                        "drive_file_id": drive_file.get("id"),
+                        "drive_link": drive_file.get("webViewLink"),
+                        "existing_drive_file": True,
+                    }
+                )
+                registration = _register_uploaded_document_in_rhodes(
+                    site_summary=site_summary,
+                    ddr_doc_type=doc_type,
+                    drive_file=drive_file,
+                    drive_filename=drive_filename,
+                    original_filename=filename,
+                    message_id=message_id,
+                    attachment=att,
+                )
+                uploaded[-1]["rhodes_registration"] = registration
+                if _record_rhodes_registration_attempt(
+                    rhodes_retry_state,
+                    retry_key=rhodes_retry_key,
+                    registration=registration,
+                    site_summary=site_summary,
+                    doc_type=doc_type,
+                    drive_file=drive_file,
+                    drive_filename=drive_filename,
+                    original_filename=filename,
+                ):
+                    manual_review.append(
+                        _manual_review_item(
+                            filename=filename,
+                            doc_type=doc_type,
+                            confidence=confidence,
+                            email_subject=metadata.subject,
+                            site_title=site_title,
+                            reason="rhodes_registration_retry_exhausted",
+                            error=str(
+                                registration.get("error")
+                                or registration.get("reason")
+                                or ""
+                            ),
+                        )
+                    )
+                    review_needed = True
                 continue
             existing_docs = _list_m1_documents_by_type(gc, target_folder_id)
             if "raycon_scenario_json" in existing_docs:

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -1605,6 +1605,94 @@ class TestRhodesDocumentRegistration:
     @patch("due_diligence_reporter.inbox_scanner._register_uploaded_document_in_rhodes")
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_existing_duplicate_drive_file_records_rhodes_registration(
+        self,
+        mock_extract,
+        mock_classify,
+        mock_register,
+        mock_ping,
+        mock_resolve_m1,
+        mock_build_summary,
+    ):
+        drive_filename = f"{datetime.now().strftime('%b %d %Y')} - Alpha Keller ISP.pdf"
+        mock_extract.return_value = MagicMock(
+            message_id="msg_rhodes_existing",
+            subject="Alpha Keller ISP",
+            sender="vendor@example.com",
+            effective_sender="vendor@example.com",
+            body_snippet="",
+            attachments=[
+                {
+                    "filename": "Alpha Keller ISP.pdf",
+                    "attachment_id": "att_isp",
+                    "mime_type": "application/pdf",
+                }
+            ],
+        )
+        mock_classify.return_value = ("isp", 0.95)
+        mock_resolve_m1.return_value = ("m1_folder_id", "M1")
+        mock_build_summary.return_value = {
+            "id": "SITE1",
+            "title": "Alpha Keller",
+            "address": "123 Main St",
+            "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+        }
+        mock_register.return_value = {
+            "status": "already_registered",
+            "rhodes_doc_type": "other",
+            "rhodes_document_id": "DOC1",
+        }
+
+        gc = MagicMock()
+        gc.file_exists_in_folder.return_value = True
+        gc.list_files_in_folder.return_value = [
+            {
+                "id": "isp_drive_id_old",
+                "name": drive_filename,
+                "webViewLink": "https://drive.google.com/file/d/isp_drive_id_old",
+                "modifiedTime": "2026-05-26T10:00:00Z",
+            },
+            {
+                "id": "isp_drive_id_existing",
+                "name": drive_filename,
+                "webViewLink": "https://drive.google.com/file/d/isp_drive_id_existing",
+                "modifiedTime": "2026-05-27T10:00:00Z",
+            },
+        ]
+
+        result = process_email(
+            gc,
+            "msg_rhodes_existing",
+            self._settings(),
+            "label_123",
+            "review_123",
+            site_records=[{"id": "SITE1", "title": "Alpha Keller", "customFields": []}],
+            rhodes_retry_state={},
+        )
+
+        assert result["skipped"] == 0
+        assert result["manual_review"] == []
+        assert result["uploaded"][0]["existing_drive_file"] is True
+        assert result["uploaded"][0]["drive_file_id"] == "isp_drive_id_existing"
+        assert result["uploaded"][0]["rhodes_registration"] == {
+            "status": "already_registered",
+            "rhodes_doc_type": "other",
+            "rhodes_document_id": "DOC1",
+        }
+        gc.gmail_get_attachment.assert_not_called()
+        gc.upload_file_to_folder.assert_not_called()
+        mock_ping.assert_not_called()
+        kwargs = mock_register.call_args.kwargs
+        assert kwargs["drive_file"]["id"] == "isp_drive_id_existing"
+        assert kwargs["drive_filename"] == drive_filename
+        assert kwargs["message_id"] == "msg_rhodes_existing"
+
+    @patch("due_diligence_reporter.inbox_scanner._build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
+    @patch("due_diligence_reporter.inbox_scanner._register_uploaded_document_in_rhodes")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
     def test_rhodes_registration_failure_records_retry_without_blocking_drive_filing(
         self,
         mock_extract,


### PR DESCRIPTION
## Summary

- reconciles duplicate existing M1 Drive files into Rhodes document registration instead of skipping them before registration
- adds exact-name lookup of the existing Drive file metadata so the registration uses the existing file ID/link without re-uploading bytes
- adds scanner regression coverage for duplicate ISP files registering in Rhodes without calling Drive upload or RayCon ping

## Verification

```powershell
uv run pytest --basetemp C:\tmp\ddr-duplicate-rhodes tests/test_inbox_scanner.py::TestRhodesDocumentRegistration -q
uv run pytest --basetemp C:\tmp\ddr-duplicate-rhodes-broad tests/test_inbox_scanner.py tests/test_rhodes.py -q
uv run ruff check src\due_diligence_reporter\inbox_scanner.py tests\test_inbox_scanner.py
uv run mypy src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py
git diff --check
```

Results:

- Rhodes scanner slice: 5 passed
- Broader scanner/Rhodes suite: 81 passed
- Ruff: passed
- Mypy: passed
- Diff check: passed, with expected Windows LF-to-CRLF warnings only
