### PR TITLE
[codex] Suppress cancelled-site inbox missing-folder reviews

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,49 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-27 - Inbox Missing-Folder Cleanup: Linked Active Rhodes Folders, Suppressed Cancelled Torrance
+
+Context:
+
+- Inbox manual review showed `missing_drive_folder` for Port Chester, Torrance,
+  Malibu, Los Angeles Beethoven, Tulsa 421 E 11th, and Santa Clara.
+- Live LocationOS records resolved for all six sites, but the active five had no
+  linked Rhodes Google Drive folder. Torrance is cancelled and its Drive folder
+  is under `G:\Shared drives\Education Ops\All Locations\0.Archive`.
+
+Actions completed:
+
+- Renamed the synced shared-drive folder
+  `Alpha Los Angeles 5400 Beethoven St` to
+  `Alpha Los Angeles 5401 Beethoven St`.
+- Linked existing Drive folder roots in LocationOS/Rhodes:
+  - Port Chester: `1KhzTP0O2-oA0ZS5JIko0LRmB3RKarch2`
+  - Malibu: `1YFji_KxEGOY38jXhxxRNNeLKn0OzqNUs`
+  - Tulsa 421 E 11th: `1aECCszKKUydifS6nx23fEV5LZWEn3seh`
+  - Santa Clara: `1RRF-_nxBMMvdcSXZsBj-qUAx_xYGKao1`
+  - Los Angeles 5401 Beethoven: `1G8fc0sX3dP83A7uMF5Bhz2pXnhRpaRJz`
+- Confirmed LocationOS `driveResolveSiteFolderPath(..., "M1 - Acquire Property")`
+  now resolves for all five active sites.
+- Updated `src/due_diligence_reporter/inbox_scanner.py` so a matched cancelled
+  Rhodes site with no Drive folder URL is skipped instead of emitted as
+  `missing_drive_folder` manual review. Active matched sites without a Drive
+  folder still emit manual review.
+- Added regression coverage in `tests/test_inbox_scanner.py` for the cancelled
+  no-folder suppression path.
+
+Verification:
+
+- `uv run pytest tests/test_inbox_scanner.py -q` -> `72 passed`
+- `uv run ruff check src/due_diligence_reporter/inbox_scanner.py tests/test_inbox_scanner.py`
+  -> `All checks passed`
+
+Notes:
+
+- Google Drive search now shows the renamed
+  `Alpha Los Angeles 5401 Beethoven St` folder for the original folder ID that
+  contained the DD report, not the empty duplicate skeleton.
+- Torrance was not linked because the Rhodes site is cancelled and its folder is
+  archived.
+
 ## 2026-05-27 - DDR RayCon Follow-up Rhodes Events
 
 Confirmed the previous vendor-gate PR was merged:
@@ -509,7 +553,6 @@ Results:
 - Full source Mypy: no issues in 32 source files.
 - Broader inbox/Rhodes/workflow suite: 107 passed.
 - Diff check: no whitespace errors; only expected Windows LF-to-CRLF warnings.
-
 ## 2026-05-27 - Lexington DDR Follow-up: Stale Automation and Stronger Summary Splitter
 
 Follow-up after `Alpha Lexington 92 Hayden Ave DD Report - 05_27_2026.docx`

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -369,6 +369,8 @@ def _build_site_summary(record: dict[str, Any]) -> dict[str, Any]:
         "id": str(record.get("id") or record.get("site_id") or "").strip(),
         "title": str(record.get("title") or record.get("name") or "").strip(),
         "address": _record_address(record),
+        "status": str(record.get("status") or "").strip(),
+        "rhodes_status": str(record.get("rhodes_status") or "").strip(),
         "drive_folder_url": _record_value(
             record,
             ("drive_folder_url", "google_folder", "folder_url"),
@@ -401,6 +403,13 @@ def _build_site_summary(record: dict[str, Any]) -> dict[str, Any]:
             {"total building sf", "building square feet", "total building square feet"},
         ),
     }
