### PR TITLE
Standardize DDR automation events

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,43 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-27 - DDR AutomationEvent Contract Module
+
+Started the next Phase 2 event-contract slice on branch
+`codex/ddr-automation-event-contract`.
+
+Current behavior in progress:
+
+- Added `src/due_diligence_reporter/automation_event.py` with a canonical
+  `AutomationEvent` dataclass and `render_automation_event_note(...)`.
+- Moved document-registration failure event construction out of
+  `inbox_scanner.py` into `build_document_registration_failed_event(...)`.
+- The rendered `AutomationEvent v1` note now carries shared contract fields:
+  source system, source ID, event kind, site ID, decision-required status,
+  requested decision, mutation status, retry state, artifact IDs, and
+  created-at timestamp.
+- DDR-specific details remain in the note body: owner, DDR/Rhodes doc types,
+  milestone, reason, Drive file name, original filename, Gmail subject, Drive
+  URL, and error.
+- Existing Rhodes note and Google Chat fallback behavior is unchanged.
+
+Verification in progress:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-automation-event-tests tests/test_automation_event.py tests/test_inbox_scanner.py::TestRhodesDocumentRegistration -q
+uv run ruff check src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\inbox_scanner.py tests\test_automation_event.py tests\test_inbox_scanner.py
+uv run mypy src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\inbox_scanner.py
+uv run pytest --basetemp C:\tmp\ddr-automation-event-broad tests/test_automation_event.py tests/test_inbox_scanner.py tests/test_scan_inbox_e2e.py tests/test_rhodes.py -q
+uv run mypy src/
+```
+
+Results:
+
+- Focused event/scanner tests: 8 passed.
+- Focused Ruff: passed.
+- Focused Mypy: no issues in 2 source files.
+- Broader inbox/Rhodes suite: 96 passed.
+- Full source Mypy: no issues in 33 source files.
+
 ## 2026-05-27 - Firestore Rhodes Registration Retry State
 
 Started the next Rhodes automation Phase 2 slice on branch

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -204,6 +204,8 @@ Rhodes registration is a non-blocking post-upload side effect. If registration f
 
 Registration retry state is persisted through a store boundary. Local development defaults to `.rhodes_registration_retry_state.json`; scheduled/production runs should set `RHODES_RETRY_STATE_STORE=firestore` and `RHODES_RETRY_STATE_FIRESTORE_PROJECT_ID=<project>` so retry attempts, Rhodes note IDs, and Google Chat fallback metadata survive runner changes. GitHub Actions can provide those values through repository variables plus the optional `GCP_FIRESTORE_SERVICE_ACCOUNT_JSON` secret, which is written to `GOOGLE_APPLICATION_CREDENTIALS` for the scan step. If Firestore is unconfigured or unavailable, the scanner falls back to the local JSON file and keeps filing documents.
 
+Material automation outcomes render through `src/due_diligence_reporter/automation_event.py`. The shared `AutomationEvent v1` note body includes source system, source ID, event kind, site ID, decision-required status, mutation status, retry state, and artifact IDs before adding DDR-specific details. This keeps Rhodes notes and Google Chat fallback alerts aligned with the cross-repo automation-event contract.
+
 ### Phase 2 â€” Per-Site Pipeline
 
 After all uploads complete, the scanner attempts to run the report pipeline for each site that received a new document. Phase 2 requires a `site_title` to look up the site context. The current classifier routes by `doc_type` only and does not match files to sites, so `site_title` is `None` in all uploads â€” **Phase 2 is currently inactive** and report generation falls to the daily sweep.

--- a/src/due_diligence_reporter/automation_event.py
+++ b/src/due_diligence_reporter/automation_event.py
@@ -1,0 +1,122 @@
+"""Shared AutomationEvent rendering for Rhodes notes and alerts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AutomationEvent:
+    """Canonical event shape for material automation outcomes."""
+
+    source_system: str
+    source_id: str
+    site_id: str
+    site_name: str
+    event_type: str
+    artifact_ids: dict[str, str] = field(default_factory=dict)
+    decision_required: bool = False
+    requested_decision: str | None = None
+    mutation_status: str = ""
+    retry_state: dict[str, Any] = field(default_factory=dict)
+    details: dict[str, str] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+def render_automation_event_note(event: AutomationEvent) -> str:
+    """Render an AutomationEvent as a stable Rhodes note body."""
+
+    lines = [
+        "AutomationEvent v1",
+        f"Source: {event.source_system}",
+        f"Source ID: {event.source_id}",
+        f"Kind: {event.event_type}",
+        f"Site: {event.site_name}",
+        f"Site ID: {event.site_id or 'unknown'}",
+        f"Decision required: {'yes' if event.decision_required else 'no'}",
+    ]
+    if event.requested_decision:
+        lines.append(f"Requested decision: {event.requested_decision}")
+    if event.mutation_status:
+        lines.append(f"Mutation status: {event.mutation_status}")
+    if event.retry_state:
+        lines.append(f"Retry state: {_format_retry_state(event.retry_state)}")
+    for label, value in event.artifact_ids.items():
+        lines.append(f"{label}: {value or 'unknown'}")
+    for label, value in event.details.items():
+        if value:
+            lines.append(f"{label}: {value}")
+    lines.append(f"Created at: {event.created_at}")
+    return "\n".join(lines)
+
+
+def build_document_registration_failed_event(
+    *,
+    site_summary: dict[str, Any],
+    registration: dict[str, Any],
+    doc_type: str,
+    drive_file: dict[str, Any],
+    drive_filename: str,
+    original_filename: str,
+    email_subject: str,
+    message_id: str,
+    thread_id: str,
+    created_at: str | None = None,
+) -> AutomationEvent:
+    """Build the DDR document-registration failure event."""
+
+    attempts = registration.get("retry_attempts") or "unknown"
+    retry_limit = registration.get("retry_limit") or "unknown"
+    event = AutomationEvent(
+        source_system="due-diligence-reporter",
+        source_id=message_id,
+        site_id=str(site_summary.get("id") or site_summary.get("site_id") or "").strip(),
+        site_name=str(site_summary.get("title") or "Unknown site").strip(),
+        event_type="document_registration_failed",
+        artifact_ids={
+            "Drive file ID": str(drive_file.get("id") or "").strip(),
+            "Gmail message ID": message_id,
+            "Gmail thread ID": thread_id,
+        },
+        decision_required=True,
+        requested_decision="repair or register the Rhodes document link for the Drive file",
+        mutation_status=str(registration.get("status") or "failed").strip(),
+        retry_state={
+            "attempts": attempts,
+            "limit": retry_limit,
+            "exhausted": registration.get("retry_exhausted"),
+        },
+        details={
+            "Owner": _format_owner(site_summary),
+            "DDR doc type": doc_type,
+            "Rhodes doc type": str(registration.get("rhodes_doc_type") or "unknown"),
+            "Rhodes milestone": str(registration.get("rhodes_milestone") or "unknown"),
+            "Reason": str(registration.get("reason") or "registration_failed").strip(),
+            "Drive file": drive_filename,
+            "Original filename": original_filename,
+            "Gmail subject": email_subject,
+            "Drive URL": str(drive_file.get("webViewLink") or "").strip(),
+            "Error": str(registration.get("error") or "").strip(),
+        },
+        created_at=created_at or datetime.now(UTC).isoformat(),
+    )
+    return event
+
+
+def _format_owner(site_summary: dict[str, Any]) -> str:
+    name = str(site_summary.get("p1_assignee_name") or "").strip()
+    email = str(site_summary.get("p1_assignee_email") or "").strip()
+    if name and email:
+        return f"{name} <{email}>"
+    return email or name or "No owner assigned"
+
+
+def _format_retry_state(retry_state: dict[str, Any]) -> str:
+    attempts = retry_state.get("attempts", "unknown")
+    limit = retry_state.get("limit", "unknown")
+    exhausted = retry_state.get("exhausted")
+    if exhausted is None:
+        return f"attempts={attempts}/{limit}"
+    return f"attempts={attempts}/{limit}; exhausted={str(bool(exhausted)).lower()}"

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -16,6 +16,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
+from .automation_event import (
+    build_document_registration_failed_event,
+    render_automation_event_note,
+)
 from .classifier import classify_by_content_llm, classify_document
 from .config import Settings
 from .google_client import GoogleClient
@@ -183,64 +187,11 @@ def _record_rhodes_registration_attempt(
     return attempts > RHODES_REGISTRATION_RETRY_LIMIT
 
 
-def _format_owner(site_summary: dict[str, Any]) -> str:
-    name = str(site_summary.get("p1_assignee_name") or "").strip()
-    email = str(site_summary.get("p1_assignee_email") or "").strip()
-    if name and email:
-        return f"{name} <{email}>"
-    return email or name or "No owner assigned"
-
-
 def _metadata_thread_id(metadata: Any, fallback_message_id: str) -> str:
     thread_id = getattr(metadata, "thread_id", "")
     if isinstance(thread_id, str) and thread_id.strip():
         return thread_id.strip()
     return fallback_message_id
-
-
-def _render_rhodes_registration_failure_event(
-    *,
-    site_summary: dict[str, Any],
-    registration: dict[str, Any],
-    doc_type: str,
-    drive_file: dict[str, Any],
-    drive_filename: str,
-    original_filename: str,
-    email_subject: str,
-    message_id: str,
-    thread_id: str,
-) -> str:
-    site_name = str(site_summary.get("title") or "Unknown site").strip()
-    reason = str(registration.get("reason") or "registration_failed").strip()
-    error = str(registration.get("error") or "").strip()
-    drive_link = str(drive_file.get("webViewLink") or "").strip()
-    drive_file_id = str(drive_file.get("id") or "").strip()
-    attempts = registration.get("retry_attempts") or "unknown"
-    retry_limit = registration.get("retry_limit") or RHODES_REGISTRATION_RETRY_LIMIT
-    lines = [
-        "AutomationEvent v1",
-        "Source: due-diligence-reporter",
-        "Kind: document_registration_failed",
-        f"Site: {site_name}",
-        f"Owner: {_format_owner(site_summary)}",
-        f"DDR doc type: {doc_type}",
-        f"Rhodes doc type: {registration.get('rhodes_doc_type') or 'unknown'}",
-        f"Rhodes milestone: {registration.get('rhodes_milestone') or 'unknown'}",
-        f"Retry attempts: {attempts}/{retry_limit}",
-        "Requested decision: repair or register the Rhodes document link for the Drive file.",
-        f"Reason: {reason}",
-        f"Drive file: {drive_filename}",
-        f"Original filename: {original_filename}",
-        f"Drive file ID: {drive_file_id}",
-        f"Gmail subject: {email_subject}",
-        f"Gmail message ID: {message_id}",
-        f"Gmail thread ID: {thread_id}",
-    ]
-    if error:
-        lines.append(f"Error: {error}")
-    if drive_link:
-        lines.append(f"Drive URL: {drive_link}")
-    return "\n".join(lines)
 
 
 def _post_google_chat_to_configured_webhooks(webhook_urls: str, text: str) -> dict[str, Any]:
@@ -281,7 +232,7 @@ def _record_rhodes_registration_failure_event(
 ) -> dict[str, Any]:
     """Write retry exhaustion to Rhodes and fall back to Chat when owner notify is absent."""
     entry = retry_state.get(retry_key) if retry_state is not None else None
-    body = _render_rhodes_registration_failure_event(
+    event = build_document_registration_failed_event(
         site_summary=site_summary,
         registration=registration,
         doc_type=doc_type,
@@ -292,6 +243,7 @@ def _record_rhodes_registration_failure_event(
         message_id=message_id,
         thread_id=thread_id,
     )
+    body = render_automation_event_note(event)
     existing_note_id = str((entry or {}).get("rhodes_failure_note_id") or "").strip()
     if existing_note_id:
         result: dict[str, Any] = {

--- a/tests/test_automation_event.py
+++ b/tests/test_automation_event.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from due_diligence_reporter.automation_event import (
+    build_document_registration_failed_event,
+    render_automation_event_note,
+)
+
+
+def test_document_registration_failed_event_renders_shared_contract_fields() -> None:
+    event = build_document_registration_failed_event(
+        site_summary={
+            "id": "SITE1",
+            "title": "Alpha Keller",
+            "p1_assignee_name": "Owner One",
+            "p1_assignee_email": "owner@example.com",
+        },
+        registration={
+            "status": "failed",
+            "reason": "rhodes_error",
+            "error": "timeout",
+            "rhodes_doc_type": "other",
+            "rhodes_milestone": "acquireProperty",
+            "retry_attempts": 3,
+            "retry_limit": 2,
+            "retry_exhausted": True,
+        },
+        doc_type="isp",
+        drive_file={
+            "id": "drive-file-1",
+            "webViewLink": "https://drive.example/file/drive-file-1",
+        },
+        drive_filename="May 27 2026 - Alpha Keller ISP.pdf",
+        original_filename="Alpha Keller ISP.pdf",
+        email_subject="Alpha Keller ISP",
+        message_id="msg-1",
+        thread_id="thread-1",
+        created_at="2026-05-27T16:45:00+00:00",
+    )
+
+    assert event.source_system == "due-diligence-reporter"
+    assert event.source_id == "msg-1"
+    assert event.site_id == "SITE1"
+    assert event.event_type == "document_registration_failed"
+    assert event.decision_required is True
+
+    note = render_automation_event_note(event)
+
+    assert "AutomationEvent v1" in note
+    assert "Source: due-diligence-reporter" in note
+    assert "Source ID: msg-1" in note
+    assert "Kind: document_registration_failed" in note
+    assert "Site ID: SITE1" in note
+    assert "Decision required: yes" in note
+    assert (
+        "Requested decision: repair or register the Rhodes document link for the Drive file"
+        in note
+    )
+    assert "Mutation status: failed" in note
+    assert "Retry state: attempts=3/2; exhausted=true" in note
+    assert "Drive file ID: drive-file-1" in note
+    assert "Gmail message ID: msg-1" in note
+    assert "Owner: Owner One <owner@example.com>" in note
+    assert "Created at: 2026-05-27T16:45:00+00:00" in note
+
+
+def test_document_registration_event_handles_missing_owner() -> None:
+    event = build_document_registration_failed_event(
+        site_summary={"id": "SITE1", "title": "Alpha Keller"},
+        registration={
+            "status": "failed",
+            "reason": "rhodes_error",
+            "retry_attempts": 3,
+            "retry_limit": 2,
+        },
+        doc_type="isp",
+        drive_file={"id": "drive-file-1"},
+        drive_filename="May 27 2026 - Alpha Keller ISP.pdf",
+        original_filename="Alpha Keller ISP.pdf",
+        email_subject="Alpha Keller ISP",
+        message_id="msg-1",
+        thread_id="thread-1",
+        created_at="2026-05-27T16:45:00+00:00",
+    )
+
+    note = render_automation_event_note(event)
+
+    assert "Owner: No owner assigned" in note


### PR DESCRIPTION
## Summary
- add a reusable DDR AutomationEvent contract/rendering module
- move document-registration failure event construction out of inbox_scanner
- include shared ledger fields in the Rhodes note body: source ID, site ID, decision-required status, mutation status, retry state, artifact IDs, and created-at
- preserve existing Rhodes note and Google Chat fallback behavior

## Verification
- uv run pytest --basetemp C:\tmp\ddr-automation-event-tests tests/test_automation_event.py tests/test_inbox_scanner.py::TestRhodesDocumentRegistration -q
- uv run ruff check src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\inbox_scanner.py tests\test_automation_event.py tests\test_inbox_scanner.py
- uv run mypy src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\inbox_scanner.py
- uv run pytest --basetemp C:\tmp\ddr-automation-event-broad tests/test_automation_event.py tests/test_inbox_scanner.py tests/test_scan_inbox_e2e.py tests/test_rhodes.py -q
- uv run mypy src/
- git diff --check