### PR TITLE
[codex] Enforce answer-first DDR exec summaries

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,44 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-27 - DDR Executive Summary Answer-First Rendering
+
+Implemented the Boston-style executive summary guardrail on `main`.
+
+Current behavior:
+
+- `docs/prompts/prompt_v4.md` now explicitly requires every executive-summary
+  field to use one answer line followed by plain-line support facts. The prompt
+  metadata was updated to `Last Updated: 2026-05-27`.
+- `src/due_diligence_reporter/google_doc_builder.py` now normalizes long
+  one-paragraph executive-summary fields into answer/support lines before
+  rendering. This preserves the Boston pattern even when the agent sends a
+  Miami-style multi-sentence paragraph.
+- Gap labels such as `[Not found - RayCon scenario pending]` stay on the answer
+  line; the explanatory sentences render as support bullets below.
+- Added builder tests for one-paragraph support bulleting and gap-label answer
+  preservation, plus updated the prompt contract test.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_google_doc_builder.py tests/test_prompt_contract.py
+uv run ruff check src\due_diligence_reporter\google_doc_builder.py tests\test_google_doc_builder.py tests\test_prompt_contract.py
+uv run mypy src/
+```
+
+Results:
+
+- Focused builder/prompt tests: 72 passed.
+- Focused Ruff on touched files: all checks passed.
+- Full source Mypy: no issues in 31 source files.
+- Raw `uv run pytest` is blocked on current checkout by inaccessible pytest
+  cache/temp directories. A broad rerun with cache folders ignored collected
+  963 tests and showed unrelated existing failures in assignment and
+  sender-filter tests plus temp-permission setup errors.
+- Repo-level `uv run ruff check .` still reports unrelated pre-existing lint in
+  `scripts/reprocess_mislabeled.py`, `tests/test_cds_verification.py`,
+  `tests/test_opening_plan.py`, and `tests/test_sender_filter.py`.
+
 ## 2026-05-27 - Rhodes Roster Performance: Hydration and Callback Fast Path
 
 Started the deferred performance slice from the DDR remediation plan on branch

--- a/docs/prompts/prompt_v4.md
+++ b/docs/prompts/prompt_v4.md
@@ -2,7 +2,7 @@
 
 **Version:** 4.0.0
 **Team:** EDU Ops Intelligence
-**Last Updated:** 2026-05-26
+**Last Updated:** 2026-05-27
 
 > V4 prompt contract. This prompt creates the structured Site Due Diligence
 > Report from the site context, Rhodes / LocationOS ownership data, and source
@@ -157,7 +157,8 @@ Use JC-style narrative:
 - Use labels plus bullets instead of paragraphs.
 - Start action items with a verb.
 - Executive-summary fields must be concise: one answer line, plus optional
-  support lines. The document builder applies the labels and support bullets.
+  support lines. Put each support fact on its own plain line. The document
+  builder applies the labels and support bullets.
 - Avoid jargon unless the term is defined in the same field.
 - Do not editorialize. Avoid phrases like `likely cost-prohibitive`,
   `appears manageable`, `well below standard`, or `recommend passing`.
@@ -257,12 +258,15 @@ the date:
 For `No`, write those fields as concise factual blockers that push past both
 8/12 and 9/8.
 
-Use this shape for each field:
+Use this shape for every executive-summary field. The first line is the answer;
+every later line is supporting detail. Do not write multiple-sentence
+paragraphs in these fields.
 
 ```text
 exec.c_permit_timeline:
 Best case: 16 weeks, worst case: 40 weeks
 9/8/2026 is 15 weeks from today