+
+
+def _is_cancelled_site(site_summary: dict[str, Any]) -> bool:
+    status = str(
+        site_summary.get("rhodes_status") or site_summary.get("status") or ""
+    ).strip()
+    return status.casefold() == "cancelled"
 
 
 @dataclass
@@ -1192,6 +1201,14 @@ def process_email(
         # configured only so the migration script can read from them.
         drive_folder_url = str(site_summary.get("drive_folder_url", "")).strip()
         if not drive_folder_url:
+            if _is_cancelled_site(site_summary):
+                logger.info(
+                    "Skipping '%s' for cancelled Rhodes site '%s' with no Drive folder URL",
+                    filename,
+                    site_title or "unknown",
+                )
+                skipped += 1
+                continue
             error_message = "Matched site has no Google Drive folder URL"
             errors.append(
                 {

--- a/tests/test_inbox_scanner.py
+++ b/tests/test_inbox_scanner.py
@@ -600,6 +600,60 @@ class TestClassification:
         mock_resolve_m1.assert_not_called()
         gc.upload_file_to_folder.assert_not_called()
 
+    @patch("due_diligence_reporter.inbox_scanner._build_site_summary")
+    @patch("due_diligence_reporter.inbox_scanner._resolve_m1_folder")
+    @patch("due_diligence_reporter.inbox_scanner.classify_document")
+    @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
+    def test_cancelled_site_with_no_drive_folder_is_suppressed(
+        self, mock_extract, mock_classify, mock_resolve_m1, mock_build_summary
+    ):
+        mock_extract.return_value = MagicMock(
+            message_id="msg_cancelled_no_drive",
+            subject="RE: New Site Kickoff: 22600 Crenshaw Blvd, Torrance, CA",
+            sender="test@example.com",
+            effective_sender="test@example.com",
+            body_snippet="May 6 Alpha Torrance Building Inspection",
+            attachments=[
+                {
+                    "filename": "May 6 Alpha Torrance Building Inspection.pdf",
+                    "attachment_id": "nd1",
+                    "mime_type": "application/pdf",
+                }
+            ],
+        )
+        mock_classify.return_value = ("building_inspection", 0.95)
+        mock_build_summary.return_value = {
+            "title": "Alpha Torrance 22600 Crenshaw Blvd",
+            "drive_folder_url": "",
+            "rhodes_status": "cancelled",
+        }
+
+        gc = MagicMock()
+        site_records = [
+            {
+                "id": "IETORRANCE",
+                "title": "Alpha Torrance 22600 Crenshaw Blvd",
+                "rhodes_status": "cancelled",
+                "customFields": [],
+            }
+        ]
+        result = process_email(
+            gc,
+            "msg_cancelled_no_drive",
+            MagicMock(),
+            "label_123",
+            "review_123",
+            site_records=site_records,
+        )
+
+        assert result["uploaded"] == []
+        assert result["skipped"] == 1
+        assert result["errors"] == []
+        assert result["manual_review"] == []
+        assert result["marked"] is True
+        mock_resolve_m1.assert_not_called()
+        gc.upload_file_to_folder.assert_not_called()
+
     @patch("due_diligence_reporter.inbox_scanner.classify_document")
     @patch("due_diligence_reporter.inbox_scanner._extract_email_metadata")
     def test_unmatched_block_plan_goes_to_manual_review(self, mock_extract, mock_classify):


### PR DESCRIPTION
## Summary

- carry Rhodes site status through inbox site summaries
- skip matched cancelled Rhodes sites when they have no Drive folder URL, instead of sending them to missing-drive-folder manual review
- keep active matched sites with missing Drive folders on the existing manual-review path
- document the live folder-link cleanup and add regression coverage for cancelled Torrance-style inbox attachments

## Validation

- uv run pytest tests/test_inbox_scanner.py -q
- uv run ruff check src/due_diligence_reporter/inbox_scanner.py tests/test_inbox_scanner.py
