### PR TITLE
Record Rhodes registration failures as events

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -51,6 +51,44 @@ Results:
 - Focused Ruff: all checks passed.
 - Full source Mypy: no issues in 31 source files.
 
+## 2026-05-27 - DDR Rhodes Registration Failure Events
+
+Started the next Rhodes automation Phase 2 slice on branch
+`codex/ddr-rhodes-registration-events`.
+
+Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/114
+
+Current behavior:
+
+- When inbox-filed document registration fails, DDR still preserves the Drive
+  filing and records retry state as before.
+- After the original attempt plus two retries, retry exhaustion now writes an
+  `AutomationEvent v1` note to the matched Rhodes site.
+- The Rhodes note mentions the P1 DRI when `p1_assignee_user_id` is present, or
+  resolves a Rhodes user ID from the P1 DRI email before adding the note.
+- If no owner can be notified in Rhodes, or the note write fails, DDR posts the
+  same event body to the configured Google Chat webhook.
+- Retry state stores `rhodes_failure_note_id` and Chat-notification metadata so
+  repeated scans do not duplicate notes or Chat alerts.
+
+Verification:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-rhodes-events-tests tests/test_inbox_scanner.py::TestRhodesDocumentRegistration tests/test_rhodes.py -q
+uv run ruff check src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py tests\test_inbox_scanner.py tests\test_rhodes.py
+uv run mypy src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py
+uv run pytest --basetemp C:\tmp\ddr-rhodes-events-broad tests/test_inbox_scanner.py tests/test_rhodes.py tests/test_scan_inbox_e2e.py -q
+git diff --check
+```
+
+Results:
+
+- Focused Rhodes/inbox tests: 19 passed.
+- Focused Ruff: all checks passed.
+- Focused Mypy: no issues in 2 source files.
+- Broader inbox/Rhodes/e2e scanner suite: 94 passed.
+- Diff check: no whitespace errors; only expected Windows LF-to-CRLF warnings.
+
 ## 2026-05-27 - DDR Executive Summary Answer-First Rendering
 
 Implemented the Boston-style executive summary guardrail on `main`.

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -200,7 +200,7 @@ For each unprocessed email with PDF attachments:
 
 Current Phase 2 behavior uses the matched Rhodes site record from Phase 1 (`site_title`, `matched_site_id`, address, and Drive folder URL). Older references below to site matching being inactive are stale and retained only until this process doc is fully cleaned up.
 
-Rhodes registration is a non-blocking post-upload side effect. If registration fails or Rhodes is unavailable, the Drive upload remains successful and the scan summary records the Rhodes registration failure for operator follow-up.
+Rhodes registration is a non-blocking post-upload side effect. If registration fails or Rhodes is unavailable, the Drive upload remains successful and the scan summary records the Rhodes registration failure for operator follow-up. The scanner retries Rhodes registration on later runs; after the original attempt plus two retries, it writes an `AutomationEvent v1` note to the Rhodes site. The note mentions the P1 DRI when a Rhodes user ID can be resolved. If no owner can be notified in Rhodes, or the note write fails, the same event is posted to the configured Google Chat webhook.
 
 ### Phase 2 â€” Per-Site Pipeline
 

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -24,10 +24,11 @@ from .m1_lookup import (
     _list_m1_documents_by_type,
     _resolve_m1_folder,
 )
-from .rhodes import register_rhodes_document_for_upload
+from .rhodes import add_rhodes_site_note, register_rhodes_document_for_upload
 from .utils import (
     escape_html_text,
     extract_text_from_pdf_bytes,
+    post_google_chat_message,
     score_site_match_strength,
     send_email,
 )
@@ -181,11 +182,188 @@ def _record_rhodes_registration_attempt(
         "last_reason": str(registration.get("reason") or "").strip(),
         "last_error": str(registration.get("error") or "").strip(),
         "last_attempt_at": datetime.now(UTC).isoformat(),
+        "rhodes_failure_note_id": str(previous.get("rhodes_failure_note_id") or "").strip(),
+        "rhodes_failure_notified_at": str(
+            previous.get("rhodes_failure_notified_at") or ""
+        ).strip(),
+        "rhodes_failure_chat_notified_at": str(
+            previous.get("rhodes_failure_chat_notified_at") or ""
+        ).strip(),
     }
     registration["retry_attempts"] = attempts
     registration["retry_limit"] = RHODES_REGISTRATION_RETRY_LIMIT
     registration["retry_exhausted"] = attempts > RHODES_REGISTRATION_RETRY_LIMIT
     return attempts > RHODES_REGISTRATION_RETRY_LIMIT
+
+
+def _format_owner(site_summary: dict[str, Any]) -> str:
+    name = str(site_summary.get("p1_assignee_name") or "").strip()
+    email = str(site_summary.get("p1_assignee_email") or "").strip()
+    if name and email:
+        return f"{name} <{email}>"
+    return email or name or "No owner assigned"
+
+
+def _metadata_thread_id(metadata: Any, fallback_message_id: str) -> str:
+    thread_id = getattr(metadata, "thread_id", "")
+    if isinstance(thread_id, str) and thread_id.strip():
+        return thread_id.strip()
+    return fallback_message_id
+
+
+def _render_rhodes_registration_failure_event(
+    *,
+    site_summary: dict[str, Any],
+    registration: dict[str, Any],
+    doc_type: str,
+    drive_file: dict[str, Any],
+    drive_filename: str,
+    original_filename: str,
+    email_subject: str,
+    message_id: str,
+    thread_id: str,
+) -> str:
+    site_name = str(site_summary.get("title") or "Unknown site").strip()
+    reason = str(registration.get("reason") or "registration_failed").strip()
+    error = str(registration.get("error") or "").strip()
+    drive_link = str(drive_file.get("webViewLink") or "").strip()
+    drive_file_id = str(drive_file.get("id") or "").strip()
+    attempts = registration.get("retry_attempts") or "unknown"
+    retry_limit = registration.get("retry_limit") or RHODES_REGISTRATION_RETRY_LIMIT
+    lines = [
+        "AutomationEvent v1",
+        "Source: due-diligence-reporter",
+        "Kind: document_registration_failed",
+        f"Site: {site_name}",
+        f"Owner: {_format_owner(site_summary)}",
+        f"DDR doc type: {doc_type}",
+        f"Rhodes doc type: {registration.get('rhodes_doc_type') or 'unknown'}",
+        f"Rhodes milestone: {registration.get('rhodes_milestone') or 'unknown'}",
+        f"Retry attempts: {attempts}/{retry_limit}",
+        "Requested decision: repair or register the Rhodes document link for the Drive file.",
+        f"Reason: {reason}",
+        f"Drive file: {drive_filename}",
+        f"Original filename: {original_filename}",
+        f"Drive file ID: {drive_file_id}",
+        f"Gmail subject: {email_subject}",
+        f"Gmail message ID: {message_id}",
+        f"Gmail thread ID: {thread_id}",
+    ]
+    if error:
+        lines.append(f"Error: {error}")
+    if drive_link:
+        lines.append(f"Drive URL: {drive_link}")
+    return "\n".join(lines)
+
+
+def _post_google_chat_to_configured_webhooks(webhook_urls: str, text: str) -> dict[str, Any]:
+    urls = [url.strip() for url in webhook_urls.split(",") if url.strip()]
+    if not urls:
+        return {"status": "skipped", "reason": "missing_google_chat_webhook_url"}
+    posted = 0
+    errors: list[str] = []
+    for url in urls:
+        try:
+            post_google_chat_message(url, text)
+            posted += 1
+        except Exception as exc:  # noqa: BLE001 - non-fatal notification side effect
+            errors.append(str(exc))
+    if errors:
+        return {
+            "status": "failed" if posted == 0 else "partial",
+            "posted": posted,
+            "errors": errors,
+        }
+    return {"status": "sent", "posted": posted}
+
+
+def _record_rhodes_registration_failure_event(
+    *,
+    settings: Settings,
+    retry_state: dict[str, dict[str, Any]] | None,
+    retry_key: str,
+    site_summary: dict[str, Any],
+    registration: dict[str, Any],
+    doc_type: str,
+    drive_file: dict[str, Any],
+    drive_filename: str,
+    original_filename: str,
+    email_subject: str,
+    message_id: str,
+    thread_id: str,
+) -> dict[str, Any]:
+    """Write retry exhaustion to Rhodes and fall back to Chat when owner notify is absent."""
+    entry = retry_state.get(retry_key) if retry_state is not None else None
+    body = _render_rhodes_registration_failure_event(
+        site_summary=site_summary,
+        registration=registration,
+        doc_type=doc_type,
+        drive_file=drive_file,
+        drive_filename=drive_filename,
+        original_filename=original_filename,
+        email_subject=email_subject,
+        message_id=message_id,
+        thread_id=thread_id,
+    )
+    existing_note_id = str((entry or {}).get("rhodes_failure_note_id") or "").strip()
+    if existing_note_id:
+        result: dict[str, Any] = {
+            "status": "skipped",
+            "reason": "already_recorded",
+            "rhodes_note_id": existing_note_id,
+            "owner_notification": str(
+                (entry or {}).get("rhodes_failure_owner_notification") or "none"
+            ),
+        }
+        if (
+            result["owner_notification"] != "mentioned"
+            and entry is not None
+            and not entry.get("rhodes_failure_chat_notified_at")
+        ):
+            repeat_chat_result = _post_google_chat_to_configured_webhooks(
+                settings.google_chat_webhook_url,
+                body,
+            )
+            entry["rhodes_failure_chat_status"] = repeat_chat_result.get("status")
+            if repeat_chat_result.get("status") in {"sent", "partial"}:
+                entry["rhodes_failure_chat_notified_at"] = datetime.now(UTC).isoformat()
+            result["google_chat"] = repeat_chat_result
+        return result
+
+    owner_user_id = str(site_summary.get("p1_assignee_user_id") or "").strip()
+    owner_email = str(site_summary.get("p1_assignee_email") or "").strip()
+    note_result = add_rhodes_site_note(
+        site_id=str(site_summary.get("id") or "").strip(),
+        body=body,
+        owner_user_id=owner_user_id,
+        owner_email=owner_email,
+    )
+    if entry is not None:
+        entry["rhodes_failure_event_status"] = note_result.get("status")
+        entry["rhodes_failure_event_reason"] = note_result.get("reason")
+        if note_result.get("status") == "created":
+            entry["rhodes_failure_note_id"] = str(note_result.get("rhodes_note_id") or "")
+            entry["rhodes_failure_notified_at"] = datetime.now(UTC).isoformat()
+            entry["rhodes_failure_owner_notification"] = note_result.get("owner_notification")
+
+    should_alert_chat = note_result.get("status") != "created" or (
+        note_result.get("owner_notification") != "mentioned"
+    )
+    chat_result: dict[str, Any] | None = None
+    if should_alert_chat and not (entry and entry.get("rhodes_failure_chat_notified_at")):
+        chat_result = _post_google_chat_to_configured_webhooks(
+            settings.google_chat_webhook_url,
+            body,
+        )
+        if entry is not None:
+            entry["rhodes_failure_chat_status"] = chat_result.get("status")
+            if chat_result.get("status") in {"sent", "partial"}:
+                entry["rhodes_failure_chat_notified_at"] = datetime.now(UTC).isoformat()
+
+    result = dict(note_result)
+    if chat_result is not None:
+        result["google_chat"] = chat_result
+    return result
 
 
 def _drive_file_from_retry_entry(entry: dict[str, Any]) -> dict[str, Any]:
@@ -257,6 +435,26 @@ def _build_site_summary(record: dict[str, Any]) -> dict[str, Any]:
             ("drive_folder_url", "google_folder", "folder_url"),
             {"google folder", "drive folder", "drive folder url"},
         ),
+        "p1_assignee_name": _record_value(
+            record,
+            ("p1_assignee_name", "p1_dri_name", "p1DriName", "p1AssigneeName"),
+            {"p1 assignee name", "p1 dri name", "p1 owner name", "site owner name"},
+        ),
+        "p1_assignee_email": _record_value(
+            record,
+            ("p1_assignee_email", "p1_dri_email", "p1DriEmail", "p1AssigneeEmail"),
+            {"p1 assignee email", "p1 dri email", "p1 owner email", "site owner email"},
+        ),
+        "p1_assignee_user_id": _record_value(
+            record,
+            (
+                "p1_assignee_user_id",
+                "p1_dri_user_id",
+                "p1DriUserId",
+                "p1AssigneeUserId",
+            ),
+            {"p1 assignee user id", "p1 dri user id", "p1 owner user id"},
+        ),
         "total_building_sf": record.get("total_building_sf")
         or record.get("building_square_feet")
         or _custom_field_value(
@@ -276,6 +474,7 @@ class EmailMetadata:
     body_snippet: str
     label_ids: list[str]
     attachments: list[dict[str, Any]]  # [{filename, attachment_id?, body_data?, mime_type}]
+    thread_id: str = ""
     # X-Original-Sender header set by Google Groups when an email is rerouted
     # through a group. Holds the actual external sender's address. Empty when
     # the email did not pass through a Google Group.
@@ -1212,6 +1411,22 @@ def process_email(
                         error=str(registration.get("error") or registration.get("reason") or ""),
                     )
                 )
+                failure_event = _record_rhodes_registration_failure_event(
+                    settings=settings,
+                    retry_state=rhodes_retry_state,
+                    retry_key=rhodes_retry_key,
+                    site_summary=site_summary,
+                    registration=registration,
+                    doc_type=doc_type,
+                    drive_file=drive_file,
+                    drive_filename=str(pending_rhodes_retry.get("drive_filename") or drive_filename),
+                    original_filename=filename,
+                    email_subject=metadata.subject,
+                    message_id=message_id,
+                    thread_id=_metadata_thread_id(metadata, message_id),
+                )
+                uploaded[-1]["rhodes_failure_event"] = failure_event
+                manual_review[-1]["rhodes_failure_event"] = failure_event
                 review_needed = True
             continue
         if gc.file_exists_in_folder(target_folder_id, drive_filename):
@@ -1298,6 +1513,22 @@ def process_email(
                             ),
                         )
                     )
+                    failure_event = _record_rhodes_registration_failure_event(
+                        settings=settings,
+                        retry_state=rhodes_retry_state,
+                        retry_key=rhodes_retry_key,
+                        site_summary=site_summary,
+                        registration=registration,
+                        doc_type=doc_type,
+                        drive_file=drive_file,
+                        drive_filename=drive_filename,
+                        original_filename=filename,
+                        email_subject=metadata.subject,
+                        message_id=message_id,
+                        thread_id=_metadata_thread_id(metadata, message_id),
+                    )
+                    uploaded[-1]["rhodes_failure_event"] = failure_event
+                    manual_review[-1]["rhodes_failure_event"] = failure_event
                     review_needed = True
                 continue
             existing_docs = _list_m1_documents_by_type(gc, target_folder_id)
@@ -1417,6 +1648,22 @@ def process_email(
                             ),
                         )
                     )
+                    failure_event = _record_rhodes_registration_failure_event(
+                        settings=settings,
+                        retry_state=rhodes_retry_state,
+                        retry_key=rhodes_retry_key,
+                        site_summary=site_summary,
+                        registration=uploaded[-1]["rhodes_registration"],
+                        doc_type=doc_type,
+                        drive_file=drive_file,
+                        drive_filename=drive_filename,
+                        original_filename=filename,
+                        email_subject=metadata.subject,
+                        message_id=message_id,
+                        thread_id=_metadata_thread_id(metadata, message_id),
+                    )
+                    uploaded[-1]["rhodes_failure_event"] = failure_event
+                    manual_review[-1]["rhodes_failure_event"] = failure_event
                     review_needed = True
 
                 folder_ping = _run_doc_arrival_folder_ping(
@@ -1632,6 +1879,7 @@ def _extract_email_metadata(gc: GoogleClient, message_id: str) -> EmailMetadata:
         body_snippet=snippet,
         label_ids=list(message.get("labelIds", [])),
         attachments=attachments,
+        thread_id=str(message.get("threadId", "") or ""),
         original_sender=original_sender,
     )
 

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -164,6 +164,24 @@ def _coerce_document_list(payload: Any) -> list[dict[str, Any]]:
     return []
 
 
+def _coerce_note(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, list):
+        first = next((item for item in payload if isinstance(item, dict)), {})
+        return first
+    if isinstance(payload, dict):
+        return _unwrap_single(payload, "note", "record", "data")
+    return {}
+
+
+def _coerce_user(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, list):
+        first = next((item for item in payload if isinstance(item, dict)), {})
+        return first
+    if isinstance(payload, dict):
+        return _unwrap_single(payload, "user", "record", "data")
+    return {}
+
+
 def _document_id(document: dict[str, Any]) -> str:
     for key in ("documentId", "_id", "id"):
         value = document.get(key)
@@ -183,6 +201,22 @@ def _document_drive_file_id(document: dict[str, Any]) -> str:
             value = drive_file.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
+    return ""
+
+
+def _note_id(note: dict[str, Any]) -> str:
+    for key in ("noteId", "_id", "id"):
+        value = note.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _user_id(user: dict[str, Any]) -> str:
+    for key in ("userId", "_id", "id"):
+        value = user.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
     return ""
 
 
@@ -579,6 +613,40 @@ class RhodesClient:
             payload["notes"] = notes.strip()
         return _coerce_document(self.call_tool("registerDocument", payload))
 
+    def add_site_note(
+        self,
+        *,
+        site_id: str,
+        body: str,
+        mentions: Iterable[str] | None = None,
+    ) -> dict[str, Any]:
+        if not site_id.strip():
+            raise RhodesError("site_id is required")
+        if not body.strip():
+            raise RhodesError("body is required")
+
+        payload: dict[str, Any] = {"siteId": site_id.strip(), "body": body.strip()}
+        clean_mentions = [m.strip() for m in (mentions or []) if m.strip()]
+        if clean_mentions:
+            payload["mentions"] = clean_mentions
+        return _coerce_note(self.call_tool("addNote", payload))
+
+    def get_user(
+        self,
+        *,
+        email: str = "",
+        user_id: str = "",
+    ) -> dict[str, Any] | None:
+        payload: dict[str, Any] = {}
+        if user_id.strip():
+            payload["userId"] = user_id.strip()
+        elif email.strip():
+            payload["email"] = email.strip()
+        else:
+            raise RhodesError("email or user_id is required")
+        user = _coerce_user(self.call_tool("getUser", payload))
+        return user or None
+
     def find_document_by_drive_file_id(
         self,
         *,
@@ -705,6 +773,64 @@ def lookup_rhodes_site_owner(
     if result["status"] == "owner_missing":
         result["message"] = "Rhodes site exists, but p1Dri is not assigned."
     return result
+
+
+def add_rhodes_site_note(
+    *,
+    site_id: str,
+    body: str,
+    owner_user_id: str = "",
+    owner_email: str = "",
+    client: RhodesClient | None = None,
+) -> dict[str, Any]:
+    """Create a Rhodes site note and mention the owner when possible."""
+    clean_site_id = site_id.strip()
+    clean_body = body.strip()
+    clean_owner_user_id = owner_user_id.strip()
+    clean_owner_email = owner_email.strip()
+    base = {
+        "rhodes_site_id": clean_site_id,
+        "owner_user_id": clean_owner_user_id,
+        "owner_email": clean_owner_email,
+        "owner_notification": "none",
+    }
+    if not clean_site_id:
+        return {**base, "status": "skipped", "reason": "missing_site_id"}
+    if not clean_body:
+        return {**base, "status": "skipped", "reason": "missing_body"}
+
+    try:
+        rhodes = client or RhodesClient()
+        resolved_owner_user_id = clean_owner_user_id
+        owner_resolution = "provided" if resolved_owner_user_id else "none"
+        if not resolved_owner_user_id and clean_owner_email:
+            try:
+                user = rhodes.get_user(email=clean_owner_email)
+            except RhodesError:
+                user = None
+                owner_resolution = "lookup_failed"
+            else:
+                resolved_owner_user_id = _user_id(user or {})
+                owner_resolution = "resolved_from_email" if resolved_owner_user_id else "not_found"
+        note = rhodes.add_site_note(
+            site_id=clean_site_id,
+            body=clean_body,
+            mentions=[resolved_owner_user_id] if resolved_owner_user_id else [],
+        )
+    except RhodesError as exc:
+        return {**base, "status": "failed", "reason": "rhodes_error", "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001 - non-fatal scanner side effect
+        return {**base, "status": "failed", "reason": "unexpected_error", "error": str(exc)}
+
+    return {
+        **base,
+        "status": "created",
+        "reason": "ok",
+        "rhodes_note_id": _note_id(note),
+        "owner_user_id": resolved_owner_user_id,
+        "owner_resolution": owner_resolution,
+        "owner_notification": "mentioned" if resolved_owner_user_id else "none",
+    }
 
 
 def map_ddr_doc_type_to_rhodes(ddr_doc_type: str) -> RhodesDocumentMapping | None:

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -16,6 +16,7 @@ from due_diligence_reporter.inbox_scanner import (
     EmailMetadata,
     _generate_drive_filename,
     _is_internal_sender,
+    _record_rhodes_registration_failure_event,
     _run_block_plan_downstream,
     _run_doc_arrival_folder_ping,
     _walk_parts,
@@ -1524,6 +1525,7 @@ class TestRhodesDocumentRegistration:
         return SimpleNamespace(
             inbox_internal_sender_addresses="",
             inbox_internal_sender_domains="trilogy.com",
+            google_chat_webhook_url="",
         )
 
     @patch("due_diligence_reporter.inbox_scanner._build_site_summary")
@@ -1757,6 +1759,8 @@ class TestRhodesDocumentRegistration:
         assert list(retry_state.values())[0]["attempts"] == 1
         assert list(retry_state.values())[0]["drive_file_id"] == "isp_drive_id"
 
+    @patch("due_diligence_reporter.inbox_scanner._post_google_chat_to_configured_webhooks")
+    @patch("due_diligence_reporter.inbox_scanner.add_rhodes_site_note")
     @patch("due_diligence_reporter.inbox_scanner._build_site_summary")
     @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
     @patch("due_diligence_reporter.inbox_scanner._run_doc_arrival_folder_ping")
@@ -1771,6 +1775,8 @@ class TestRhodesDocumentRegistration:
         mock_ping,
         mock_resolve_m1,
         mock_build_summary,
+        mock_add_note,
+        mock_chat,
     ):
         drive_filename = f"{datetime.now().strftime('%b %d %Y')} - Alpha Keller ISP.pdf"
         retry_state = {
@@ -1807,6 +1813,9 @@ class TestRhodesDocumentRegistration:
             "title": "Alpha Keller",
             "address": "123 Main St",
             "drive_folder_url": "https://drive.google.com/drive/folders/site_abc",
+            "p1_assignee_name": "Owner One",
+            "p1_assignee_email": "owner@example.com",
+            "p1_assignee_user_id": "USER1",
         }
         mock_register.return_value = {
             "status": "failed",
@@ -1814,6 +1823,11 @@ class TestRhodesDocumentRegistration:
             "error": "still down",
         }
         mock_ping.return_value = {"status": "accepted"}
+        mock_add_note.return_value = {
+            "status": "created",
+            "rhodes_note_id": "NOTE1",
+            "owner_notification": "mentioned",
+        }
 
         gc = MagicMock()
         gc.file_exists_in_folder.return_value = True
@@ -1830,7 +1844,69 @@ class TestRhodesDocumentRegistration:
 
         assert result["uploaded"][0]["retry_existing_upload"] is True
         assert result["manual_review"][0]["reason"] == "rhodes_registration_retry_exhausted"
+        assert result["manual_review"][0]["rhodes_failure_event"]["rhodes_note_id"] == "NOTE1"
+        assert result["uploaded"][0]["rhodes_failure_event"]["owner_notification"] == "mentioned"
         assert list(retry_state.values())[0]["attempts"] == 3
+        assert list(retry_state.values())[0]["rhodes_failure_note_id"] == "NOTE1"
+        mock_add_note.assert_called_once()
+        note_kwargs = mock_add_note.call_args.kwargs
+        assert note_kwargs["site_id"] == "SITE1"
+        assert note_kwargs["owner_user_id"] == "USER1"
+        assert "AutomationEvent v1" in note_kwargs["body"]
+        assert "Kind: document_registration_failed" in note_kwargs["body"]
+        mock_chat.assert_not_called()
+
+    @patch("due_diligence_reporter.inbox_scanner._post_google_chat_to_configured_webhooks")
+    @patch("due_diligence_reporter.inbox_scanner.add_rhodes_site_note")
+    def test_registration_failure_event_posts_chat_when_owner_missing(
+        self,
+        mock_add_note,
+        mock_chat,
+    ):
+        retry_state: dict[str, dict[str, object]] = {"SITE1|isp|Alpha Keller ISP.pdf": {}}
+        mock_add_note.return_value = {
+            "status": "created",
+            "rhodes_note_id": "NOTE1",
+            "owner_notification": "none",
+        }
+        mock_chat.return_value = {"status": "sent", "posted": 1}
+
+        result = _record_rhodes_registration_failure_event(
+            settings=SimpleNamespace(google_chat_webhook_url="https://chat.example/hook"),
+            retry_state=retry_state,
+            retry_key="SITE1|isp|Alpha Keller ISP.pdf",
+            site_summary={"id": "SITE1", "title": "Alpha Keller"},
+            registration={
+                "status": "failed",
+                "reason": "rhodes_error",
+                "error": "timeout",
+                "rhodes_doc_type": "other",
+                "rhodes_milestone": "acquireProperty",
+                "retry_attempts": 3,
+                "retry_limit": 2,
+            },
+            doc_type="isp",
+            drive_file={
+                "id": "isp_drive_id",
+                "webViewLink": "https://drive.google.com/file/d/isp_drive_id",
+            },
+            drive_filename="May 27 2026 - Alpha Keller ISP.pdf",
+            original_filename="Alpha Keller ISP.pdf",
+            email_subject="Alpha Keller ISP",
+            message_id="msg_rhodes_retry_exhausted",
+            thread_id="thread_rhodes_retry_exhausted",
+        )
+
+        assert result["status"] == "created"
+        assert result["google_chat"] == {"status": "sent", "posted": 1}
+        mock_add_note.assert_called_once()
+        assert mock_add_note.call_args.kwargs["owner_user_id"] == ""
+        assert mock_add_note.call_args.kwargs["owner_email"] == ""
+        mock_chat.assert_called_once()
+        assert mock_chat.call_args.args[0] == "https://chat.example/hook"
+        assert "Owner: No owner assigned" in mock_chat.call_args.args[1]
+        assert retry_state["SITE1|isp|Alpha Keller ISP.pdf"]["rhodes_failure_note_id"] == "NOTE1"
+        assert retry_state["SITE1|isp|Alpha Keller ISP.pdf"]["rhodes_failure_chat_status"] == "sent"
 
     def test_build_scan_summary_includes_rhodes_registration_counts(self):
         from due_diligence_reporter.inbox_scanner import build_scan_summary

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from due_diligence_reporter.rhodes import (
     RhodesError,
+    add_rhodes_site_note,
     list_rhodes_site_records,
     lookup_rhodes_site_owner,
     map_ddr_doc_type_to_rhodes,
@@ -23,6 +24,8 @@ class FakeRhodesClient:
         self.drive_root = drive_root
         self.documents: list[dict[str, Any]] = []
         self.registered_documents: list[dict[str, Any]] = []
+        self.notes: list[dict[str, Any]] = []
+        self.users_by_email: dict[str, dict[str, Any]] = {}
         self.calls: list[tuple[str, dict[str, str]]] = []
 
     def resolve_site(self, *, name: str = "", address: str = "") -> dict[str, Any] | None:
@@ -110,6 +113,43 @@ class FakeRhodesClient:
         }
         self.registered_documents.append(document)
         return document
+
+    def get_user(
+        self,
+        *,
+        email: str = "",
+        user_id: str = "",
+    ) -> dict[str, Any] | None:
+        self.calls.append(("get_user", {"email": email, "user_id": user_id}))
+        if user_id:
+            return {"_id": user_id, "email": email}
+        return self.users_by_email.get(email)
+
+    def add_site_note(
+        self,
+        *,
+        site_id: str,
+        body: str,
+        mentions: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            (
+                "add_site_note",
+                {
+                    "site_id": site_id,
+                    "body": body,
+                    "mentions": ",".join(mentions or []),
+                },
+            )
+        )
+        note = {
+            "_id": f"NOTE{len(self.notes) + 1}",
+            "siteId": site_id,
+            "body": body,
+            "mentions": mentions or [],
+        }
+        self.notes.append(note)
+        return note
 
 
 def test_lookup_rhodes_site_owner_returns_p1_report_fields() -> None:
@@ -367,3 +407,39 @@ def test_register_rhodes_document_for_upload_handles_missing_config(monkeypatch)
     assert result["status"] == "failed"
     assert result["reason"] == "rhodes_error"
     assert "RHODES_API_KEY" in result["error"]
+
+
+def test_add_rhodes_site_note_mentions_owner_user_id() -> None:
+    client = FakeRhodesClient()
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        body="AutomationEvent v1\nKind: document_registration_failed",
+        owner_user_id="USER1",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["rhodes_note_id"] == "NOTE1"
+    assert result["owner_notification"] == "mentioned"
+    assert client.notes[0]["mentions"] == ["USER1"]
+
+
+def test_add_rhodes_site_note_resolves_owner_email() -> None:
+    client = FakeRhodesClient()
+    client.users_by_email["owner@example.com"] = {
+        "_id": "USER2",
+        "email": "owner@example.com",
+    }
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        body="AutomationEvent v1\nKind: document_registration_failed",
+        owner_email="owner@example.com",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["owner_user_id"] == "USER2"
+    assert result["owner_resolution"] == "resolved_from_email"
+    assert client.notes[0]["mentions"] == ["USER2"]


### PR DESCRIPTION
## Summary
- write Rhodes document-registration retry exhaustion as an AutomationEvent v1 site note
- mention the P1 DRI when a Rhodes user ID is present or resolvable from email
- fall back to configured Google Chat when no owner can be notified in Rhodes or the note write fails
- persist note/chat metadata in retry state to avoid duplicate alerts

## Verification
- uv run pytest --basetemp C:\tmp\ddr-rhodes-events-tests tests/test_inbox_scanner.py::TestRhodesDocumentRegistration tests/test_rhodes.py -q
- uv run ruff check src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py tests\test_inbox_scanner.py tests\test_rhodes.py
- uv run mypy src\due_diligence_reporter\inbox_scanner.py src\due_diligence_reporter\rhodes.py
- uv run pytest --basetemp C:\tmp\ddr-rhodes-events-broad tests/test_inbox_scanner.py tests/test_rhodes.py tests/test_scan_inbox_e2e.py -q
- git diff --check