### PR TITLE
Handle failed RayCon scenario payloads

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,56 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Failed Scenario State
+
+Confirmed PR #126 was merged at `8dc8b16` and continued on a clean branch:
+
+- Branch: `codex/ddr-raycon-failed-state`
+
+Changed:
+
+- Readiness now distinguishes a present `raycon_scenario.json` from a usable
+  RayCon scenario. Payloads with `status: failed`, `status:
+  validation_failed`, `status: error`, or `validation.passed: false` surface as
+  `failed_validation` instead of satisfying the full-report RayCon slot.
+- Failed RayCon report fields are carried into report generation as
+  authoritative cached fields. If the agent supplies RayCon values anyway, the
+  failed RayCon state overrides the RayCon-sourced cost/CAPEX/open-date tokens.
+- Partial DDR completeness now has a separate `raycon_scenario_failed` reason,
+  renders `RayCon validation failed` in the banner, preserves the RayCon
+  failure reason, and treats generic `[Not found - RayCon scenario pending]`
+  labels as pending instead of filled values.
+- RayCon follow-up failed-scenario retry rows remain alert rows, so Rhodes
+  owner-note / Google Chat fallback notification happens even when the workflow
+  also dispatches an automatic recovery job.
+- Updated `docs/process/HOW-IT-WORKS.md` with the failed-validation contract.
+
+Verification:
+
+```powershell
+uv run python -m py_compile src\due_diligence_reporter\raycon_client.py src\due_diligence_reporter\completeness.py src\due_diligence_reporter\google_doc_builder.py src\due_diligence_reporter\server.py src\due_diligence_reporter\report_pipeline.py scripts\raycon_followup.py
+uv run pytest --basetemp C:\tmp\ddr-raycon-failed-state-focused tests/test_completeness.py tests/test_dd_output_fixes.py tests/test_vendor_gate.py tests/test_report_pipeline.py::TestCheckSiteReadinessDirect tests/test_diagnose_site_readiness.py tests/test_raycon_followup.py::TestFailedScenarioAlerts -q
+uv run pytest --basetemp C:\tmp\ddr-raycon-failed-state-final2 tests/test_raycon_client.py tests/test_completeness.py tests/test_dd_output_fixes.py tests/test_vendor_gate.py tests/test_report_pipeline.py tests/test_diagnose_site_readiness.py tests/test_raycon_followup.py tests/test_google_doc_builder.py tests/test_dd_republish.py tests/test_rhodes_events.py -q
+uv run ruff check src\due_diligence_reporter\raycon_client.py src\due_diligence_reporter\completeness.py src\due_diligence_reporter\google_doc_builder.py src\due_diligence_reporter\server.py src\due_diligence_reporter\report_pipeline.py scripts\raycon_followup.py tests\test_raycon_client.py tests\test_completeness.py tests\test_dd_output_fixes.py tests\test_vendor_gate.py tests\test_report_pipeline.py tests\test_diagnose_site_readiness.py tests\test_raycon_followup.py
+uv run mypy src/
+git diff --check
+```
+
+Results:
+
+- Focused RayCon failed-state suite: 126 passed.
+- Affected RayCon/report/Rhodes suite: 388 passed.
+- Ruff on touched code/tests: passed.
+- Full source Mypy: no issues in 38 source files.
+- Diff check: passed with expected Windows LF-to-CRLF warnings only.
+
+Next:
+
+- Commit, push, and open the PR for `codex/ddr-raycon-failed-state`.
+- After merge, rerun RayCon follow-up or the DDR republish path against Tulsa
+  6940 S Utica Ave and Santa Clara 2340 Calle de Luna so Rhodes gets the
+  failed-validation owner note and the DDRs render explicit RayCon validation
+  failure instead of pending/filled placeholders.
+
 ## 2026-05-28 - Inbox Manual Review Rhodes Events
 
 Confirmed the previous shared-helper PR was merged:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,6 +5,10 @@
 Confirmed PR #126 was merged at `8dc8b16` and continued on a clean branch:
 
 - Branch: `codex/ddr-raycon-failed-state`
+- Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/127
+- Implementation commit: `39f48d1` (`Handle failed RayCon scenario payloads`)
+- Current state: branch pushed, draft PR open, GitHub reports merge state
+  `CLEAN`. No checks were reported when checked.
 
 Changed:
 
@@ -45,7 +49,7 @@ Results:
 
 Next:
 
-- Commit, push, and open the PR for `codex/ddr-raycon-failed-state`.
+- Wait for CI/review on PR #127.
 - After merge, rerun RayCon follow-up or the DDR republish path against Tulsa
   6940 S Utica Ave and Santa Clara 2340 Calle de Luna so Rhodes gets the
   failed-validation owner note and the DDRs render explicit RayCon validation

--- a/docs/process/HOW-IT-WORKS.md
+++ b/docs/process/HOW-IT-WORKS.md
@@ -279,6 +279,13 @@ and RayCon scenario readiness. Missing vendor inputs no longer block the
 first publish; they are logged as open verification items and the report
 republishes as authoritative inputs arrive. ISP remains informational.
 
+RayCon readiness distinguishes a physically present `raycon_scenario.json`
+from a usable one. A JSON with `status: failed` or `validation.passed: false`
+is treated as `failed_validation`, not as a successful RayCon input. Failed
+RayCon fields render as `RayCon validation failed` in the partial DDR banner
+and table cells, and full-report readiness waits for a valid replacement
+`raycon_scenario.json`.
+
 ### SIR Learning Loop
 
 Readiness also records non-blocking SIR comparison metadata. When both an
@@ -439,9 +446,15 @@ Three skill tools analyze the source data and produce structured outputs. The fi
 
 **Source-read fallback:** If the pipeline does not know the Rhodes site ID, Rhodes cannot create the note, or the P1 DRI cannot be mentioned, the same `source_review_required` event body is posted to the configured Google Chat webhook.
 
-**Vendor-gate activity:** When the full vendor input set is present (vendor SIR, vendor Building Inspection, and RayCon Scenario JSON) but report generation still fails or the generated report remains incomplete, the pipeline records a `vendor_gate_review_required` `AutomationEvent v1` site note in Rhodes. The note includes the run ID, required input set, failure reason, Drive folder, and trace link when available.
+**Vendor-gate activity:** When the full vendor input set is present (vendor SIR, vendor Building Inspection, and a usable RayCon Scenario JSON) but report generation still fails or the generated report remains incomplete, the pipeline records a `vendor_gate_review_required` `AutomationEvent v1` site note in Rhodes. The note includes the run ID, required input set, failure reason, Drive folder, and trace link when available.
 
 **Vendor-gate fallback:** If the pipeline does not know the Rhodes site ID, Rhodes cannot create the note, or the P1 DRI cannot be mentioned, the same `vendor_gate_review_required` event body is posted to the configured Google Chat webhook.
