### PR TITLE
[codex] Share DDR Rhodes event helper

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,65 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - DDR Shared Rhodes Event Helper
+
+Confirmed the previous downstream helper PR was merged:
+
+- `alpha-analysis-downstream-processing` PR #51 merged at `aae32a1`.
+
+Continued Phase 3 adapter-efficiency work with a narrow DDR helper extraction.
+
+Branch: `codex/ddr-shared-rhodes-events`
+
+Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/125
+
+Implementation commit: `7ed5b40` (`Share DDR Rhodes event helper`)
+
+Current state: branch pushed, draft PR open, GitHub reports merge state
+`CLEAN`. No checks were reported when checked.
+
+Changed:
+
+- Added `src/due_diligence_reporter/rhodes_events.py` as the shared DDR
+  boundary for `AutomationEvent` Rhodes note creation, owner-notification Chat
+  fallback decisions, and configured Google Chat posting.
+- Reused the helper from inbox document-registration failure events, report
+  pipeline source-review/vendor-gate/report-summary events, and RayCon
+  follow-up events.
+- Preserved existing event status shapes and test patch points while removing
+  duplicated note/fallback logic from the call sites.
+- Added direct helper regression coverage for owner context, missing site IDs,
+  Chat fallback decisioning, and partial Chat send failures.
+
+Verification:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-shared-rhodes-events-focused tests/test_rhodes_events.py tests/test_automation_event.py tests/test_report_pipeline.py tests/test_inbox_scanner.py::TestRhodesDocumentRegistration tests/test_raycon_followup.py -q
+uv run ruff check src\due_diligence_reporter\rhodes_events.py src\due_diligence_reporter\report_pipeline.py src\due_diligence_reporter\inbox_scanner.py scripts\raycon_followup.py tests\test_rhodes_events.py tests\test_report_pipeline.py tests\test_inbox_scanner.py tests\test_raycon_followup.py
+uv run mypy src\due_diligence_reporter\rhodes_events.py src\due_diligence_reporter\report_pipeline.py src\due_diligence_reporter\inbox_scanner.py
+uv run python -m py_compile scripts\raycon_followup.py
+uv run pytest --basetemp C:\tmp\ddr-shared-rhodes-events-broad tests/test_rhodes_events.py tests/test_automation_event.py tests/test_report_pipeline.py tests/test_inbox_scanner.py tests/test_scan_inbox_e2e.py tests/test_raycon_followup.py tests/test_raycon_runtime_state_store.py tests/test_dd_republish.py tests/test_rhodes.py -q
+uv run mypy src/
+git diff --check
+git diff --cached --check
+```
+
+Results:
+
+- Focused helper/event/report/inbox/RayCon suite: 113 passed.
+- Ruff on touched code/tests: passed.
+- Focused Mypy: no issues in 3 source files.
+- Script compile: passed.
+- Broader affected DDR suite: 246 passed.
+- Full source Mypy: no issues in 38 source files.
+- Diff checks: passed with expected Windows LF-to-CRLF warnings and the
+  existing user-level ignore permission warning only.
+
+Next:
+
+- Wait for CI/review on PR #125.
+- After merge, continue with the next remaining adapter consolidation or
+  notification-only path that still lacks a Rhodes-owned record.
+
 ## 2026-05-27 - Inbox Missing-Folder Cleanup: Linked Active Rhodes Folders, Suppressed Cancelled Torrance
 
 Context:

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -64,7 +64,6 @@ import requests  # noqa: E402
 
 from due_diligence_reporter.automation_event import (  # noqa: E402
     build_raycon_followup_alert_event,
-    render_automation_event_note,
 )
 from due_diligence_reporter.config import get_settings  # noqa: E402
 from due_diligence_reporter.dd_republish import (  # noqa: E402
@@ -100,6 +99,10 @@ from due_diligence_reporter.rhodes import (  # noqa: E402
     RhodesError,
     add_rhodes_site_note,
     list_rhodes_site_records,
+)
+from due_diligence_reporter.rhodes_events import (  # noqa: E402
+    record_rhodes_automation_event,
+    should_alert_google_chat,
 )
 from due_diligence_reporter.server import save_skill_report  # noqa: E402
 from due_diligence_reporter.utils import (  # noqa: E402
@@ -540,29 +543,11 @@ def _record_raycon_followup_event(
         block_plan_file_id=str(row.get("block_plan_file_id") or "").strip(),
         raycon_run_id=str(row.get("raycon_run_id") or "").strip(),
     )
-    body = render_automation_event_note(event)
-    if event.site_id:
-        note_result = add_rhodes_site_note(
-            site_id=event.site_id,
-            body=body,
-            owner_user_id=str(row.get("p1_assignee_user_id") or "").strip(),
-            owner_email=str(row.get("p1_assignee_email") or "").strip(),
-        )
-    else:
-        note_result = {
-            "status": "skipped",
-            "reason": "missing_site_id",
-            "owner_notification": "none",
-        }
-
-    return (
-        {
-            "event_type": event.event_type,
-            "source_id": event.source_id,
-            "decision_required": event.decision_required,
-            **note_result,
-        },
-        body,
+    return record_rhodes_automation_event(
+        event,
+        owner_user_id=str(row.get("p1_assignee_user_id") or "").strip(),
+        owner_email=str(row.get("p1_assignee_email") or "").strip(),
+        add_note=add_rhodes_site_note,
     )
 
 
@@ -588,10 +573,7 @@ def _notify_raycon_followup_rows(
             message=message,
         )
         row["raycon_followup_event"] = event_status
-        if (
-            event_status.get("status") != "created"
-            or event_status.get("owner_notification") != "mentioned"
-        ):
+        if should_alert_google_chat(event_status):
             chat_bodies.append(body)
             chat_rows.append(row)
 

--- a/src/due_diligence_reporter/inbox_scanner.py
+++ b/src/due_diligence_reporter/inbox_scanner.py
@@ -28,11 +28,17 @@ from .m1_lookup import (
     _resolve_m1_folder,
 )
 from .rhodes import add_rhodes_site_note, register_rhodes_document_for_upload
+from .rhodes_events import (
+    post_google_chat_to_configured_webhooks as _post_google_chat_to_configured_webhooks,
+)
+from .rhodes_events import (
+    record_rhodes_automation_event,
+    should_alert_google_chat,
+)
 from .rhodes_retry_state_store import JsonRhodesRetryStateStore, RhodesRetryState
 from .utils import (
     escape_html_text,
     extract_text_from_pdf_bytes,
-    post_google_chat_message,
     score_site_match_strength,
     send_email,
 )
@@ -194,27 +200,6 @@ def _metadata_thread_id(metadata: Any, fallback_message_id: str) -> str:
     return fallback_message_id
 
 
-def _post_google_chat_to_configured_webhooks(webhook_urls: str, text: str) -> dict[str, Any]:
-    urls = [url.strip() for url in webhook_urls.split(",") if url.strip()]
-    if not urls:
-        return {"status": "skipped", "reason": "missing_google_chat_webhook_url"}
-    posted = 0
-    errors: list[str] = []
-    for url in urls:
-        try:
-            post_google_chat_message(url, text)
-            posted += 1
-        except Exception as exc:  # noqa: BLE001 - non-fatal notification side effect
-            errors.append(str(exc))
-    if errors:
-        return {
-            "status": "failed" if posted == 0 else "partial",
-            "posted": posted,
-            "errors": errors,
-        }
-    return {"status": "sent", "posted": posted}
-
-
 def _record_rhodes_registration_failure_event(
     *,
     settings: Settings,
@@ -271,23 +256,22 @@ def _record_rhodes_registration_failure_event(
 
     owner_user_id = str(site_summary.get("p1_assignee_user_id") or "").strip()
     owner_email = str(site_summary.get("p1_assignee_email") or "").strip()
-    note_result = add_rhodes_site_note(
-        site_id=str(site_summary.get("id") or "").strip(),
+    event_status, _ = record_rhodes_automation_event(
+        event,
         body=body,
         owner_user_id=owner_user_id,
         owner_email=owner_email,
+        add_note=add_rhodes_site_note,
     )
     if entry is not None:
-        entry["rhodes_failure_event_status"] = note_result.get("status")
-        entry["rhodes_failure_event_reason"] = note_result.get("reason")
-        if note_result.get("status") == "created":
-            entry["rhodes_failure_note_id"] = str(note_result.get("rhodes_note_id") or "")
+        entry["rhodes_failure_event_status"] = event_status.get("status")
+        entry["rhodes_failure_event_reason"] = event_status.get("reason")
+        if event_status.get("status") == "created":
+            entry["rhodes_failure_note_id"] = str(event_status.get("rhodes_note_id") or "")
             entry["rhodes_failure_notified_at"] = datetime.now(UTC).isoformat()
-            entry["rhodes_failure_owner_notification"] = note_result.get("owner_notification")
+            entry["rhodes_failure_owner_notification"] = event_status.get("owner_notification")
 
-    should_alert_chat = note_result.get("status") != "created" or (
-        note_result.get("owner_notification") != "mentioned"
-    )
+    should_alert_chat = should_alert_google_chat(event_status)
     chat_result: dict[str, Any] | None = None
     if should_alert_chat and not (entry and entry.get("rhodes_failure_chat_notified_at")):
         chat_result = _post_google_chat_to_configured_webhooks(
@@ -299,7 +283,7 @@ def _record_rhodes_registration_failure_event(
             if chat_result.get("status") in {"sent", "partial"}:
                 entry["rhodes_failure_chat_notified_at"] = datetime.now(UTC).isoformat()
 
-    result = dict(note_result)
+    result = dict(event_status)
     if chat_result is not None:
         result["google_chat"] = chat_result
     return result

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -20,7 +20,6 @@ from .automation_event import (
     build_dd_report_summary_event,
     build_source_review_required_event,
     build_vendor_gate_review_required_event,
-    render_automation_event_note,
 )
 from .classifier import (
     AI_GENERATED_DOC_TYPES,
@@ -51,6 +50,11 @@ from .pipeline_manifest import manifest_has_secret_like_value, persist_run_manif
 from .pipeline_quality import evaluate_run_quality
 from .provenance import classify_provenance
 from .rhodes import add_rhodes_site_note, lookup_rhodes_site_owner
+from .rhodes_events import (
+    post_google_chat_to_configured_webhooks,
+    record_rhodes_automation_event,
+    should_alert_google_chat,
+)
 from .sir_learning import build_sir_learning_review
 from .utils import (
     escape_html_text,
@@ -1314,31 +1318,13 @@ def _record_vendor_gate_alert_step(
         drive_folder_url=drive_folder_url,
         trace_url=trace_url,
     )
-    body = render_automation_event_note(event)
-    if event.site_id:
-        note_result = add_rhodes_site_note(
-            site_id=event.site_id,
-            body=body,
-            owner_user_id=owner_user_id,
-            owner_email=owner_email,
-        )
-    else:
-        note_result = {
-            "status": "skipped",
-            "reason": "missing_site_id",
-            "owner_notification": "none",
-        }
-
-    event_status: dict[str, Any] = {
-        "event_type": event.event_type,
-        "source_id": event.source_id,
-        "decision_required": event.decision_required,
-        **note_result,
-    }
-    should_alert_chat = (
-        note_result.get("status") != "created"
-        or note_result.get("owner_notification") != "mentioned"
+    event_status, body = record_rhodes_automation_event(
+        event,
+        owner_user_id=owner_user_id,
+        owner_email=owner_email,
+        add_note=add_rhodes_site_note,
     )
+    should_alert_chat = should_alert_google_chat(event_status)
     chat_result: dict[str, Any] | None = None
     if should_alert_chat:
         chat_result = _post_google_chat_to_configured_webhooks(
@@ -1352,7 +1338,7 @@ def _record_vendor_gate_alert_step(
         name="DDR vendor gate AutomationEvent",
         metadata=event_status,
     )
-    note_status = str(note_result.get("status") or "")
+    note_status = str(event_status.get("status") or "")
     chat_status = str((chat_result or {}).get("status") or "")
     if note_status == "created" and chat_status not in {"failed", "skipped"}:
         recorder.record(
@@ -1373,7 +1359,7 @@ def _record_vendor_gate_alert_step(
         )
         return
 
-    message = str(note_result.get("error") or note_result.get("reason") or "unknown")
+    message = str(event_status.get("error") or event_status.get("reason") or "unknown")
     if should_alert_chat and chat_status in {"failed", "skipped"}:
         message = f"{message}; Google Chat fallback {chat_status}"
     recorder.record(
@@ -1649,24 +1635,11 @@ def _owner_user_id_from_context(context: dict[str, Any] | None) -> str:
 
 
 def _post_google_chat_to_configured_webhooks(webhook_urls: str, text: str) -> dict[str, Any]:
-    urls = [url.strip() for url in webhook_urls.split(",") if url.strip()]
-    if not urls:
-        return {"status": "skipped", "reason": "missing_google_chat_webhook_url"}
-    posted = 0
-    error_count = 0
-    for url in urls:
-        try:
-            post_google_chat_message(url, text)
-            posted += 1
-        except Exception:  # noqa: BLE001 - non-fatal notification side effect
-            error_count += 1
-    if error_count:
-        return {
-            "status": "failed" if posted == 0 else "partial",
-            "posted": posted,
-            "error_count": error_count,
-        }
-    return {"status": "sent", "posted": posted}
+    return post_google_chat_to_configured_webhooks(
+        webhook_urls,
+        text,
+        post_message=post_google_chat_message,
+    )
 
 
 def _report_data_from_trace(trace: ReportTrace | None) -> dict[str, Any]:
@@ -1734,30 +1707,13 @@ def _record_source_alert_step(
             drive_folder_url=drive_folder_url,
             trace_url=trace_url,
         )
-        body = render_automation_event_note(event)
-        if event.site_id:
-            note_result = add_rhodes_site_note(
-                site_id=event.site_id,
-                body=body,
-                owner_user_id=owner_user_id,
-                owner_email=owner_email,
-            )
-        else:
-            note_result = {
-                "status": "skipped",
-                "reason": "missing_site_id",
-                "owner_notification": "none",
-            }
-        event_status: dict[str, Any] = {
-            "event_type": event.event_type,
-            "source_id": event.source_id,
-            "decision_required": event.decision_required,
-            **note_result,
-        }
-        if (
-            note_result.get("status") != "created"
-            or note_result.get("owner_notification") != "mentioned"
-        ):
+        event_status, body = record_rhodes_automation_event(
+            event,
+            owner_user_id=owner_user_id,
+            owner_email=owner_email,
+            add_note=add_rhodes_site_note,
+        )
+        if should_alert_google_chat(event_status):
             event_status["google_chat"] = _post_google_chat_to_configured_webhooks(
                 settings.google_chat_webhook_url,
                 body,
@@ -1885,31 +1841,15 @@ def _record_rhodes_report_event_step(
         open_questions=result.open_questions,
         closed_open_questions=result.closed_open_questions,
     )
-    body = render_automation_event_note(event)
-    note_result: dict[str, Any]
-    if not event.site_id:
-        note_result = {
-            "status": "skipped",
-            "reason": "missing_site_id",
-            "owner_notification": "none",
-        }
-    else:
-        note_result = add_rhodes_site_note(
-            site_id=event.site_id,
-            body=body,
-            owner_user_id=owner_user_id,
-            owner_email=owner_email,
-        )
-
-    event_status: dict[str, Any] = {
-        "event_type": event.event_type,
-        "source_id": event.source_id,
-        "decision_required": event.decision_required,
-        **note_result,
-    }
-    should_alert_chat = event.decision_required and (
-        note_result.get("status") != "created"
-        or note_result.get("owner_notification") != "mentioned"
+    event_status, body = record_rhodes_automation_event(
+        event,
+        owner_user_id=owner_user_id,
+        owner_email=owner_email,
+        add_note=add_rhodes_site_note,
+    )
+    should_alert_chat = should_alert_google_chat(
+        event_status,
+        decision_required=event.decision_required,
     )
     chat_result: dict[str, Any] | None = None
     if should_alert_chat:
@@ -1925,7 +1865,7 @@ def _record_rhodes_report_event_step(
         name="DDR report AutomationEvent",
         metadata=event_status,
     )
-    note_status = str(note_result.get("status") or "")
+    note_status = str(event_status.get("status") or "")
     chat_status = str((chat_result or {}).get("status") or "")
     if note_status == "created" and chat_status not in {"failed", "skipped"}:
         recorder.record(
@@ -1951,11 +1891,11 @@ def _record_rhodes_report_event_step(
             started_at,
             started_monotonic,
             "skipped",
-            skipped_reason=str(note_result.get("reason") or "skipped"),
+            skipped_reason=str(event_status.get("reason") or "skipped"),
         )
         return
 
-    message = str(note_result.get("error") or note_result.get("reason") or "unknown")
+    message = str(event_status.get("error") or event_status.get("reason") or "unknown")
     if should_alert_chat and chat_status in {"failed", "skipped"}:
         message = f"{message}; Google Chat fallback {chat_status}"
     recorder.record(

--- a/src/due_diligence_reporter/rhodes_events.py
+++ b/src/due_diligence_reporter/rhodes_events.py
@@ -1,0 +1,94 @@
+"""Shared Rhodes note and Google Chat helpers for AutomationEvent writes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from .automation_event import AutomationEvent, render_automation_event_note
+from .rhodes import add_rhodes_site_note
+from .utils import post_google_chat_message
+
+AddRhodesSiteNote = Callable[..., dict[str, Any]]
+PostGoogleChatMessage = Callable[[str, str], None]
+
+
+def record_rhodes_automation_event(
+    event: AutomationEvent,
+    *,
+    owner_user_id: str = "",
+    owner_email: str = "",
+    body: str | None = None,
+    add_note: AddRhodesSiteNote = add_rhodes_site_note,
+) -> tuple[dict[str, Any], str]:
+    """Write an AutomationEvent to Rhodes and return normalized status plus body."""
+
+    rendered_body = body if body is not None else render_automation_event_note(event)
+    if event.site_id:
+        note_result = add_note(
+            site_id=event.site_id,
+            body=rendered_body,
+            owner_user_id=owner_user_id,
+            owner_email=owner_email,
+        )
+    else:
+        note_result = {
+            "status": "skipped",
+            "reason": "missing_site_id",
+            "owner_notification": "none",
+        }
+
+    return (
+        {
+            "event_type": event.event_type,
+            "source_id": event.source_id,
+            "decision_required": event.decision_required,
+            **note_result,
+        },
+        rendered_body,
+    )
+
+
+def should_alert_google_chat(
+    event_status: dict[str, Any],
+    *,
+    decision_required: bool = True,
+) -> bool:
+    """Return True when Rhodes did not notify an owner and Chat fallback is needed."""
+
+    if not decision_required:
+        return False
+    return event_status.get("status") != "created" or (
+        event_status.get("owner_notification") != "mentioned"
+    )
+
+
+def post_google_chat_to_configured_webhooks(
+    webhook_urls: str,
+    text: str,
+    *,
+    post_message: PostGoogleChatMessage = post_google_chat_message,
+) -> dict[str, Any]:
+    """Post text to one or more comma-separated Google Chat webhooks."""
+
+    urls = [url.strip() for url in webhook_urls.split(",") if url.strip()]
+    if not urls:
+        return {"status": "skipped", "reason": "missing_google_chat_webhook_url"}
+
+    posted = 0
+    errors: list[str] = []
+    for url in urls:
+        try:
+            post_message(url, text)
+            posted += 1
+        except Exception as exc:  # noqa: BLE001 - non-fatal notification side effect
+            errors.append(str(exc))
+
+    if errors:
+        return {
+            "status": "failed" if posted == 0 else "partial",
+            "posted": posted,
+            "errors": errors,
+            "error_count": len(errors),
+        }
+    return {"status": "sent", "posted": posted}

--- a/tests/test_rhodes_events.py
+++ b/tests/test_rhodes_events.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+from due_diligence_reporter.automation_event import AutomationEvent
+from due_diligence_reporter.rhodes_events import (
+    post_google_chat_to_configured_webhooks,
+    record_rhodes_automation_event,
+    should_alert_google_chat,
+)
+
+
+def _event(*, site_id: str = "SITE1", decision_required: bool = True) -> AutomationEvent:
+    return AutomationEvent(
+        source_system="due-diligence-reporter",
+        source_id="run-1",
+        site_id=site_id,
+        site_name="Alpha Test",
+        event_type="test_event",
+        decision_required=decision_required,
+        created_at="2026-05-28T12:00:00+00:00",
+    )
+
+
+def test_record_rhodes_automation_event_writes_note_with_owner_context() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def add_note(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {
+            "status": "created",
+            "rhodes_note_id": "NOTE1",
+            "owner_notification": "mentioned",
+        }
+
+    result, body = record_rhodes_automation_event(
+        _event(),
+        owner_user_id="USER1",
+        owner_email="owner@example.com",
+        add_note=add_note,
+    )
+
+    assert result == {
+        "event_type": "test_event",
+        "source_id": "run-1",
+        "decision_required": True,
+        "status": "created",
+        "rhodes_note_id": "NOTE1",
+        "owner_notification": "mentioned",
+    }
+    assert calls == [
+        {
+            "site_id": "SITE1",
+            "body": body,
+            "owner_user_id": "USER1",
+            "owner_email": "owner@example.com",
+        }
+    ]
+    assert "AutomationEvent v1" in body
+    assert "Kind: test_event" in body
+
+
+def test_record_rhodes_automation_event_skips_missing_site_id() -> None:
+    def add_note(**_: Any) -> dict[str, Any]:
+        raise AssertionError("add_note should not be called without a site ID")
+
+    result, body = record_rhodes_automation_event(_event(site_id=""), add_note=add_note)
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "missing_site_id"
+    assert result["owner_notification"] == "none"
+    assert "Site ID: unknown" in body
+
+
+def test_should_alert_google_chat_requires_decision_and_owner_notification() -> None:
+    assert not should_alert_google_chat(
+        {"status": "created", "owner_notification": "mentioned"}
+    )
+    assert should_alert_google_chat({"status": "failed", "owner_notification": "none"})
+    assert should_alert_google_chat(
+        {"status": "created", "owner_notification": "none"},
+        decision_required=False,
+    ) is False
+
+
+def test_post_google_chat_to_configured_webhooks_reports_partial_failure() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def post_message(url: str, text: str) -> None:
+        calls.append((url, text))
+        if "bad" in url:
+            raise RuntimeError("chat down")
+
+    result = post_google_chat_to_configured_webhooks(
+        "https://chat.example/good, https://chat.example/bad",
+        "event body",
+        post_message=post_message,
+    )
+
+    assert result == {
+        "status": "partial",
+        "posted": 1,
+        "errors": ["chat down"],
+        "error_count": 1,
+    }
+    assert calls == [
+        ("https://chat.example/good", "event body"),
+        ("https://chat.example/bad", "event body"),
+    ]
+
+
+def test_post_google_chat_to_configured_webhooks_skips_missing_config() -> None:
+    assert post_google_chat_to_configured_webhooks(" ", "event body") == {
+        "status": "skipped",
+        "reason": "missing_google_chat_webhook_url",
+    }


### PR DESCRIPTION
## Summary
- Add a shared DDR Rhodes AutomationEvent helper for site-note writes, owner-notification Chat fallback checks, and configured Google Chat posting.
- Reuse it from inbox registration-failure events, report pipeline source/vendor/report events, and RayCon follow-up events.
- Preserve existing event status shapes and module patch points while reducing duplicated note/fallback logic.

## Verification
- uv run pytest --basetemp C:\tmp\ddr-shared-rhodes-events-focused tests/test_rhodes_events.py tests/test_automation_event.py tests/test_report_pipeline.py tests/test_inbox_scanner.py::TestRhodesDocumentRegistration tests/test_raycon_followup.py -q
- uv run ruff check src\due_diligence_reporter\rhodes_events.py src\due_diligence_reporter\report_pipeline.py src\due_diligence_reporter\inbox_scanner.py scripts\raycon_followup.py tests\test_rhodes_events.py tests\test_report_pipeline.py tests\test_inbox_scanner.py tests\test_raycon_followup.py
- uv run mypy src\due_diligence_reporter\rhodes_events.py src\due_diligence_reporter\report_pipeline.py src\due_diligence_reporter\inbox_scanner.py
- uv run python -m py_compile scripts\raycon_followup.py
- uv run pytest --basetemp C:\tmp\ddr-shared-rhodes-events-broad tests/test_rhodes_events.py tests/test_automation_event.py tests/test_report_pipeline.py tests/test_inbox_scanner.py tests/test_scan_inbox_e2e.py tests/test_raycon_followup.py tests/test_raycon_runtime_state_store.py tests/test_dd_republish.py tests/test_rhodes.py -q
- uv run mypy src/
- git diff --check
- git diff --cached --check