+Public hearing dependency is the binding constraint
 ```
 
 ---

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -435,6 +435,51 @@ def _strip_inline_citation_markers(value: str) -> str:
     return re.sub(r"\s*\[\d+\]", "", value).strip()
 
 
+def _split_summary_prose_into_lines(value: str) -> list[str]:
+    """Split one-paragraph executive-summary prose into answer/support lines.
+
+    The agent is prompted to send one answer line followed by support lines, but
+    it sometimes sends a single paragraph with several sentences. The renderer
+    still needs to preserve the Boston-style answer-first display.
+    """
+    text = value.strip()
+    if not text:
+        return []
+
+    gap_match = re.match(r"^(\[[^\]]+\])\s+(.+)$", text)
+    if gap_match:
+        return [
+            gap_match.group(1),
+            *_split_summary_prose_into_lines(gap_match.group(2)),
+        ]
+
+    protected_abbreviations = {
+        "Ch.": "Ch<dot>",
+        "Sec.": "Sec<dot>",
+        "St.": "St<dot>",
+        "Dr.": "Dr<dot>",
+        "Ave.": "Ave<dot>",
+        "Rd.": "Rd<dot>",
+        "No.": "No<dot>",
+        "e.g.": "e<dot>g<dot>",
+        "i.e.": "i<dot>e<dot>",
+    }
+    protected = text
+    for source, replacement in protected_abbreviations.items():
+        protected = protected.replace(source, replacement)
+
+    parts = re.split(r"(?<=[.!?])\s+(?=[A-Z])", protected)
+    lines: list[str] = []
+    for part in parts:
+        restored = part
+        for source, replacement in protected_abbreviations.items():
+            restored = restored.replace(replacement, source)
+        restored = restored.strip()
+        if restored:
+            lines.append(restored)
+    return lines
+
+
 def _format_source_note_line(value: str) -> str:
     """Strip numeric citation prefixes from consolidated source-note lines."""
     return re.sub(r"^\[\d+\]\s*", "", value.strip())
@@ -635,10 +680,14 @@ def _summary_display_lines(value: str) -> list[str]:
         line = _strip_inline_citation_markers(line)
         if line:
             lines.append(line)
+    if len(lines) == 1 and len(lines[0]) >= 140:
+        split_lines = _split_summary_prose_into_lines(lines[0])
+        if len(split_lines) > 1:
+            return split_lines
     if lines:
         return lines
     fallback = _strip_inline_citation_markers(value.strip())
-    return [fallback] if fallback else []
+    return _split_summary_prose_into_lines(fallback) if fallback else []
 
 
 def _insert_labeled_summary_field(

--- a/tests/test_google_doc_builder.py
+++ b/tests/test_google_doc_builder.py
@@ -828,6 +828,62 @@ class TestBuildDdReportDocRequestStructure:
             for request in requests
         )
 
+    def test_exec_summary_single_paragraph_support_is_bulleted(self) -> None:
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {
+            "meta.site_name": "Test",
+            "meta.report_date": "04/14/2026",
+            "exec.c_occupancy": (
+                "An existing Conditional Use Permit covers school use at this site, "
+                "capped at 180 students. Transferring the CUP to Alpha School "
+                "requires a Planning Board modification hearing. The historic "
+                "district review must also be cleared before permit issuance."
+            ),
+        }
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        requests = _all_batch_requests(docs_svc)
+        support_insert = next(
+            request["insertText"]
+            for request in requests
+            if request.get("insertText", {}).get("text")
+            == (
+                "Transferring the CUP to Alpha School requires a Planning Board "
+                "modification hearing.\n"
+            )
+        )
+        support_start = support_insert["location"]["index"]
+
+        assert any(
+            "createParagraphBullets" in request
+            and request["createParagraphBullets"]["range"]["startIndex"]
+            <= support_start
+            < request["createParagraphBullets"]["range"]["endIndex"]
+            for request in requests
+        )
+
+    def test_exec_summary_gap_prefix_stays_answer_line(self) -> None:
+        docs_svc = _make_mock_docs_service()
+        drive_svc = MagicMock()
+        repl = {
+            "meta.site_name": "Test",
+            "meta.report_date": "04/14/2026",
+            "exec.c_construction_timeline": (
+                "[Not found - RayCon scenario pending] Construction timeline cannot "
+                "be confirmed without a RayCon Scenario. Existing school use reduces "
+                "scope uncertainty, but historic review can still delay permits."
+            ),
+        }
+
+        build_dd_report_doc(docs_svc, drive_svc, "doc123", repl, "Test")
+
+        inserted_text = _inserted_text(docs_svc)
+
+        assert "Construction Timeline: [Not found - RayCon scenario pending]\n" in inserted_text
+        assert "Construction timeline cannot be confirmed without a RayCon Scenario.\n" in inserted_text
+
 
 class TestGapLabelsForLinks:
     """Test that link tokens with no value get appropriate gap labels."""

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -48,7 +48,7 @@ def test_prompt_v4_keeps_first_round_contract() -> None:
     text = _prompt_text()
     required_phrases = [
         "Version:** 4.0.0",
-        "Last Updated:** 2026-05-26",
+        "Last Updated:** 2026-05-27",
         "V4 prompt contract",
         "first-round DDR",
         "current school year (8/12 or 9/8)",
@@ -61,6 +61,7 @@ def test_prompt_v4_keeps_first_round_contract() -> None:
         "exec.citations_block",
         "Source Notes",
         "one answer line",
+        "support fact on its own plain line",
         "Source notes render after the Referenced Reports",
         "does not render in",
         "After `create_dd_report` returns a document, stop.",


### PR DESCRIPTION
## Summary
- Tighten the V4 DDR prompt so executive-summary fields use one answer line plus separate support facts.
- Add a renderer guardrail that splits long one-paragraph executive-summary prose into answer-first support bullets.
- Cover Miami-style prose and gap-label preservation with builder tests.

## Why
The Boston DDR had the right leadership shape: answer first, supporting facts below. The Miami Beach DDR showed the failure mode where support facts were packed into dense prose lines.

## Validation
- uv run pytest tests/test_google_doc_builder.py tests/test_prompt_contract.py
- uv run ruff check src\due_diligence_reporter\google_doc_builder.py tests\test_google_doc_builder.py tests\test_prompt_contract.py
- uv run mypy src/

Notes: raw uv run pytest is currently blocked by existing inaccessible pytest cache/temp dirs and unrelated assignment/sender-filter failures on this checkout. Repo-wide uv run ruff check . still reports unrelated pre-existing lint in scripts/reprocess_mislabeled.py and several test files.