### PR TITLE
Record DD report outcomes in Rhodes

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,64 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-27 - DDR Report Outcome Rhodes Events
+
+Confirmed the previous Drive-to-Rhodes reconciliation PR was merged:
+
+- `due-diligence-reporter` PR #119 merged at `4244aea`.
+
+Continued the Phase 4 record-completion work with a narrow report-outcome
+slice.
+
+Branch: `codex/ddr-rhodes-report-summary-events`
+
+Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/120
+
+Implementation commit: `3f79154` (`Record DD report outcomes in Rhodes`)
+
+Changed:
+
+- Added a DDR report summary `AutomationEvent v1` builder for
+  `dd_report_created` and `dd_report_updated`.
+- `process_site_pipeline` now writes a Rhodes site note after a report reaches
+  `report_created`.
+- The Rhodes note records the DD report ID/URL, run ID, trigger source for
+  updates, still-open verification items, and newly closed verification items.
+- The note mentions the P1 DRI when a Rhodes user can be resolved from owner
+  context. If open items require a decision and no owner mention is possible,
+  the same event body is posted to the configured Google Chat webhook.
+- The result is stored on `PipelineResult.rhodes_report_event` and in the run
+  manifest as `rhodes_report_event`.
+- Updated `docs/process/HOW-IT-WORKS.md`.
+
+Verification:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-rhodes-report-events-focused tests/test_automation_event.py tests/test_report_pipeline.py -q
+uv run ruff check src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\pipeline_contracts.py src\due_diligence_reporter\report_pipeline.py tests\test_automation_event.py tests\test_report_pipeline.py
+uv run mypy src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\pipeline_contracts.py src\due_diligence_reporter\report_pipeline.py
+uv run pytest --basetemp C:\tmp\ddr-rhodes-report-events-broad tests/test_automation_event.py tests/test_report_pipeline.py tests/test_dd_republish.py tests/test_rhodes.py -q
+uv run mypy src/
+git diff --check
+uv run pytest --basetemp C:\tmp\ddr-rhodes-report-events-affected tests/test_automation_event.py tests/test_report_pipeline.py tests/test_dd_republish.py tests/test_rhodes.py tests/test_inbox_scanner.py -q
+```
+
+Results:
+
+- Focused event/report pipeline suite: 43 passed.
+- Focused Ruff: passed.
+- Focused Mypy: no issues in 3 source files.
+- Broader event/report/republish/Rhodes suite: 92 passed.
+- Full source Mypy: no issues in 37 source files.
+- Diff check: passed; Git emitted expected Windows LF-to-CRLF warnings only.
+- Affected event/report/republish/Rhodes/inbox suite: 163 passed.
+
+Next:
+
+- Wait for CI/review on PR #120.
+- After merge, continue with the shared Rhodes adapter extraction design, or
+  the next concrete record-completion path that still posts only to
+  notification surfaces instead of Rhodes.
+
 ## 2026-05-27 - Drive-to-Rhodes Document Reconciliation
 
 Started the remaining Phase 2 Drive-to-Rhodes reconciliation slice on branch

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -208,7 +208,7 @@ DD Report republish dedupe state uses the same store pattern. Local development 
 
 RayCon follow-up runtime state is also behind a store boundary. Local development defaults to `.raycon_dispatch_state.json` and `.raycon_followup_alerts.json`; scheduled/production runs should set `RAYCON_RUNTIME_STATE_STORE=firestore` and `RAYCON_RUNTIME_STATE_FIRESTORE_PROJECT_ID=<project>` so RayCon dispatch dedupe and stuck-site alert suppression survive runner changes. Successful Firestore saves refresh the local JSON files so the existing GitHub Actions cache remains a current fallback.
 
-Material automation outcomes render through `src/due_diligence_reporter/automation_event.py`. The shared `AutomationEvent v1` note body includes source system, source ID, event kind, site ID, decision-required status, mutation status, retry state, and artifact IDs before adding DDR-specific details. This keeps Rhodes notes and Google Chat fallback alerts aligned with the cross-repo automation-event contract.
+Material automation outcomes render through `src/due_diligence_reporter/automation_event.py`. The shared `AutomationEvent v1` note body includes source system, source ID, event kind, site ID, decision-required status, mutation status, retry state, and artifact IDs before adding DDR-specific details. This keeps Rhodes notes and Google Chat fallback alerts aligned with the cross-repo automation-event contract. Report generation also writes a Rhodes `dd_report_created` or `dd_report_updated` note when a DD report is created. That note carries the report URL, run ID, still-open verification items, and newly closed verification items. If open items require a decision and no Rhodes owner mention is possible, the same event is posted to the configured Google Chat webhook.
 
 **Drive-to-Rhodes reconciliation:** `scripts/drive_rhodes_reconciliation.py` is the safety sweep for files that already exist in a site's `M1 - Acquire Property` folder. It loads Rhodes-linked sites, scans each M1 folder, classifies recognized DDR source files, and idempotently registers missing Rhodes document records by Drive file ID. The scheduled `Drive Rhodes Reconciliation` workflow runs this backfill on weekdays; manual runs can pass `--dry-run` / workflow `dry_run=true` to report what would be registered without writing to Rhodes. Generated or unmapped reports are surfaced as skipped rows instead of being forced into unsafe Rhodes document types.
 
@@ -431,7 +431,17 @@ Three skill tools analyze the source data and produce structured outputs. The fi
 
 ---
 
-### Step 8 â€” Send Email Notification
+### Step 8 -- Record Rhodes Report Event
+
+**Tool:** `addNote` through the Rhodes MCP client
+
+**Activity:** When the report reaches `report_created`, the pipeline records an `AutomationEvent v1` site note in Rhodes. The note includes the generated DD report ID/URL, run ID, trigger source for updates, open verification item count, closed verification item count, and up to five open/closed item summaries. It mentions the P1 DRI when a Rhodes user can be resolved from the owner context.
+
+**Fallback:** If open verification items require a decision and the P1 DRI cannot be mentioned in Rhodes, the pipeline posts the same event body to the configured Google Chat webhook. If Rhodes cannot be written at all, the run records a failed `rhodes.report_event` step so the manifest shows that the system of record was not updated.
+
+---
+
+### Step 9 â€” Send Email Notification
 
 **Tool:** `send_dd_report_email(site_name, report_url, key_findings, additional_recipients)`
 

--- a/src/due_diligence_reporter/automation_event.py
+++ b/src/due_diligence_reporter/automation_event.py
@@ -105,6 +105,60 @@ def build_document_registration_failed_event(
     return event
 
 
+def build_dd_report_summary_event(
+    *,
+    site_id: str,
+    site_name: str,
+    run_id: str,
+    doc_id: str | None,
+    doc_url: str | None,
+    source_event: dict[str, Any] | None = None,
+    open_questions: list[dict[str, Any]] | None = None,
+    closed_open_questions: list[dict[str, Any]] | None = None,
+    created_at: str | None = None,
+) -> AutomationEvent:
+    """Build the DDR generated/updated report summary event."""
+
+    open_items = open_questions or []
+    closed_items = closed_open_questions or []
+    source = source_event or {}
+    is_update = bool(source)
+    artifact_ids = {
+        "Run ID": run_id,
+    }
+    if doc_id:
+        artifact_ids["DD report ID"] = doc_id
+    source_drive_file_id = str(source.get("drive_file_id") or "").strip()
+    if source_drive_file_id:
+        artifact_ids["Source Drive file ID"] = source_drive_file_id
+
+    details = {
+        "DD report URL": str(doc_url or "").strip(),
+        "Trigger source": str(source.get("source_type") or "").strip(),
+        "Source file": str(source.get("file_name") or "").strip(),
+        "Open item count": str(len(open_items)),
+        "Closed item count": str(len(closed_items)),
+    }
+    details.update(_indexed_item_details("Open item", open_items))
+    details.update(_indexed_item_details("Closed item", closed_items))
+
+    return AutomationEvent(
+        source_system="due-diligence-reporter",
+        source_id=run_id,
+        site_id=site_id.strip(),
+        site_name=site_name.strip() or "Unknown site",
+        event_type="dd_report_updated" if is_update else "dd_report_created",
+        artifact_ids=artifact_ids,
+        decision_required=bool(open_items),
+        requested_decision=(
+            "review and resolve DDR open verification items" if open_items else None
+        ),
+        mutation_status="report_created",
+        details=details,
+        created_at=created_at or datetime.now(UTC).isoformat(),
+    )
+
+
 def _format_owner(site_summary: dict[str, Any]) -> str:
     name = str(site_summary.get("p1_assignee_name") or "").strip()
     email = str(site_summary.get("p1_assignee_email") or "").strip()
@@ -120,3 +174,17 @@ def _format_retry_state(retry_state: dict[str, Any]) -> str:
     if exhausted is None:
         return f"attempts={attempts}/{limit}"
     return f"attempts={attempts}/{limit}; exhausted={str(bool(exhausted)).lower()}"
+
+
+def _indexed_item_details(
+    label: str,
+    items: list[dict[str, Any]],
+    *,
+    limit: int = 5,
+) -> dict[str, str]:
+    details: dict[str, str] = {}
+    for index, item in enumerate(items[:limit], start=1):
+        text = str(item.get("display_text") or item.get("text") or "").strip()
+        if text:
+            details[f"{label} {index}"] = text
+    return details

--- a/src/due_diligence_reporter/pipeline_contracts.py
+++ b/src/due_diligence_reporter/pipeline_contracts.py
@@ -142,6 +142,7 @@ class PipelineRun:
     open_questions: list[dict[str, Any]] = field(default_factory=list)
     closed_open_questions: list[dict[str, Any]] = field(default_factory=list)
     republish_summary: dict[str, Any] | None = None
+    rhodes_report_event: dict[str, Any] | None = None
     manifest_path: str | None = None
     manifest_url: str | None = None
 
@@ -160,6 +161,7 @@ class PipelineRun:
             "open_questions": self.open_questions,
             "closed_open_questions": self.closed_open_questions,
             "republish_summary": self.republish_summary,
+            "rhodes_report_event": self.rhodes_report_event,
             "manifest_path": self.manifest_path,
             "manifest_url": self.manifest_url,
             "failed_step": failed_step_name(self.steps),

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 import anthropic
 
+from .automation_event import build_dd_report_summary_event, render_automation_event_note
 from .classifier import (
     AI_GENERATED_DOC_TYPES,
     SOURCE_FOLDER_DOC_TYPES,
@@ -44,7 +45,7 @@ from .pipeline_contracts import (
 from .pipeline_manifest import manifest_has_secret_like_value, persist_run_manifest
 from .pipeline_quality import evaluate_run_quality
 from .provenance import classify_provenance
-from .rhodes import lookup_rhodes_site_owner
+from .rhodes import add_rhodes_site_note, lookup_rhodes_site_owner
 from .sir_learning import build_sir_learning_review
 from .utils import (
     escape_html_text,
@@ -786,6 +787,7 @@ class PipelineResult:
     open_questions: list[dict[str, Any]] = field(default_factory=list)
     closed_open_questions: list[dict[str, Any]] = field(default_factory=list)
     republish_summary: dict[str, Any] | None = None
+    rhodes_report_event: dict[str, Any] | None = None
     steps: list[StepResult] = field(default_factory=list)
 
 
@@ -958,6 +960,7 @@ def _attach_result_metadata(run: PipelineRun, result: PipelineResult) -> None:
     run.open_questions = result.open_questions
     run.closed_open_questions = result.closed_open_questions
     run.republish_summary = result.republish_summary
+    run.rhodes_report_event = result.rhodes_report_event
 
 
 def _get_payload_error(result: dict[str, Any]) -> str | None:
@@ -1560,6 +1563,43 @@ def _first_text(*values: Any) -> str | None:
     return None
 
 
+def _owner_user_id_from_context(context: dict[str, Any] | None) -> str:
+    if not isinstance(context, dict):
+        return ""
+    for key in ("p1_assignee_user_id", "owner_user_id", "p1_user_id"):
+        value = context.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    owner = context.get("p1_dri")
+    if isinstance(owner, dict):
+        for key in ("userId", "user_id", "_id", "id"):
+            value = owner.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _post_google_chat_to_configured_webhooks(webhook_urls: str, text: str) -> dict[str, Any]:
+    urls = [url.strip() for url in webhook_urls.split(",") if url.strip()]
+    if not urls:
+        return {"status": "skipped", "reason": "missing_google_chat_webhook_url"}
+    posted = 0
+    error_count = 0
+    for url in urls:
+        try:
+            post_google_chat_message(url, text)
+            posted += 1
+        except Exception:  # noqa: BLE001 - non-fatal notification side effect
+            error_count += 1
+    if error_count:
+        return {
+            "status": "failed" if posted == 0 else "partial",
+            "posted": posted,
+            "error_count": error_count,
+        }
+    return {"status": "sent", "posted": posted}
+
+
 def _report_data_from_trace(trace: ReportTrace | None) -> dict[str, Any]:
     if trace is None:
         return {}
@@ -1716,6 +1756,114 @@ def _record_email_step(
         )
     else:
         recorder.record("notify.email", started_at, started_monotonic, "succeeded")
+
+
+def _record_rhodes_report_event_step(
+    recorder: _RunRecorder,
+    settings: Settings,
+    result: PipelineResult,
+    *,
+    site_id: str,
+    owner_user_id: str,
+    owner_email: str,
+) -> None:
+    started_at, started_monotonic = recorder.start()
+    event = build_dd_report_summary_event(
+        site_id=site_id,
+        site_name=result.site_title,
+        run_id=recorder.run_id,
+        doc_id=result.doc_id,
+        doc_url=result.doc_url,
+        source_event=result.source_event,
+        open_questions=result.open_questions,
+        closed_open_questions=result.closed_open_questions,
+    )
+    body = render_automation_event_note(event)
+    note_result: dict[str, Any]
+    if not event.site_id:
+        note_result = {
+            "status": "skipped",
+            "reason": "missing_site_id",
+            "owner_notification": "none",
+        }
+    else:
+        note_result = add_rhodes_site_note(
+            site_id=event.site_id,
+            body=body,
+            owner_user_id=owner_user_id,
+            owner_email=owner_email,
+        )
+
+    event_status: dict[str, Any] = {
+        "event_type": event.event_type,
+        "source_id": event.source_id,
+        "decision_required": event.decision_required,
+        **note_result,
+    }
+    should_alert_chat = event.decision_required and (
+        note_result.get("status") != "created"
+        or note_result.get("owner_notification") != "mentioned"
+    )
+    chat_result: dict[str, Any] | None = None
+    if should_alert_chat:
+        chat_result = _post_google_chat_to_configured_webhooks(
+            settings.google_chat_webhook_url,
+            body,
+        )
+        event_status["google_chat"] = chat_result
+
+    result.rhodes_report_event = event_status
+    artifact = ArtifactRef(
+        kind="rhodes_note",
+        name="DDR report AutomationEvent",
+        metadata=event_status,
+    )
+    note_status = str(note_result.get("status") or "")
+    chat_status = str((chat_result or {}).get("status") or "")
+    if note_status == "created" and chat_status not in {"failed", "skipped"}:
+        recorder.record(
+            "rhodes.report_event",
+            started_at,
+            started_monotonic,
+            "succeeded",
+            artifacts=[artifact],
+        )
+        return
+    if note_status == "created" and not should_alert_chat:
+        recorder.record(
+            "rhodes.report_event",
+            started_at,
+            started_monotonic,
+            "succeeded",
+            artifacts=[artifact],
+        )
+        return
+    if note_status == "skipped" and not event.decision_required:
+        recorder.record(
+            "rhodes.report_event",
+            started_at,
+            started_monotonic,
+            "skipped",
+            skipped_reason=str(note_result.get("reason") or "skipped"),
+        )
+        return
+
+    message = str(note_result.get("error") or note_result.get("reason") or "unknown")
+    if should_alert_chat and chat_status in {"failed", "skipped"}:
+        message = f"{message}; Google Chat fallback {chat_status}"
+    recorder.record(
+        "rhodes.report_event",
+        started_at,
+        started_monotonic,
+        "failed",
+        error=_pipeline_error(
+            recorder.run_id,
+            "rhodes.report_event",
+            "rhodes_report_event_failed",
+            message,
+        ),
+        artifacts=[artifact],
+    )
 
 
 def process_site_pipeline(
@@ -2133,6 +2281,14 @@ def process_site_pipeline(
         source_event=source_event,
         open_questions_before=open_questions_before,
         validated=True,
+    )
+    _record_rhodes_report_event_step(
+        recorder,
+        settings,
+        final_result,
+        site_id=recorder.site_id or site_id or "",
+        owner_user_id=_owner_user_id_from_context(rhodes_owner_context),
+        owner_email=p1_email or "",
     )
     _record_email_step(
         recorder,

--- a/tests/test_automation_event.py
+++ b/tests/test_automation_event.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from due_diligence_reporter.automation_event import (
+    build_dd_report_summary_event,
     build_document_registration_failed_event,
     render_automation_event_note,
 )
@@ -85,3 +86,50 @@ def test_document_registration_event_handles_missing_owner() -> None:
     note = render_automation_event_note(event)
 
     assert "Owner: No owner assigned" in note
+
+
+def test_dd_report_summary_event_renders_open_and_closed_items() -> None:
+    event = build_dd_report_summary_event(
+        site_id="SITE1",
+        site_name="Alpha Keller",
+        run_id="run-1",
+        doc_id="doc-1",
+        doc_url="https://docs.google.com/document/d/doc-1",
+        source_event={
+            "source_type": "vendor_sir",
+            "drive_file_id": "drive-file-1",
+            "file_name": "Alpha Keller SIR.pdf",
+        },
+        open_questions=[
+            {
+                "display_text": "Confirm zoning use from the vendor SIR",
+                "expected_source_type": "vendor_sir",
+            }
+        ],
+        closed_open_questions=[
+            {
+                "display_text": "Resolve construction timeline from RayCon",
+                "expected_source_type": "raycon_scenario",
+            }
+        ],
+        created_at="2026-05-27T18:15:00+00:00",
+    )
+
+    assert event.event_type == "dd_report_updated"
+    assert event.source_id == "run-1"
+    assert event.decision_required is True
+    assert event.requested_decision == "review and resolve DDR open verification items"
+
+    note = render_automation_event_note(event)
+
+    assert "Kind: dd_report_updated" in note
+    assert "Mutation status: report_created" in note
+    assert "Run ID: run-1" in note
+    assert "DD report ID: doc-1" in note
+    assert "Source Drive file ID: drive-file-1" in note
+    assert "DD report URL: https://docs.google.com/document/d/doc-1" in note
+    assert "Trigger source: vendor_sir" in note
+    assert "Open item count: 1" in note
+    assert "Open item 1: Confirm zoning use from the vendor SIR" in note
+    assert "Closed item count: 1" in note
+    assert "Closed item 1: Resolve construction timeline from RayCon" in note

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -440,6 +440,140 @@ class TestProcessSitePipeline:
         assert result.doc_url == "https://docs.google.com/document/d/doc123"
         mock_agent.assert_called_once()
 
+    @patch("due_diligence_reporter.report_pipeline.add_rhodes_site_note")
+    @patch("due_diligence_reporter.server.check_report_completeness")
+    @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
+    @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
+    def test_report_created_records_rhodes_summary_event(
+        self,
+        mock_readiness,
+        mock_agent,
+        mock_completeness,
+        mock_rhodes_note,
+    ):
+        mock_readiness.return_value = {
+            "sir_found": True,
+            "isp_found": False,
+            "inspection_found": True,
+            "report_exists": False,
+        }
+        trace = ReportTrace(
+            site_name="Alpha Keller",
+            started_at="2026-05-27T18:00:00+00:00",
+            events=[],
+            final_report_data={
+                "verification.open_items": "- Confirm zoning use from the vendor SIR",
+            },
+        )
+        mock_agent.return_value = {
+            "success": True,
+            "doc_id": "doc123",
+            "doc_url": "https://docs.google.com/document/d/doc123",
+            "trace": trace,
+        }
+        mock_rhodes_note.return_value = {
+            "status": "created",
+            "reason": "ok",
+            "rhodes_note_id": "NOTE1",
+            "owner_notification": "mentioned",
+        }
+
+        async def fake_completeness(doc_id):
+            return {"ready_to_send": True, "pending_section_count": 0}
+
+        mock_completeness.side_effect = fake_completeness
+
+        result = process_site_pipeline(
+            MagicMock(),
+            "Alpha Keller",
+            "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Keller"],
+            {},
+            "system prompt",
+            _make_settings(),
+            p1_email="owner@example.com",
+            site_id="SITE1",
+        )
+
+        assert result.status == "report_created"
+        assert result.rhodes_report_event is not None
+        assert result.rhodes_report_event["status"] == "created"
+        assert result.rhodes_report_event["rhodes_note_id"] == "NOTE1"
+        note_kwargs = mock_rhodes_note.call_args.kwargs
+        assert note_kwargs["site_id"] == "SITE1"
+        assert note_kwargs["owner_email"] == "owner@example.com"
+        assert "Kind: dd_report_created" in note_kwargs["body"]
+        assert "Decision required: yes" in note_kwargs["body"]
+        assert "Open item 1: Confirm zoning use from the vendor SIR" in note_kwargs["body"]
+        step = next(step for step in result.steps if step.step == "rhodes.report_event")
+        assert step.status == "succeeded"
+
+    @patch("due_diligence_reporter.report_pipeline.post_google_chat_message")
+    @patch("due_diligence_reporter.report_pipeline.add_rhodes_site_note")
+    @patch("due_diligence_reporter.server.check_report_completeness")
+    @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
+    @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
+    def test_report_created_with_open_items_alerts_chat_when_owner_not_mentioned(
+        self,
+        mock_readiness,
+        mock_agent,
+        mock_completeness,
+        mock_rhodes_note,
+        mock_chat,
+    ):
+        mock_readiness.return_value = {
+            "sir_found": True,
+            "isp_found": False,
+            "inspection_found": True,
+            "report_exists": False,
+        }
+        trace = ReportTrace(
+            site_name="Alpha Keller",
+            started_at="2026-05-27T18:00:00+00:00",
+            events=[],
+            final_report_data={
+                "verification.open_items": "- Confirm education approval path",
+            },
+        )
+        mock_agent.return_value = {
+            "success": True,
+            "doc_id": "doc123",
+            "doc_url": "https://docs.google.com/document/d/doc123",
+            "trace": trace,
+        }
+        mock_rhodes_note.return_value = {
+            "status": "created",
+            "reason": "ok",
+            "rhodes_note_id": "NOTE1",
+            "owner_notification": "none",
+        }
+
+        async def fake_completeness(doc_id):
+            return {"ready_to_send": True, "pending_section_count": 0}
+
+        mock_completeness.side_effect = fake_completeness
+        settings = _make_settings()
+        settings.google_chat_webhook_url = "https://chat.example/webhook"
+
+        result = process_site_pipeline(
+            MagicMock(),
+            "Alpha Keller",
+            "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Keller"],
+            {},
+            "system prompt",
+            settings,
+            site_id="SITE1",
+        )
+
+        assert result.rhodes_report_event is not None
+        assert result.rhodes_report_event["google_chat"]["status"] == "sent"
+        mock_chat.assert_called_once()
+        assert mock_chat.call_args.args[0] == "https://chat.example/webhook"
+        assert "Requested decision: review and resolve DDR open verification items" in (
+            mock_chat.call_args.args[1]
+        )
+
     @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
     @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
     def test_agent_failure(self, mock_readiness, mock_agent):


### PR DESCRIPTION
Summary:
- Add DDR report summary AutomationEvent builder for dd_report_created and dd_report_updated.
- Record generated report URL, run ID, still-open verification items, and closed verification items as a Rhodes site note after report creation.
- Mention the P1 DRI when possible and post decision-required open-item events to Google Chat when no owner mention is available.
- Persist the Rhodes report-event result into PipelineResult and run manifests.
- Document the report-event step in the DDR process guide.

Verification:
- uv run pytest --basetemp C:\tmp\ddr-rhodes-report-events-focused tests/test_automation_event.py tests/test_report_pipeline.py -q
- uv run ruff check src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\pipeline_contracts.py src\due_diligence_reporter\report_pipeline.py tests\test_automation_event.py tests\test_report_pipeline.py
- uv run mypy src\due_diligence_reporter\automation_event.py src\due_diligence_reporter\pipeline_contracts.py src\due_diligence_reporter\report_pipeline.py
- uv run pytest --basetemp C:\tmp\ddr-rhodes-report-events-broad tests/test_automation_event.py tests/test_report_pipeline.py tests/test_dd_republish.py tests/test_rhodes.py -q
- uv run mypy src/
- git diff --check
- uv run pytest --basetemp C:\tmp\ddr-rhodes-report-events-affected tests/test_automation_event.py tests/test_report_pipeline.py tests/test_dd_republish.py tests/test_rhodes.py tests/test_inbox_scanner.py -q