### PR TITLE
Reconcile Drive documents into Rhodes

### DIFF
--- a/.github/workflows/drive-rhodes-reconciliation.yml
+++ b/.github/workflows/drive-rhodes-reconciliation.yml
@@ -1,0 +1,115 @@
+name: Drive Rhodes Reconciliation
+
+on:
+  schedule:
+    - cron: '45 10 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Optional site filter'
+        required: false
+        type: string
+      dry_run:
+        description: 'Detect only; do not register Rhodes documents'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+concurrency:
+  group: drive-rhodes-reconciliation
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  drive-rhodes-reconciliation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.14"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify required secrets
+        run: |
+          [ -n "${{ secrets.OAUTH_CLIENT_ID }}" ] || { echo "OAUTH_CLIENT_ID missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_CLIENT_SECRET }}" ] || { echo "OAUTH_CLIENT_SECRET missing"; exit 1; }
+          [ -n "${{ secrets.OAUTH_REFRESH_TOKEN }}" ] || { echo "OAUTH_REFRESH_TOKEN missing"; exit 1; }
+          [ -n "${{ secrets.RHODES_API_KEY }}" ] || { echo "RHODES_API_KEY missing"; exit 1; }
+
+      - name: Create .env file from secrets
+        env:
+          RHODES_API_KEY: ${{ secrets.RHODES_API_KEY }}
+          RHODES_MCP_URL: ${{ secrets.RHODES_MCP_URL }}
+        run: |
+          touch .env
+          echo "RHODES_API_KEY=${RHODES_API_KEY}" >> .env
+          echo "RHODES_MCP_URL=${RHODES_MCP_URL}" >> .env
+
+      - name: Write Google OAuth client secrets
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          mkdir -p credentials
+          python -c "
+          import json, os
+          data = {
+              'installed': {
+                  'client_id': os.environ['OAUTH_CLIENT_ID'],
+                  'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+                  'redirect_uris': ['http://localhost'],
+                  'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                  'token_uri': 'https://oauth2.googleapis.com/token',
+              }
+          }
+          with open('credentials/client_secrets.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+
+      - name: Write Google OAuth refresh token
+        env:
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+          python -c "
+          import json, os
+          data = {
+              'token': None,
+              'refresh_token': os.environ['OAUTH_REFRESH_TOKEN'],
+              'token_uri': 'https://oauth2.googleapis.com/token',
+              'client_id': os.environ['OAUTH_CLIENT_ID'],
+              'client_secret': os.environ['OAUTH_CLIENT_SECRET'],
+              'scopes': [
+                  'https://www.googleapis.com/auth/drive',
+                  'https://www.googleapis.com/auth/documents',
+                  'https://www.googleapis.com/auth/gmail.modify',
+              ],
+          }
+          with open('.gcp-saved-tokens.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+
+      - name: Run Drive Rhodes reconciliation
+        env:
+          INPUT_SITE: ${{ inputs.site }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "${INPUT_DRY_RUN:-}" = "true" ]; then args+=(--dry-run); fi
+          if [ -n "${INPUT_SITE:-}" ]; then args+=(--site "$INPUT_SITE"); fi
+          uv run python scripts/drive_rhodes_reconciliation.py "${args[@]}"

--- a/.github/workflows/publish-to-mcp-hive.yml
+++ b/.github/workflows/publish-to-mcp-hive.yml
@@ -255,6 +255,7 @@ jobs:
             "Vendor Doc Republish Sweep"
             "Daily DD Check"
             "RayCon Follow-up"
+            "Drive Rhodes Reconciliation"
           )
           for workflow in "${workflows[@]}"; do
             gh run list \

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,66 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-27 - Drive-to-Rhodes Document Reconciliation
+
+Started the remaining Phase 2 Drive-to-Rhodes reconciliation slice on branch
+`codex/ddr-drive-rhodes-reconcile`.
+
+Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/119
+
+Commit: `f7be81d` (`Reconcile Drive documents into Rhodes`)
+
+Current state: branch pushed, draft PR open and mergeable. No status checks were
+reported yet when checked.
+
+Changed:
+
+- Added `src/due_diligence_reporter/drive_rhodes_reconciliation.py`.
+  The sweep loads Rhodes-linked site records, resolves each site's canonical
+  `M1 - Acquire Property` folder without creating folders, classifies recognized
+  M1 files, and registers missing Rhodes document links by Drive file ID.
+- Registration reuses `register_rhodes_document_for_upload`, preserving the
+  existing DDR -> Rhodes doc type mapping and idempotent `listDocuments`
+  pre-check.
+- Generated or unmapped M1 files are reported as skipped rows rather than
+  forced into unsafe Rhodes document types.
+- Added `scripts/drive_rhodes_reconciliation.py` with `--dry-run` and `--site`
+  controls.
+- Added the weekday `Drive Rhodes Reconciliation` GitHub Actions workflow and
+  included it in stale mutating run cancellation/timeout contract tests.
+- Updated `docs/process/HOW-IT-WORKS.md`.
+
+Verification:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-drive-rhodes-focused tests/test_drive_rhodes_reconciliation.py -q
+uv run pytest --basetemp C:\tmp\ddr-drive-rhodes-broad tests/test_drive_rhodes_reconciliation.py tests/test_rhodes.py tests/test_m1_lookup.py tests/test_workflow_contracts.py tests/test_vendor_doc_sweep.py -q
+uv run pytest --basetemp C:\tmp\ddr-drive-rhodes-affected tests/test_drive_rhodes_reconciliation.py tests/test_rhodes.py tests/test_m1_lookup.py tests/test_workflow_contracts.py tests/test_vendor_doc_sweep.py tests/test_inbox_scanner.py -q
+uv run ruff check src\due_diligence_reporter\drive_rhodes_reconciliation.py scripts\drive_rhodes_reconciliation.py tests\test_drive_rhodes_reconciliation.py tests\test_workflow_contracts.py
+uv run mypy src\due_diligence_reporter\drive_rhodes_reconciliation.py
+uv run mypy src/
+uv run python -m py_compile scripts\drive_rhodes_reconciliation.py
+git diff --check
+git diff --cached --check
+```
+
+Results:
+
+- Focused reconciliation tests: 4 passed.
+- Broader Rhodes/M1/workflow/vendor sweep tests: 33 passed.
+- Affected inbox/Rhodes/M1/workflow/vendor suite: 104 passed.
+- Ruff on touched code/tests: passed.
+- Focused Mypy: no issues in 1 source file.
+- Full source Mypy: no issues in 37 source files.
+- Script compile: passed.
+- Diff checks: passed; Git emitted the existing user-level ignore permission
+  warning and expected Windows LF-to-CRLF warnings only.
+
+Next:
+
+- Wait for CI/review on PR #119.
+- After merge, continue with a shared Rhodes adapter skeleton or DDR generated
+  report/open-item/closed-item Rhodes summary events.
+
 ## 2026-05-27 - Firestore RayCon Runtime State
 
 Started the next Phase 2 durable-state item on branch

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,7 +7,10 @@ Started the remaining Phase 2 Drive-to-Rhodes reconciliation slice on branch
 
 Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/119
 
-Commit: `f7be81d` (`Reconcile Drive documents into Rhodes`)
+Implementation commit: `f7be81d` (`Reconcile Drive documents into Rhodes`)
+
+This handoff entry is included on the same PR branch after the implementation
+commit.
 
 Current state: branch pushed, draft PR open and mergeable. No status checks were
 reported yet when checked.

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -210,6 +210,8 @@ RayCon follow-up runtime state is also behind a store boundary. Local developmen
 
 Material automation outcomes render through `src/due_diligence_reporter/automation_event.py`. The shared `AutomationEvent v1` note body includes source system, source ID, event kind, site ID, decision-required status, mutation status, retry state, and artifact IDs before adding DDR-specific details. This keeps Rhodes notes and Google Chat fallback alerts aligned with the cross-repo automation-event contract.
 
+**Drive-to-Rhodes reconciliation:** `scripts/drive_rhodes_reconciliation.py` is the safety sweep for files that already exist in a site's `M1 - Acquire Property` folder. It loads Rhodes-linked sites, scans each M1 folder, classifies recognized DDR source files, and idempotently registers missing Rhodes document records by Drive file ID. The scheduled `Drive Rhodes Reconciliation` workflow runs this backfill on weekdays; manual runs can pass `--dry-run` / workflow `dry_run=true` to report what would be registered without writing to Rhodes. Generated or unmapped reports are surfaced as skipped rows instead of being forced into unsafe Rhodes document types.
+
 ### Phase 2 â€” Per-Site Pipeline
 
 After all uploads complete, the scanner attempts to run the report pipeline for each site that received a new document. Phase 2 requires a `site_title` to look up the site context. The current classifier routes by `doc_type` only and does not match files to sites, so `site_title` is `None` in all uploads â€” **Phase 2 is currently inactive** and report generation falls to the daily sweep.

--- a/scripts/drive_rhodes_reconciliation.py
+++ b/scripts/drive_rhodes_reconciliation.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Reconcile existing M1 Drive files into Rhodes document records."""
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_project_root / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_project_root / ".env")
+
+from due_diligence_reporter.config import get_settings  # noqa: E402
+from due_diligence_reporter.drive_rhodes_reconciliation import (  # noqa: E402
+    run_drive_rhodes_reconciliation,
+)
+from due_diligence_reporter.google_client import GoogleClient  # noqa: E402
+from due_diligence_reporter.rhodes import RhodesClient, list_rhodes_site_records  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+logger = logging.getLogger("drive_rhodes_reconciliation")
+
+
+def main(*, dry_run: bool = False, site: str = "") -> None:
+    settings = get_settings()
+    gc = GoogleClient.from_oauth_config(
+        client_config_path=str(settings.get_client_config_path()),
+        token_file_path=str(settings.get_token_file_path()),
+        oauth_port=settings.oauth_port,
+        scopes=settings.google_scopes,
+    )
+    rhodes = RhodesClient()
+    site_records = list_rhodes_site_records(client=rhodes)
+    if site.strip():
+        needle = site.strip().lower()
+        site_records = [
+            record
+            for record in site_records
+            if needle
+            in " ".join(
+                str(record.get(key) or "").lower()
+                for key in ("id", "site_id", "title", "name", "slug", "address")
+            )
+        ]
+
+    result = run_drive_rhodes_reconciliation(
+        gc,
+        site_records=site_records,
+        dry_run=dry_run,
+        rhodes_client=rhodes,
+    )
+
+    print(
+        "Drive Rhodes reconciliation: "
+        f"sites={result['sites_scanned']} "
+        f"recognized_files={result['recognized_files']} "
+        f"registered={result['registered']} "
+        f"already_registered={result['already_registered']} "
+        f"would_register={result['would_register']} "
+        f"skipped={result['skipped']} "
+        f"errors={result['errors']}"
+    )
+    for row in result["rows"]:
+        print(
+            "  "
+            f"{row.get('site_title') or row.get('site_id')}: "
+            f"{row.get('drive_file_name') or '-'} "
+            f"({row.get('ddr_doc_type') or '-'}) -> "
+            f"{row.get('status')}:{row.get('reason') or '-'}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--site", default="", help="Optional site id/name/address substring")
+    args = parser.parse_args()
+    main(dry_run=args.dry_run, site=args.site)

--- a/src/due_diligence_reporter/drive_rhodes_reconciliation.py
+++ b/src/due_diligence_reporter/drive_rhodes_reconciliation.py
@@ -1,0 +1,235 @@
+"""Reconcile existing M1 Drive files into Rhodes document records."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .classifier import classify_document
+from .google_client import GoogleClient
+from .m1_lookup import M1_RECOGNIZED_DOC_TYPES, _resolve_m1_folder
+from .rhodes import (
+    RhodesClient,
+    RhodesError,
+    map_ddr_doc_type_to_rhodes,
+    register_rhodes_document_for_upload,
+)
+
+logger = logging.getLogger("drive_rhodes_reconciliation")
+
+RECONCILIATION_SOURCE = "drive_rhodes_reconciliation"
+
+
+def run_drive_rhodes_reconciliation(
+    gc: GoogleClient,
+    *,
+    site_records: list[dict[str, Any]],
+    dry_run: bool = False,
+    rhodes_client: RhodesClient | None = None,
+) -> dict[str, Any]:
+    """Register existing recognized M1 Drive files on their Rhodes site records.
+
+    This sweep is intentionally idempotent. Rhodes document registration is
+    checked by Drive file ID before any write, so repeated runs become no-ops
+    once each file has a Rhodes document record.
+    """
+    rows: list[dict[str, Any]] = []
+    for site_record in site_records:
+        site_summary = _site_summary(site_record)
+        rows.extend(
+            _reconcile_site(
+                gc,
+                site_summary=site_summary,
+                dry_run=dry_run,
+                rhodes_client=rhodes_client,
+            )
+        )
+
+    return {
+        "sites_scanned": len(site_records),
+        "recognized_files": sum(1 for row in rows if row.get("drive_file_id")),
+        "registered": sum(1 for row in rows if row.get("status") == "registered"),
+        "already_registered": sum(
+            1 for row in rows if row.get("status") == "already_registered"
+        ),
+        "would_register": sum(1 for row in rows if row.get("status") == "would_register"),
+        "skipped": sum(1 for row in rows if row.get("status") == "skipped"),
+        "errors": sum(1 for row in rows if row.get("status") in {"error", "failed"}),
+        "rows": rows,
+    }
+
+
+def _reconcile_site(
+    gc: GoogleClient,
+    *,
+    site_summary: dict[str, str],
+    dry_run: bool,
+    rhodes_client: RhodesClient | None,
+) -> list[dict[str, Any]]:
+    site_id = site_summary["id"]
+    site_title = site_summary["title"]
+    drive_folder_url = site_summary["drive_folder_url"]
+    base = {
+        "site_id": site_id,
+        "site_title": site_title,
+    }
+    if not site_id:
+        return [{**base, "status": "skipped", "reason": "missing_site_id"}]
+    if not drive_folder_url:
+        return [{**base, "status": "skipped", "reason": "missing_drive_folder_url"}]
+
+    try:
+        m1_folder_id, _m1_folder_url = _resolve_m1_folder(
+            gc,
+            drive_folder_url,
+            create_if_missing=False,
+            allow_legacy_fallback=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - one site should not stop the sweep
+        logger.warning("Failed to resolve M1 for %s: %s", site_title or site_id, exc)
+        return [
+            {
+                **base,
+                "status": "error",
+                "reason": "m1_resolution_failed",
+                "error": str(exc),
+            }
+        ]
+    if not m1_folder_id:
+        return [{**base, "status": "skipped", "reason": "m1_folder_missing"}]
+
+    try:
+        files = gc.list_files_in_folder(m1_folder_id)
+    except Exception as exc:  # noqa: BLE001 - one site should not stop the sweep
+        logger.warning("Failed to list M1 files for %s: %s", site_title or site_id, exc)
+        return [
+            {
+                **base,
+                "status": "error",
+                "reason": "m1_file_listing_failed",
+                "error": str(exc),
+            }
+        ]
+
+    rows: list[dict[str, Any]] = []
+    for file_info in files:
+        row = _reconcile_file(
+            site_summary=site_summary,
+            file_info=file_info,
+            dry_run=dry_run,
+            rhodes_client=rhodes_client,
+        )
+        if row is not None:
+            rows.append(row)
+    if not rows:
+        rows.append({**base, "status": "skipped", "reason": "no_recognized_m1_files"})
+    return rows
+
+
+def _reconcile_file(
+    *,
+    site_summary: dict[str, str],
+    file_info: dict[str, Any],
+    dry_run: bool,
+    rhodes_client: RhodesClient | None,
+) -> dict[str, Any] | None:
+    file_name = str(file_info.get("name") or "").strip()
+    if not file_name:
+        return None
+    ddr_doc_type, confidence = classify_document(file_name)
+    if ddr_doc_type not in M1_RECOGNIZED_DOC_TYPES:
+        return None
+
+    site_id = site_summary["id"]
+    drive_file_id = str(file_info.get("id") or "").strip()
+    drive_url = str(file_info.get("webViewLink") or "").strip()
+    mime_type = str(file_info.get("mimeType") or "application/pdf").strip()
+    mapping = map_ddr_doc_type_to_rhodes(ddr_doc_type)
+    base: dict[str, Any] = {
+        "site_id": site_id,
+        "site_title": site_summary["title"],
+        "drive_file_id": drive_file_id,
+        "drive_file_name": file_name,
+        "drive_link": drive_url,
+        "ddr_doc_type": ddr_doc_type,
+        "classification_confidence": confidence,
+        "rhodes_doc_type": mapping.doc_type if mapping else "",
+        "rhodes_milestone": mapping.milestone if mapping else "",
+    }
+    if not drive_file_id:
+        return {**base, "status": "error", "reason": "missing_drive_file_id"}
+    if mapping is None:
+        return {**base, "status": "skipped", "reason": "unmapped_doc_type"}
+
+    if dry_run:
+        existing = _find_existing_document(
+            rhodes_client,
+            site_id=site_id,
+            drive_file_id=drive_file_id,
+            doc_type=mapping.doc_type,
+            milestone=mapping.milestone,
+        )
+        if existing is not None:
+            return {
+                **base,
+                "status": "already_registered",
+                "reason": "already_linked",
+                "rhodes_document_id": _document_id(existing),
+            }
+        return {**base, "status": "would_register", "reason": "dry_run"}
+
+    registration = register_rhodes_document_for_upload(
+        site_id=site_id,
+        ddr_doc_type=ddr_doc_type,
+        title=file_name,
+        drive_file_id=drive_file_id,
+        drive_url=drive_url,
+        mime_type=mime_type,
+        original_filename=file_name,
+        source=RECONCILIATION_SOURCE,
+        client=rhodes_client,
+    )
+    return {**base, **registration}
+
+
+def _find_existing_document(
+    rhodes_client: RhodesClient | None,
+    *,
+    site_id: str,
+    drive_file_id: str,
+    doc_type: str,
+    milestone: str | None,
+) -> dict[str, Any] | None:
+    if rhodes_client is None:
+        return None
+    try:
+        return rhodes_client.find_document_by_drive_file_id(
+            site_id=site_id,
+            drive_file_id=drive_file_id,
+            doc_type=doc_type,
+            milestone=milestone,
+        )
+    except RhodesError as exc:
+        logger.warning(
+            "Dry-run Rhodes document lookup failed for site=%s file=%s: %s",
+            site_id,
+            drive_file_id,
+            exc,
+        )
+        return None
+
+
+def _site_summary(site_record: dict[str, Any]) -> dict[str, str]:
+    return {
+        "id": str(site_record.get("id") or site_record.get("site_id") or "").strip(),
+        "title": str(site_record.get("title") or site_record.get("name") or "").strip(),
+        "drive_folder_url": str(site_record.get("drive_folder_url") or "").strip(),
+    }
+
+
+def _document_id(document: dict[str, Any]) -> str:
+    for key in ("documentId", "_id", "id"):
+        value = document.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""

--- a/tests/test_drive_rhodes_reconciliation.py
+++ b/tests/test_drive_rhodes_reconciliation.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from due_diligence_reporter.drive_rhodes_reconciliation import (
+    run_drive_rhodes_reconciliation,
+)
+
+
+class FakeRhodesClient:
+    def __init__(self) -> None:
+        self.documents: list[dict[str, Any]] = []
+        self.registered_documents: list[dict[str, Any]] = []
+
+    def find_document_by_drive_file_id(
+        self,
+        *,
+        site_id: str,
+        drive_file_id: str,
+        doc_type: str | None = None,
+        milestone: str | None = None,
+    ) -> dict[str, Any] | None:
+        for document in self.documents:
+            if document.get("driveFileId") == drive_file_id:
+                return document
+        return None
+
+    def register_document(
+        self,
+        *,
+        site_id: str,
+        title: str,
+        doc_type: str,
+        drive_file_id: str,
+        drive_url: str = "",
+        mime_type: str = "",
+        milestone: str | None = None,
+        quality_bar: str | None = None,
+        notes: str = "",
+    ) -> dict[str, Any]:
+        document = {
+            "_id": f"DOC{len(self.registered_documents) + 1}",
+            "siteId": site_id,
+            "title": title,
+            "docType": doc_type,
+            "driveFileId": drive_file_id,
+            "driveUrl": drive_url,
+            "mimeType": mime_type,
+            "milestone": milestone,
+            "qualityBar": quality_bar,
+            "notes": notes,
+        }
+        self.registered_documents.append(document)
+        return document
+
+
+def _site() -> dict[str, str]:
+    return {
+        "id": "SITE1",
+        "title": "Alpha Test",
+        "drive_folder_url": "https://drive.google.com/drive/folders/root",
+    }
+
+
+def _gc(files: list[dict[str, Any]]) -> MagicMock:
+    gc = MagicMock()
+    gc.list_subfolders.return_value = [
+        {
+            "id": "m1",
+            "name": "M1 - Acquire Property",
+            "webViewLink": "https://drive/m1",
+        }
+    ]
+    gc.list_files_in_folder.return_value = files
+    return gc
+
+
+def test_reconciliation_registers_unlinked_m1_source_docs() -> None:
+    rhodes = FakeRhodesClient()
+    gc = _gc(
+        [
+            {
+                "id": "sir-1",
+                "name": "Alpha Test SIR.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-05-27T10:00:00Z",
+                "webViewLink": "https://drive/sir-1",
+            },
+            {
+                "id": "school-1",
+                "name": "Alpha Test School Approval Report.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-05-27T11:00:00Z",
+                "webViewLink": "https://drive/school-1",
+            },
+        ]
+    )
+
+    result = run_drive_rhodes_reconciliation(
+        gc,
+        site_records=[_site()],
+        rhodes_client=rhodes,  # type: ignore[arg-type]
+    )
+
+    assert result["registered"] == 1
+    assert result["skipped"] == 1
+    assert rhodes.registered_documents[0]["docType"] == "siteInvestigationReport"
+    assert rhodes.registered_documents[0]["milestone"] == "acquireProperty"
+    assert "Registered by DDR drive_rhodes_reconciliation." in (
+        rhodes.registered_documents[0]["notes"]
+    )
+    skipped = [row for row in result["rows"] if row["status"] == "skipped"]
+    assert skipped[0]["reason"] == "unmapped_doc_type"
+
+
+def test_reconciliation_skips_already_registered_drive_file() -> None:
+    rhodes = FakeRhodesClient()
+    rhodes.documents = [{"_id": "DOC_EXISTING", "driveFileId": "sir-1"}]
+    gc = _gc(
+        [
+            {
+                "id": "sir-1",
+                "name": "Alpha Test SIR.pdf",
+                "mimeType": "application/pdf",
+                "webViewLink": "https://drive/sir-1",
+            }
+        ]
+    )
+
+    result = run_drive_rhodes_reconciliation(
+        gc,
+        site_records=[_site()],
+        rhodes_client=rhodes,  # type: ignore[arg-type]
+    )
+
+    assert result["already_registered"] == 1
+    assert result["registered"] == 0
+    assert rhodes.registered_documents == []
+    assert result["rows"][0]["rhodes_document_id"] == "DOC_EXISTING"
+
+
+def test_reconciliation_dry_run_reports_would_register_without_writing() -> None:
+    rhodes = FakeRhodesClient()
+    gc = _gc(
+        [
+            {
+                "id": "inspection-1",
+                "name": "Alpha Test Building Inspection Report.pdf",
+                "mimeType": "application/pdf",
+                "webViewLink": "https://drive/inspection-1",
+            }
+        ]
+    )
+
+    result = run_drive_rhodes_reconciliation(
+        gc,
+        site_records=[_site()],
+        dry_run=True,
+        rhodes_client=rhodes,  # type: ignore[arg-type]
+    )
+
+    assert result["would_register"] == 1
+    assert result["registered"] == 0
+    assert rhodes.registered_documents == []
+    assert result["rows"][0]["rhodes_doc_type"] == "propertyConditionAssessment"
+
+
+def test_reconciliation_skips_site_without_m1_folder() -> None:
+    gc = MagicMock()
+    gc.list_subfolders.return_value = []
+
+    result = run_drive_rhodes_reconciliation(gc, site_records=[_site()])
+
+    assert result["recognized_files"] == 0
+    assert result["skipped"] == 1
+    assert result["rows"][0]["reason"] == "m1_folder_missing"

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -39,6 +39,7 @@ def test_workflow_dispatch_site_inputs_are_not_interpolated_in_shell() -> None:
         "daily-dd-check.yml",
         "vendor-doc-republish-sweep.yml",
         "reprocess-mislabeled.yml",
+        "drive-rhodes-reconciliation.yml",
     ):
         shell = "\n".join(_run_blocks(_workflow_text(workflow)))
         assert "${{ inputs.site }}" not in shell
@@ -81,6 +82,7 @@ def test_publish_to_mcp_hive_cancels_stale_mutating_runs() -> None:
         '"Vendor Doc Republish Sweep"',
         '"Daily DD Check"',
         '"RayCon Follow-up"',
+        '"Drive Rhodes Reconciliation"',
     ):
         assert workflow in text
 
@@ -88,6 +90,7 @@ def test_publish_to_mcp_hive_cancels_stale_mutating_runs() -> None:
 def test_long_running_mutating_workflows_have_timeouts() -> None:
     assert "timeout-minutes: 60" in _workflow_text("inbox-scan.yml")
     assert "timeout-minutes: 60" in _workflow_text("vendor-doc-republish-sweep.yml")
+    assert "timeout-minutes: 60" in _workflow_text("drive-rhodes-reconciliation.yml")
 
 
 def test_inbox_scan_can_enable_firestore_retry_state_without_required_secret() -> None:


### PR DESCRIPTION
Summary:
- Add a Drive-to-Rhodes reconciliation sweep that scans Rhodes-linked site M1 folders and idempotently registers recognized DDR source files by Drive file ID.
- Add a weekday GitHub Actions workflow plus manual dry-run/site-filter controls for the backfill.
- Update workflow guardrails and process docs so the new mutating workflow is covered by stale-run cancellation and timeout checks.

Verification:
- uv run pytest --basetemp C:\tmp\ddr-drive-rhodes-focused tests/test_drive_rhodes_reconciliation.py -q
- uv run pytest --basetemp C:\tmp\ddr-drive-rhodes-broad tests/test_drive_rhodes_reconciliation.py tests/test_rhodes.py tests/test_m1_lookup.py tests/test_workflow_contracts.py tests/test_vendor_doc_sweep.py -q
- uv run pytest --basetemp C:\tmp\ddr-drive-rhodes-affected tests/test_drive_rhodes_reconciliation.py tests/test_rhodes.py tests/test_m1_lookup.py tests/test_workflow_contracts.py tests/test_vendor_doc_sweep.py tests/test_inbox_scanner.py -q
- uv run ruff check src\due_diligence_reporter\drive_rhodes_reconciliation.py scripts\drive_rhodes_reconciliation.py tests\test_drive_rhodes_reconciliation.py tests\test_workflow_contracts.py
- uv run mypy src\due_diligence_reporter\drive_rhodes_reconciliation.py
- uv run mypy src/
- uv run python -m py_compile scripts\drive_rhodes_reconciliation.py
- git diff --check
- git diff --cached --check