+
+**RayCon failed-validation activity:** When RayCon follow-up sees a failed
+`raycon_scenario.json`, it records a `raycon_followup_alert` note in Rhodes
+even if it also starts an automatic retry. The note carries the RayCon failure
+reason and run ID. If no site owner can be mentioned, the same event body goes
+to the configured Google Chat webhook.
 
 **Activity:** When the report reaches `report_created`, the pipeline records an `AutomationEvent v1` site note in Rhodes. The note includes the generated DD report ID/URL, run ID, trigger source for updates, open verification item count, closed verification item count, and up to five open/closed item summaries. It mentions the P1 DRI when a Rhodes user can be resolved from the owner context.
 

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -776,12 +776,17 @@ def _failed_scenario_base_row(
     report_fields: dict[str, str],
 ) -> dict[str, Any]:
     reason = report_fields.get("exec.raycon_failure_reason", "") or "unspecified"
+    run_id = report_fields.get("exec.raycon_run_id", "")
+    modified = str(scenario.get("_drive_modified_time", "") or "")
     return {
         "site": site_name,
         "alert": f"raycon run failed: {reason}",
+        "alert_dedup_key": (
+            f"{site_name}:failed_scenario:{run_id or reason[:120]}:{modified}"
+        ),
         "raycon_status": report_fields.get("exec.raycon_status", ""),
-        "raycon_run_id": report_fields.get("exec.raycon_run_id", ""),
-        "json_modified": scenario.get("_drive_modified_time", ""),
+        "raycon_run_id": run_id,
+        "json_modified": modified,
     }
 
 
@@ -796,7 +801,7 @@ def _failed_scenario_dispatch_row(
         "dispatch_reason": "failed_scenario_retry",
         "previous_failure": reason,
         "job_id": dispatch_result.get("job_id"),
-        "raycon_run_id": dispatch_result.get("raycon_run_id"),
+        "retry_raycon_run_id": dispatch_result.get("raycon_run_id"),
         "status": dispatch_result.get("status"),
         "status_url_present": dispatch_result.get("status_url_present"),
         "block_plan_file_id": dispatch_result.get("block_plan_file_id"),
@@ -811,6 +816,7 @@ def _failed_scenario_status_row(
 ) -> dict[str, Any] | None:
     if status in RAYCON_IN_PROGRESS_STATUSES:
         return {
+            **base_row,
             "site": site_name,
             "skipped": f"raycon recovery job {status}",
             "block_plan_file_id": block_plan_file_id,
@@ -864,7 +870,10 @@ def _handle_failed_scenario(
         redispatch_after=redispatch_after,
     )
     if dispatch_result.get("dispatched"):
-        return _failed_scenario_dispatch_row(site_name, reason, dispatch_result)
+        return {
+            **base_row,
+            **_failed_scenario_dispatch_row(site_name, reason, dispatch_result),
+        }
     if dispatch_result.get("dispatch_error"):
         return {
             "site": site_name,

--- a/src/due_diligence_reporter/completeness.py
+++ b/src/due_diligence_reporter/completeness.py
@@ -5,8 +5,9 @@ Computes a structured ``completeness`` block that downstream consumers
 to decide whether a report is "complete" or
 "partial-on-purpose -- waiting on a known input".
 
-Known pending reasons include missing RayCon scenario data and first-round
-reports that intentionally carry open vendor-verification items.
+Known pending reasons include missing RayCon scenario data, failed RayCon
+validation, and first-round reports that intentionally carry open
+vendor-verification items.
 """
 
 from __future__ import annotations
@@ -21,6 +22,8 @@ from .raycon_client import RAYCON_BREAKDOWN_ROWS
 
 RAYCON_PENDING_REASON = "raycon_scenario_pending"
 RAYCON_PENDING_TRIGGER_FILE = "raycon_scenario.json"
+RAYCON_FAILED_REASON = "raycon_scenario_failed"
+RAYCON_FAILED_TRIGGER_FILE = "valid raycon_scenario.json"
 VENDOR_VERIFICATION_PENDING_REASON = "vendor_verification_pending"
 VENDOR_VERIFICATION_TRIGGER_FILE = "vendor source documents"
 VERIFICATION_OPEN_ITEMS_TOKEN = "_internal.verification_open_items"
@@ -29,6 +32,7 @@ VERIFICATION_OPEN_ITEMS_TOKEN = "_internal.verification_open_items"
 # renderer in the document builder. New reason keys must add an entry here
 # or the banner falls back to the raw key.
 REASON_DISPLAY_LABELS: dict[str, str] = {
+    RAYCON_FAILED_REASON: "RayCon validation failed",
     RAYCON_PENDING_REASON: "RayCon cost & capacity",
     VENDOR_VERIFICATION_PENDING_REASON: "Vendor verification",
 }
@@ -36,6 +40,7 @@ REASON_DISPLAY_LABELS: dict[str, str] = {
 # Trigger files keyed by reason — drives the ``auto_republish_on``
 # array on the completeness block.
 REASON_TRIGGER_FILES: dict[str, str] = {
+    RAYCON_FAILED_REASON: RAYCON_FAILED_TRIGGER_FILE,
     RAYCON_PENDING_REASON: RAYCON_PENDING_TRIGGER_FILE,
     VENDOR_VERIFICATION_PENDING_REASON: VENDOR_VERIFICATION_TRIGGER_FILE,
 }
@@ -72,16 +77,31 @@ _RAYCON_TOKEN_PATHS: frozenset[str] = frozenset(raycon_token_paths())
 _RAYCON_PENDING_PLACEHOLDER_PREFIXES: tuple[str, ...] = (
     "[Not found - Fastest Open scenario not extracted",
     "[Not found - Max Capacity scenario not extracted",
+    "[Not found - RayCon scenario pending",
 )
+
+_RAYCON_FAILED_PLACEHOLDER_PREFIXES: tuple[str, ...] = (
+    "[Not found - RayCon validation failed",
+    "[Not found - RayCon scenario failed",
+)
+
+
+def raycon_placeholder_reason(value: Any) -> str | None:
+    """Return the completeness reason represented by a RayCon placeholder."""
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if any(text.startswith(prefix) for prefix in _RAYCON_FAILED_PLACEHOLDER_PREFIXES):
+        return RAYCON_FAILED_REASON
+    if any(text.startswith(prefix) for prefix in _RAYCON_PENDING_PLACEHOLDER_PREFIXES):
+        return RAYCON_PENDING_REASON
+    return None
 
 
 def is_raycon_pending_placeholder(value: Any) -> bool:
     """Return True if *value* is the placeholder server.py installs when
     a RayCon-derived field has no real data yet."""
-    if not isinstance(value, str):
-        return False
-    text = value.strip()
-    return any(text.startswith(prefix) for prefix in _RAYCON_PENDING_PLACEHOLDER_PREFIXES)
+    return raycon_placeholder_reason(value) == RAYCON_PENDING_REASON
 
 
 def _is_filled(value: Any) -> bool:
@@ -91,7 +111,7 @@ def _is_filled(value: Any) -> bool:
     text = value.strip()
     if not text:
         return False
-    if is_raycon_pending_placeholder(text):
+    if raycon_placeholder_reason(text) is not None:
         return False
     return True
 
@@ -101,7 +121,11 @@ def _is_filled(value: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
+def compute_completeness_block(
+    replacements: dict[str, str],
+    *,
+    raycon_failure_reason: str = "",
+) -> dict[str, Any]:
     """Compute the ``report_metadata.completeness`` block for a report.
 
     Walks the final populated token map and counts filled vs. pending
@@ -124,6 +148,7 @@ def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
             }
     """
     pending_by_reason: dict[str, list[str]] = {}
+    raycon_failed = bool(str(raycon_failure_reason or "").strip())
     filled = 0
     pending = 0
 
@@ -133,9 +158,15 @@ def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
                 VENDOR_VERIFICATION_PENDING_REASON, []
             ).append(token)
             pending += 1
-        elif token in _RAYCON_TOKEN_PATHS and not _is_filled(value):
-            pending_by_reason.setdefault(RAYCON_PENDING_REASON, []).append(token)
-            pending += 1
+        elif token in _RAYCON_TOKEN_PATHS:
+            reason = raycon_placeholder_reason(value)
+            if reason is None and not _is_filled(value):
+                reason = RAYCON_FAILED_REASON if raycon_failed else RAYCON_PENDING_REASON
+            if reason is not None:
+                pending_by_reason.setdefault(reason, []).append(token)
+                pending += 1
+            elif _is_filled(value):
+                filled += 1
         elif _is_filled(value):
             filled += 1
 
@@ -155,18 +186,23 @@ def compute_completeness_block(replacements: dict[str, str]) -> dict[str, Any]:
 
     stage = "partial" if pending > 0 else "complete"
 
-    return {
+    block: dict[str, Any] = {
         "stage": stage,
         "filled_token_count": filled,
         "pending_token_count": pending,
         "pending_reasons": pending_reasons_sorted,
         "auto_republish_on": auto_republish_on,
     }
+    if RAYCON_FAILED_REASON in pending_reasons_sorted and raycon_failure_reason:
+        block["raycon_failure_reason"] = str(raycon_failure_reason).strip()
+    return block
 
 
 def project_completeness_from_readiness(
     *,
     raycon_scenario_found: bool,
+    raycon_scenario_failed: bool = False,
+    raycon_failure_reason: str = "",
     verification_open_items_pending: bool = False,
 ) -> dict[str, Any]:
     """Project what the completeness block will look like *before* the
@@ -180,7 +216,9 @@ def project_completeness_from_readiness(
     open items will be logged.
     """
     pending_reasons_unsorted: dict[str, list[str]] = {}
-    if not raycon_scenario_found:
+    if raycon_scenario_failed:
+        pending_reasons_unsorted[RAYCON_FAILED_REASON] = sorted(_RAYCON_TOKEN_PATHS)
+    elif not raycon_scenario_found:
         pending_reasons_unsorted[RAYCON_PENDING_REASON] = sorted(_RAYCON_TOKEN_PATHS)
     if verification_open_items_pending:
         pending_reasons_unsorted[VENDOR_VERIFICATION_PENDING_REASON] = [
@@ -201,7 +239,7 @@ def project_completeness_from_readiness(
     pending_count = sum(len(paths) for paths in pending_reasons.values())
     stage = "partial" if pending_count > 0 else "complete"
 
-    return {
+    block: dict[str, Any] = {
         "stage": stage,
         # Filled count is unknown pre-generation — caller is asking what
         # the *shape* would look like. Surface the projected pending
@@ -211,3 +249,6 @@ def project_completeness_from_readiness(
         "pending_reasons": pending_reasons,
         "auto_republish_on": auto_republish_on,
     }
+    if RAYCON_FAILED_REASON in pending_reasons and raycon_failure_reason:
+        block["raycon_failure_reason"] = str(raycon_failure_reason).strip()
+    return block

--- a/src/due_diligence_reporter/google_doc_builder.py
+++ b/src/due_diligence_reporter/google_doc_builder.py
@@ -12,6 +12,7 @@ import re
 from typing import Any
 
 from .completeness import (
+    RAYCON_FAILED_REASON,
     RAYCON_PENDING_REASON,
     REASON_DISPLAY_LABELS,
     REASON_TRIGGER_FILES,
@@ -898,6 +899,12 @@ def format_partial_banner_text(
             for reason in reasons
             if reason in REASON_TRIGGER_FILES
         })
+    raycon_failure_reason = ""
+    if isinstance(reasons, dict) and RAYCON_FAILED_REASON in reasons:
+        raycon_failure_reason = str(
+            completeness.get("raycon_failure_reason") or ""
+        ).strip()
+
     if isinstance(triggers, list) and triggers:
         trigger_text = ", ".join(str(item) for item in triggers if str(item).strip())
         follow_up = (
@@ -908,9 +915,16 @@ def format_partial_banner_text(
     else:
         follow_up = "Review open items before treating this as a final DDR."
 
+    failure_line = (
+        f"RayCon validation reason: {raycon_failure_reason[:500]}.\n"
+        if raycon_failure_reason
+        else ""
+    )
+
     return (
         "PARTIAL REPORT -- pending data\n"
         f"Missing: {missing_str}{timestamp_clause}.\n"
+        f"{failure_line}"
         f"{follow_up}\n"
     )
 

--- a/src/due_diligence_reporter/raycon_client.py
+++ b/src/due_diligence_reporter/raycon_client.py
@@ -677,7 +677,11 @@ def _scenario_breakdown(
 # when validation didn't pass (no scenarios computed); ``"completed"`` /
 # ``"success"`` for a happy run. Anything else is treated as completed for
 # back-compat with payloads that predate the envelope.
-RAYCON_FAILED_STATUSES: frozenset[str] = frozenset({"failed", "error"})
+RAYCON_FAILED_STATUSES: frozenset[str] = frozenset({
+    "failed",
+    "validation_failed",
+    "error",
+})
 
 
 def raycon_payload_status(payload: dict[str, Any]) -> str:

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -27,6 +27,7 @@ from .classifier import (
     classify_document_type,
     match_file_to_site_llm,
 )
+from .completeness import raycon_token_paths
 from .config import Settings, get_settings
 from .google_client import GoogleClient
 from .m1_lookup import _list_m1_documents_by_type, _resolve_m1_folder
@@ -49,6 +50,14 @@ from .pipeline_contracts import (
 from .pipeline_manifest import manifest_has_secret_like_value, persist_run_manifest
 from .pipeline_quality import evaluate_run_quality
 from .provenance import classify_provenance
+from .raycon_client import (
+    RAYCON_FAILED_STATUSES,
+    RayConSchemaError,
+    raycon_payload_failed,
+    raycon_payload_status,
+    raycon_scenario_to_report_fields,
+    read_raycon_scenario_from_m1,
+)
 from .rhodes import add_rhodes_site_note, lookup_rhodes_site_owner
 from .rhodes_events import (
     post_google_chat_to_configured_webhooks,
@@ -66,6 +75,8 @@ from .utils import (
 )
 
 logger = logging.getLogger("report_pipeline")
+
+_RAYCON_REPORT_FIELD_PATHS: frozenset[str] = frozenset(raycon_token_paths())
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Tool definitions for the Claude API call (mirrors the MCP tools)
@@ -402,6 +413,86 @@ def match_site_in_shared_cache(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _raycon_readiness_metadata(
+    gc: GoogleClient,
+    drive_folder_url: str,
+    m1_folder_id: str | None,
+    m1_files_by_type: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Return readiness fields for the M1 RayCon scenario JSON."""
+    raycon_scenario_file = m1_files_by_type.get("raycon_scenario_json")
+    if not raycon_scenario_file:
+        return {
+            "raycon_scenario_found": False,
+            "raycon_scenario_usable": False,
+            "raycon_scenario_status": "missing",
+            "raycon_scenario_failed": False,
+            "raycon_scenario_failure_reason": "",
+            "raycon_scenario_run_id": "",
+            "raycon_report_data_fields": {},
+        }
+
+    base: dict[str, Any] = {
+        "raycon_scenario_found": True,
+        "raycon_scenario_usable": False,
+        "raycon_scenario_status": "read_error",
+        "raycon_scenario_failed": True,
+        "raycon_scenario_failure_reason": "",
+        "raycon_scenario_run_id": "",
+        "raycon_scenario_file_id": str(raycon_scenario_file.get("id") or ""),
+        "raycon_scenario_modified_time": str(
+            raycon_scenario_file.get("modifiedTime") or ""
+        ),
+        "raycon_report_data_fields": {},
+    }
+
+    try:
+        scenario = read_raycon_scenario_from_m1(
+            gc,
+            drive_folder_url,
+            m1_folder_id=m1_folder_id,
+            m1_files=[f for f in m1_files_by_type.values() if f],
+        )
+    except RayConSchemaError as e:
+        return {
+            **base,
+            "raycon_scenario_status": "invalid",
+            "raycon_scenario_failure_reason": str(e),
+        }
+    except Exception as e:  # pragma: no cover
+        logger.warning("RayCon scenario read failed: %s", e)
+        return {
+            **base,
+            "raycon_scenario_failure_reason": str(e),
+        }
+
+    if scenario is None:
+        return {
+            **base,
+            "raycon_scenario_status": "missing",
+            "raycon_scenario_failure_reason": "raycon_scenario.json could not be read",
+        }
+
+    report_fields = raycon_scenario_to_report_fields(scenario)
+    failed = raycon_payload_failed(scenario)
+    status = raycon_payload_status(scenario) or "completed"
+    failure_reason = str(
+        report_fields.get("exec.raycon_failure_reason") or ""
+    ).strip()
+    if failed and not failure_reason:
+        failure_reason = f"RayCon status: {status or 'failed'}"
+
+    return {
+        **base,
+        "raycon_scenario_usable": not failed,
+        "raycon_scenario_status": "failed_validation" if failed else status,
+        "raycon_scenario_failed": failed,
+        "raycon_scenario_failure_reason": failure_reason,
+        "raycon_scenario_run_id": report_fields.get("exec.raycon_run_id", ""),
+        "raycon_report_data_fields": report_fields,
+    }
+
+
 def check_site_readiness_direct(
     gc: GoogleClient,
     drive_folder_url: str,
@@ -510,11 +601,18 @@ def check_site_readiness_direct(
     # The third gating input. Lives only in M1 (written by RayCon's async
     # /v1/jobs hand-off) and is keyed by the dedicated ``raycon_scenario_json``
     # doc_type so an AI raycon_scenario_report can never satisfy this slot.
-    raycon_scenario_file: dict[str, Any] | None = None
+    raycon_metadata: dict[str, Any] = _raycon_readiness_metadata(
+        gc, drive_folder_url, m1_folder_id, {}
+    )
     if m1_folder_id:
         try:
             m1_files_by_type = _list_m1_documents_by_type(gc, m1_folder_id)
-            raycon_scenario_file = m1_files_by_type.get("raycon_scenario_json")
+            raycon_metadata = _raycon_readiness_metadata(
+                gc,
+                drive_folder_url,
+                m1_folder_id,
+                m1_files_by_type,
+            )
         except Exception as e:  # pragma: no cover
             logger.warning(
                 "M1 lookup failed for raycon_scenario_json in %s: %s", site_title, e
@@ -541,7 +639,7 @@ def check_site_readiness_direct(
         "sir_vendor": files_by_type["sir"] is not None and sir_is_vendor,
         "inspection_vendor": files_by_type["building_inspection"] is not None
             and inspection_is_vendor,
-        "raycon_scenario_found": raycon_scenario_file is not None,
+        **raycon_metadata,
         "report_exists": files_by_type["dd_report"] is not None,
         "e_occupancy_report_found": files_by_type["e_occupancy_report"] is not None,
         "school_approval_report_found": files_by_type["school_approval_report"] is not None,
@@ -1122,6 +1220,14 @@ def _merge_cached_report_fields(
     for key, value in cached_report_fields.items():
         report_data.setdefault(key, value)
 
+    cached_raycon_status = str(
+        cached_report_fields.get("exec.raycon_status") or ""
+    ).strip().lower()
+    if cached_raycon_status in RAYCON_FAILED_STATUSES:
+        for key, value in cached_report_fields.items():
+            if key.startswith("exec.raycon_") or key in _RAYCON_REPORT_FIELD_PATHS:
+                report_data[key] = value
+
     merged["report_data"] = report_data
     return merged
 
@@ -1160,8 +1266,16 @@ def _missing_required_docs(readiness: dict[str, Any]) -> list[str]:
                 if readiness.get("inspection_found")
                 else "Building Inspection"
             )
-        if not readiness.get("raycon_scenario_found", False):
+        raycon_found = bool(readiness.get("raycon_scenario_found", False))
+        raycon_usable = bool(readiness.get("raycon_scenario_usable", raycon_found))
+        if not raycon_found:
             missing.append("RayCon Scenario JSON")
+        elif not raycon_usable:
+            status = str(readiness.get("raycon_scenario_status") or "").strip()
+            if status == "failed_validation":
+                missing.append("Successful RayCon Scenario JSON")
+            else:
+                missing.append("Usable RayCon Scenario JSON")
         return missing
 
     if not readiness.get("sir_found", False):
@@ -2051,6 +2165,10 @@ def process_site_pipeline(
             gc=gc,
             drive_folder_url=drive_folder_url,
         )
+
+    raycon_report_fields = readiness.get("raycon_report_data_fields")
+    if isinstance(raycon_report_fields, dict):
+        initial_report_fields.update(raycon_report_fields)
 
     readiness_result = _resolve_readiness_result(
         site_title, readiness, force_regenerate=force_regenerate

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -30,6 +30,7 @@ from .classifier import (
 from .completeness import (
     REASON_DISPLAY_LABELS,
     compute_completeness_block,
+    is_raycon_pending_placeholder,
     project_completeness_from_readiness,
     raycon_token_paths,
 )
@@ -47,7 +48,7 @@ from .m1_lookup import (
     _list_m1_documents_by_type,
     _resolve_m1_folder,
 )
-from .raycon_client import RAYCON_BREAKDOWN_ROWS
+from .raycon_client import RAYCON_BREAKDOWN_ROWS, RAYCON_FAILED_STATUSES
 from .rebl import ReblResolution, resolve_address
 from .report_schema import (
     ALLOWED_CAN_WE_ANSWERS,
@@ -2338,6 +2339,25 @@ def _format_block_plan_submitted_display(iso_ts: str) -> str:
     return parsed.strftime("%Y-%m-%d %H:%M UTC")
 
 
+def _raycon_failure_reason_from_flat(flat_report_data: dict[str, Any]) -> str:
+    """Return the RayCon validation failure reason carried in report data."""
+    status = str(flat_report_data.get("exec.raycon_status") or "").strip().lower()
+    reason = str(
+        flat_report_data.get("exec.raycon_failure_reason") or ""
+    ).strip()
+    if reason:
+        return reason
+    if status in RAYCON_FAILED_STATUSES:
+        return f"RayCon status: {status}"
+    return ""
+
+
+def _fill_raycon_failed_placeholders(replacements: dict[str, str]) -> None:
+    """Force RayCon-sourced tokens to an explicit validation-failed label."""
+    for token in raycon_token_paths():
+        replacements[token] = "[Not found - RayCon validation failed]"
+
+
 def _normalize_report_replacements(
     report_data: dict[str, Any],
     site_name: str,
@@ -2347,6 +2367,7 @@ def _normalize_report_replacements(
 ) -> tuple[dict[str, str], list[str], list[str], dict[str, str], ReblResolution]:
     """Normalize report data and fill permissive current gap labels."""
     flat_report_data = flatten_report_data_for_replacement(report_data)
+    raycon_failure_reason = _raycon_failure_reason_from_flat(flat_report_data)
     report_data, rebl_resolution = _inject_report_defaults(
         report_data,
         site_address=site_address,
@@ -2362,6 +2383,8 @@ def _normalize_report_replacements(
             replacements["exec.c_answer"] = normalized_answer
     if site_name.strip():
         replacements["meta.site_name"] = site_name.strip()
+    if raycon_failure_reason:
+        _fill_raycon_failed_placeholders(replacements)
     _fill_fastest_open_placeholders(replacements)
     _fill_max_capacity_placeholders(replacements)
 
@@ -2530,11 +2553,19 @@ def _fill_scenario_placeholders(
     """Fill missing scenario summary and detailed breakdown fields."""
     for metric in ("capacity", "capex", "open_date"):
         token = f"exec.{scenario}_{metric}"
-        if token not in replacements or not str(replacements[token]).strip():
+        if (
+            token not in replacements
+            or not str(replacements[token]).strip()
+            or is_raycon_pending_placeholder(replacements[token])
+        ):
             replacements[token] = label
     for row_key, _ in RAYCON_BREAKDOWN_ROWS:
         token = f"exec.cost_{row_key}_{scenario}"
-        if token not in replacements or not str(replacements[token]).strip():
+        if (
+            token not in replacements
+            or not str(replacements[token]).strip()
+            or is_raycon_pending_placeholder(replacements[token])
+        ):
             replacements[token] = label
 
 
@@ -2751,7 +2782,13 @@ async def create_dd_report(
             # Compute the partial-on-purpose completeness metadata. Done
             # before the doc builder runs so the renderer can prepend
             # the "PARTIAL REPORT" banner when stage == "partial".
-            completeness = compute_completeness_block(replacements)
+            raycon_failure_reason = _raycon_failure_reason_from_flat(
+                flatten_report_data_for_replacement(report_data)
+            )
+            completeness = compute_completeness_block(
+                replacements,
+                raycon_failure_reason=raycon_failure_reason,
+            )
             _attach_block_plan_submitted_timestamp(
                 gc=gc,
                 drive_folder_url=drive_folder_url,
@@ -2860,10 +2897,23 @@ async def check_site_readiness(
 
             sir_found = bool(readiness.get("sir_found"))
             report_exists = bool(readiness.get("report_exists"))
+            raycon_found = bool(readiness.get("raycon_scenario_found"))
+            raycon_usable = bool(readiness.get("raycon_scenario_usable", raycon_found))
+            raycon_failed = raycon_found and not raycon_usable
+            raycon_failure_reason = str(
+                readiness.get("raycon_scenario_failure_reason") or ""
+            ).strip()
             missing_docs = [] if sir_found else ["sir"]
             ready_for_report = sir_found and not report_exists
             projected_completeness = project_completeness_from_readiness(
-                raycon_scenario_found=bool(readiness.get("raycon_scenario_found")),
+                raycon_scenario_found=raycon_found,
+                raycon_scenario_failed=raycon_failed,
+                raycon_failure_reason=raycon_failure_reason,
+            )
+            raycon_status_label = (
+                "failed validation"
+                if raycon_failed
+                else ("found" if raycon_found else "not yet posted")
             )
 
             return {
@@ -2873,7 +2923,10 @@ async def check_site_readiness(
                 "isp_found": bool(readiness.get("isp_found")),
                 "inspection_found": bool(readiness.get("inspection_found")),
                 "report_exists": report_exists,
-                "raycon_scenario_found": bool(readiness.get("raycon_scenario_found")),
+                "raycon_scenario_found": raycon_found,
+                "raycon_scenario_usable": raycon_usable,
+                "raycon_scenario_status": readiness.get("raycon_scenario_status", ""),
+                "raycon_scenario_failure_reason": raycon_failure_reason,
                 "missing_docs": missing_docs,
                 "ready_for_report": ready_for_report,
                 "drive_folder_url": drive_folder_url,
@@ -2883,7 +2936,8 @@ async def check_site_readiness(
                     f"  SIR: {'found' if sir_found else 'not found'}",
                     f"  Building Inspection: {'found' if readiness.get('inspection_found') else 'not found'}",
                     f"  DD Report: {'exists' if report_exists else 'not yet created'}",
-                    f"  RayCon scenario: {'found' if readiness.get('raycon_scenario_found') else 'not yet posted'}",
+                    f"  RayCon scenario: {raycon_status_label}",
+                    f"  RayCon failure: {raycon_failure_reason}" if raycon_failure_reason else "",
                     "",
                     "Ready for first-round report generation." if ready_for_report else (
                         "Not ready - " + ", ".join(missing_docs) + " missing." if missing_docs else "Report already exists."
@@ -3020,11 +3074,24 @@ def _build_blocking_entries(
         bi_present = bool(readiness.get("inspection_found"))
 
     raycon_present = bool(readiness.get("raycon_scenario_found"))
+    raycon_usable = bool(readiness.get("raycon_scenario_usable", raycon_present))
+    raycon_failed = raycon_present and not raycon_usable
 
     raycon_entry: dict[str, Any] = {
         "doc": "raycon_scenario",
-        "status": "present" if raycon_present else "pending",
+        "status": (
+            str(readiness.get("raycon_scenario_status") or "failed_validation")
+            if raycon_failed
+            else ("present" if raycon_present else "pending")
+        ),
     }
+    if raycon_failed:
+        raycon_entry["failure_reason"] = str(
+            readiness.get("raycon_scenario_failure_reason") or ""
+        )
+        raycon_entry["raycon_run_id"] = str(
+            readiness.get("raycon_scenario_run_id") or ""
+        )
     if not raycon_present:
         raycon_entry["block_plan_present"] = block_plan_present
         raycon_entry["last_dispatch"] = raycon_last_dispatch
@@ -3180,6 +3247,8 @@ async def diagnose_site_readiness(
 
             block_plan_present = block_plan_file_id is not None
             raycon_present = bool(readiness.get("raycon_scenario_found"))
+            raycon_usable = bool(readiness.get("raycon_scenario_usable", raycon_present))
+            raycon_failed = raycon_present and not raycon_usable
 
             # Resolve last_dispatch:
             #   1. If RayCon scenario is present, the dispatch already
@@ -3239,6 +3308,10 @@ async def diagnose_site_readiness(
 
             projection = project_completeness_from_readiness(
                 raycon_scenario_found=raycon_present,
+                raycon_scenario_failed=raycon_failed,
+                raycon_failure_reason=str(
+                    readiness.get("raycon_scenario_failure_reason") or ""
+                ).strip(),
             )
             pending_paths: list[str] = []
             for paths in projection.get("pending_reasons", {}).values():

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from due_diligence_reporter import completeness as completeness_module
 from due_diligence_reporter.completeness import (
+    RAYCON_FAILED_REASON,
     RAYCON_PENDING_REASON,
     REASON_DISPLAY_LABELS,
     VENDOR_VERIFICATION_PENDING_REASON,
@@ -11,6 +12,7 @@ from due_diligence_reporter.completeness import (
     compute_completeness_block,
     is_raycon_pending_placeholder,
     project_completeness_from_readiness,
+    raycon_placeholder_reason,
     raycon_token_paths,
 )
 from due_diligence_reporter.google_doc_builder import format_partial_banner_text
@@ -29,6 +31,15 @@ class TestIsRayconPendingPlaceholder:
     def test_max_capacity_placeholder(self) -> None:
         assert is_raycon_pending_placeholder(
             "[Not found - Max Capacity scenario not extracted]"
+        )
+
+    def test_generic_raycon_pending_placeholder(self) -> None:
+        assert is_raycon_pending_placeholder("[Not found - RayCon scenario pending]")
+
+    def test_failed_placeholder_has_failed_reason(self) -> None:
+        assert (
+            raycon_placeholder_reason("[Not found - RayCon validation failed]")
+            == RAYCON_FAILED_REASON
         )
 
     def test_real_value_is_not_placeholder(self) -> None:
@@ -144,6 +155,19 @@ class TestComputeCompletenessBlock:
             VERIFICATION_OPEN_ITEMS_TOKEN
         ]
 
+    def test_raycon_failure_reason_marks_blank_raycon_tokens_failed(self) -> None:
+        replacements = dict.fromkeys(raycon_token_paths(), "")
+        block = compute_completeness_block(
+            replacements,
+            raycon_failure_reason="capacity_not_defensible",
+        )
+
+        assert block["stage"] == "partial"
+        assert block["pending_token_count"] == 28
+        assert block["auto_republish_on"] == ["valid raycon_scenario.json"]
+        assert RAYCON_FAILED_REASON in block["pending_reasons"]
+        assert block["raycon_failure_reason"] == "capacity_not_defensible"
+
 
 class TestProjectCompletenessFromReadiness:
     def test_raycon_missing_projects_partial(self) -> None:
@@ -160,6 +184,18 @@ class TestProjectCompletenessFromReadiness:
         assert block["pending_token_count"] == 0
         assert block["pending_reasons"] == {}
         assert block["auto_republish_on"] == []
+
+    def test_raycon_failed_projects_failed_partial(self) -> None:
+        block = project_completeness_from_readiness(
+            raycon_scenario_found=True,
+            raycon_scenario_failed=True,
+            raycon_failure_reason="capacity_not_defensible",
+        )
+        assert block["stage"] == "partial"
+        assert block["pending_token_count"] == 28
+        assert block["pending_reasons"].keys() == {RAYCON_FAILED_REASON}
+        assert block["auto_republish_on"] == ["valid raycon_scenario.json"]
+        assert block["raycon_failure_reason"] == "capacity_not_defensible"
 
     def test_verification_open_items_pending_projects_partial(self) -> None:
         block = project_completeness_from_readiness(
@@ -209,6 +245,18 @@ class TestFormatPartialBannerText:
             block_plan_submitted_display="2026-05-07 13:42 UTC",
         )
         assert "Vendor verification" in text
+        assert "Block Plan submitted" not in text
+
+    def test_partial_with_raycon_failure_shows_failure_reason(self) -> None:
+        block = {
+            "stage": "partial",
+            "pending_reasons": {RAYCON_FAILED_REASON: ["exec.fastest_open_capex"]},
+            "auto_republish_on": ["valid raycon_scenario.json"],
+            "raycon_failure_reason": "capacity_not_defensible",
+        }
+        text = format_partial_banner_text(block)
+        assert "RayCon validation failed" in text
+        assert "capacity_not_defensible" in text
         assert "Block Plan submitted" not in text
 
     def test_partial_falls_back_when_timestamp_missing(self) -> None:

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -481,6 +481,32 @@ class TestReportNormalizationDefaults:
         assert replacements["exec.max_capacity_capex"] == "[Not found - Max Capacity scenario not extracted]"
         assert "exec.max_value_capacity" not in replacements
 
+    def test_normalize_report_replacements_marks_failed_raycon_tokens(self) -> None:
+        from due_diligence_reporter.server import _normalize_report_replacements
+
+        replacements, _, _, _, _ = _normalize_report_replacements(
+            report_data={
+                "exec": {
+                    "raycon_status": "failed",
+                    "raycon_failure_reason": "capacity_not_defensible",
+                    "fastest_open_capex": "$401,000",
+                    "cost_grand_total_fastest_open": "$401,000",
+                },
+            },
+            site_name="Alpha Tulsa 6940 S Utica Ave",
+            report_date="05/28/2026",
+            drive_folder_url="https://drive.google.com/drive/folders/folder123",
+        )
+
+        assert (
+            replacements["exec.fastest_open_capex"]
+            == "[Not found - RayCon validation failed]"
+        )
+        assert (
+            replacements["exec.cost_grand_total_fastest_open"]
+            == "[Not found - RayCon validation failed]"
+        )
+
     def test_normalize_report_replacements_preserves_verification_open_items(self) -> None:
         from due_diligence_reporter.google_doc_builder import VERIFICATION_OPEN_ITEMS_KEY
         from due_diligence_reporter.server import _normalize_report_replacements

--- a/tests/test_diagnose_site_readiness.py
+++ b/tests/test_diagnose_site_readiness.py
@@ -30,8 +30,14 @@ def _readiness(
     inspection_found: bool = True,
     inspection_vendor: bool = True,
     raycon_scenario_found: bool = True,
+    raycon_scenario_usable: bool | None = None,
+    raycon_scenario_status: str = "",
+    raycon_scenario_failure_reason: str = "",
+    raycon_scenario_run_id: str = "",
     report_exists: bool = False,
 ) -> dict:
+    if raycon_scenario_usable is None:
+        raycon_scenario_usable = raycon_scenario_found
     return {
         "sir_found": sir_found,
         "sir_vendor": sir_vendor,
@@ -39,6 +45,10 @@ def _readiness(
         "inspection_vendor": inspection_vendor,
         "isp_found": False,
         "raycon_scenario_found": raycon_scenario_found,
+        "raycon_scenario_usable": raycon_scenario_usable,
+        "raycon_scenario_status": raycon_scenario_status,
+        "raycon_scenario_failure_reason": raycon_scenario_failure_reason,
+        "raycon_scenario_run_id": raycon_scenario_run_id,
         "report_exists": report_exists,
         "e_occupancy_report_found": False,
         "school_approval_report_found": False,
@@ -331,6 +341,45 @@ def test_raycon_scenario_present_uses_run_timestamp(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # 5. Unknown site → graceful error response, not a crash.
 # ---------------------------------------------------------------------------
+
+
+def test_raycon_scenario_failed_is_not_full_report_ready(tmp_path, monkeypatch):
+    _vendor_gate_on(monkeypatch)
+    _no_dispatch_state(tmp_path, monkeypatch)
+
+    patchers = _patch_common(
+        readiness=_readiness(
+            raycon_scenario_found=True,
+            raycon_scenario_usable=False,
+            raycon_scenario_status="failed_validation",
+            raycon_scenario_failure_reason="capacity_not_defensible",
+            raycon_scenario_run_id="rc_failed",
+        ),
+        m1_docs={
+            "block_plan": {"id": "bp-1", "modifiedTime": "2026-05-07T13:00:00Z"},
+            "raycon_scenario_json": {
+                "id": "rs-1",
+                "modifiedTime": "2026-05-07T13:30:00Z",
+            },
+        },
+    )
+    _enter_all(patchers)
+    try:
+        result = _run()
+    finally:
+        _stop_all(patchers)
+
+    assert result["ready_for_full_report"] is False
+    raycon_entry = next(b for b in result["blocking"] if b["doc"] == "raycon_scenario")
+    assert raycon_entry["status"] == "failed_validation"
+    assert raycon_entry["failure_reason"] == "capacity_not_defensible"
+    assert raycon_entry["raycon_run_id"] == "rc_failed"
+    assert result["projected_completeness"]["pending_reasons"] == {
+        "raycon_scenario_failed": result["would_be_pending"]
+    }
+    assert result["pending_reason_labels"] == {
+        "raycon_scenario_failed": "RayCon validation failed"
+    }
 
 
 def test_missing_drive_url_returns_graceful_error(tmp_path, monkeypatch):

--- a/tests/test_raycon_client.py
+++ b/tests/test_raycon_client.py
@@ -1073,6 +1073,23 @@ class TestRayConPayloadEnvelope:
         assert fields["exec.raycon_status"] == "failed"
         assert "no_address_match" in fields["exec.raycon_failure_reason"]
 
+    def test_validation_failed_status_blanks_all_scenario_fields(self) -> None:
+        payload = {
+            "schema_version": "1.0",
+            "status": "validation_failed",
+            "analysis": {
+                "fastest_open": {"grand_total": 100, "timeline_weeks": 4},
+                "max_capacity": {"grand_total": 200, "timeline_weeks": 8},
+            },
+            "validation": {"passed": True, "errors": []},
+        }
+
+        fields = raycon_scenario_to_report_fields(payload)
+
+        assert fields["exec.fastest_open_capex"] == ""
+        assert fields["exec.max_capacity_capex"] == ""
+        assert fields["exec.raycon_status"] == "validation_failed"
+
     def test_failed_via_validation_passed_false_blanks_scenarios(self) -> None:
         """Status optimistic but validation says no — still treat as failure."""
         payload = {

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -470,8 +470,11 @@ class TestFailedScenarioAlerts:
 
         assert row["dispatched"] is True
         assert row["dispatch_reason"] == "failed_scenario_retry"
+        assert "raycon run failed" in row["alert"]
         assert "microschool tier" in row["previous_failure"]
         assert row["job_id"] == "job-retry"
+        assert row["raycon_run_id"] == "rc_old"
+        assert "failed_scenario:rc_old" in row["alert_dedup_key"]
         assert dispatch_state["bp_file_1"]["job_id"] == "job-retry"
         mock_post.assert_called_once()
         mock_save.assert_not_called()

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 from due_diligence_reporter.report_pipeline import (
@@ -1062,6 +1063,53 @@ class TestCheckSiteReadinessDirect:
         )
         assert result_empty["sir_found"] is True
 
+    @patch("due_diligence_reporter.report_pipeline._list_m1_documents_by_type")
+    @patch("due_diligence_reporter.report_pipeline._resolve_m1_folder")
+    def test_failed_raycon_json_is_not_usable_for_full_report(
+        self,
+        mock_resolve_m1,
+        mock_list_m1,
+    ):
+        mock_resolve_m1.return_value = ("m1-folder-id", "M1")
+        mock_list_m1.return_value = {
+            "raycon_scenario_json": {
+                "id": "raycon-json-1",
+                "name": "raycon_scenario.json",
+                "modifiedTime": "2026-05-28T14:00:00Z",
+            }
+        }
+        gc = MagicMock()
+        gc.list_files_recursive.return_value = []
+        gc.download_file_bytes.return_value = json.dumps(
+            {
+                "schema_version": "1.0",
+                "status": "failed",
+                "raycon_run_id": "rc_failed",
+                "validation": {
+                    "passed": False,
+                    "errors": ["capacity_not_defensible"],
+                },
+            }
+        ).encode("utf-8")
+
+        result = check_site_readiness_direct(
+            gc,
+            "https://drive.google.com/drive/folders/abc123",
+            ["Alpha Tulsa 6940 S Utica Ave"],
+            {"sir": [], "isp": [], "building_inspection": []},
+            site_title="Alpha Tulsa 6940 S Utica Ave",
+        )
+
+        assert result["raycon_scenario_found"] is True
+        assert result["raycon_scenario_usable"] is False
+        assert result["raycon_scenario_status"] == "failed_validation"
+        assert result["raycon_scenario_run_id"] == "rc_failed"
+        assert "capacity_not_defensible" in result["raycon_scenario_failure_reason"]
+        assert (
+            result["raycon_report_data_fields"]["exec.raycon_failure_reason"]
+            == "capacity_not_defensible"
+        )
+
 
 # ---------------------------------------------------------------------------
 # PipelineResult dataclass
@@ -1106,6 +1154,28 @@ class TestAgentToolMerging:
 
         assert merged["report_data"]["exec.fastest_open_capex"] == "$100,000"
         assert merged["report_data"]["exec.cost_demolition_fastest_open"] == "$0"
+
+    def test_failed_raycon_cached_fields_override_agent_values(self):
+        merged = _merge_cached_report_fields(
+            {
+                "report_data": {
+                    "exec.fastest_open_capex": "$100,000",
+                    "exec.raycon_status": "completed",
+                },
+            },
+            {
+                "exec.raycon_status": "failed",
+                "exec.raycon_failure_reason": "capacity_not_defensible",
+                "exec.fastest_open_capex": "",
+            },
+        )
+
+        assert merged["report_data"]["exec.raycon_status"] == "failed"
+        assert (
+            merged["report_data"]["exec.raycon_failure_reason"]
+            == "capacity_not_defensible"
+        )
+        assert merged["report_data"]["exec.fastest_open_capex"] == ""
 
     @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
     @patch("due_diligence_reporter.report_pipeline.route_tool_call_sync")

--- a/tests/test_vendor_gate.py
+++ b/tests/test_vendor_gate.py
@@ -95,6 +95,20 @@ class TestMissingRequiredDocsVendorGate:
         }
         assert _missing_required_docs(readiness) == ["RayCon Scenario JSON"]
 
+    def test_blocks_when_raycon_json_failed_validation(self):
+        readiness = {
+            "sir_found": True,
+            "sir_vendor": True,
+            "inspection_found": True,
+            "inspection_vendor": True,
+            "raycon_scenario_found": True,
+            "raycon_scenario_usable": False,
+            "raycon_scenario_status": "failed_validation",
+        }
+        assert _missing_required_docs(readiness) == [
+            "Successful RayCon Scenario JSON"
+        ]
+
     def test_blocks_when_inspection_is_ai_only(self):
         readiness = {
             "sir_found": True,


### PR DESCRIPTION
## Summary
- Classify failed RayCon scenario JSONs as failed validation instead of usable full-report inputs.
- Render failed RayCon state explicitly in DDR completeness/banners and override agent RayCon values with authoritative failed payload fields.
- Keep failed-scenario retry rows on the RayCon follow-up alert path so Rhodes owner notes or Google Chat fallback happen even when an automatic retry dispatches.

## Verification
- uv run python -m py_compile src\due_diligence_reporter\raycon_client.py src\due_diligence_reporter\completeness.py src\due_diligence_reporter\google_doc_builder.py src\due_diligence_reporter\server.py src\due_diligence_reporter\report_pipeline.py scripts\raycon_followup.py
- uv run pytest --basetemp C:\tmp\ddr-raycon-failed-state-final2 tests/test_raycon_client.py tests/test_completeness.py tests/test_dd_output_fixes.py tests/test_vendor_gate.py tests/test_report_pipeline.py tests/test_diagnose_site_readiness.py tests/test_raycon_followup.py tests/test_google_doc_builder.py tests/test_dd_republish.py tests/test_rhodes_events.py -q
- uv run ruff check src\due_diligence_reporter\raycon_client.py src\due_diligence_reporter\completeness.py src\due_diligence_reporter\google_doc_builder.py src\due_diligence_reporter\server.py src\due_diligence_reporter\report_pipeline.py scripts\raycon_followup.py tests\test_raycon_client.py tests\test_completeness.py tests\test_dd_output_fixes.py tests\test_vendor_gate.py tests\test_report_pipeline.py tests\test_diagnose_site_readiness.py tests\test_raycon_followup.py
- uv run mypy src/
- git diff --check