### PR TITLE
[codex] Enforce RayCon alert delivery

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -23,6 +23,8 @@ Live findings:
 
 Branch: `codex/raycon-alert-delivery-enforced`
 
+Draft PR: https://github.com/GFooteGK1/due-diligence-reporter/pull/129
+
 Changed:
 
 - RayCon follow-up now logs sanitized Rhodes/Chat notification status for each
@@ -49,7 +51,7 @@ Results:
 
 Next:
 
-- Open PR for `codex/raycon-alert-delivery-enforced`.
+- Wait for CI/review on PR #129.
 - After merge, rerun RayCon Follow-up for `6940 S Utica` and
   `2340 Calle de Luna`. If Rhodes note creation still fails, the workflow
   should fail and log the exact `raycon_followup_event` status instead of

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,60 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Alert Delivery Enforcement
+
+Tested PR #128 after merge on `main` at
+`164caac02d8c82582a4bd190fce105c32b3493ea`:
+
+- Tulsa manual run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26577057390
+- Santa Clara manual run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26577064119
+
+Live findings:
+
+- Both runs completed successfully.
+- Both runs detected the failed `raycon_scenario.json` and resolved Devin Bates
+  as the P1 owner.
+- Rhodes readback showed no new site note and no `note.added` audit entry for
+  either Tulsa or Santa Clara.
+- Workflow logs showed `published=0 alerts=1 errors=0`; the alert row existed,
+  but notification delivery was not visible in the logs and did not affect the
+  workflow exit code.
+
+Branch: `codex/raycon-alert-delivery-enforced`
+
+Changed:
+
+- RayCon follow-up now logs sanitized Rhodes/Chat notification status for each
+  fresh alert/error row.
+- Owner-assigned rows only count as delivered when Rhodes creates the note and
+  mentions the owner. A Google Chat post no longer advances alert dedupe for an
+  owner-assigned row whose owner notification failed.
+- Fresh alert/error rows with undelivered notifications now make the workflow
+  exit non-zero instead of completing green.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-followup
+uv run ruff check scripts/raycon_followup.py tests/test_raycon_followup.py
+uv run mypy scripts/raycon_followup.py
+```
+
+Results:
+
+- RayCon follow-up test file: 58 passed.
+- Ruff on touched files: passed.
+- Script Mypy: no issues.
+
+Next:
+
+- Open PR for `codex/raycon-alert-delivery-enforced`.
+- After merge, rerun RayCon Follow-up for `6940 S Utica` and
+  `2340 Calle de Luna`. If Rhodes note creation still fails, the workflow
+  should fail and log the exact `raycon_followup_event` status instead of
+  silently reporting success.
+
 ## 2026-05-28 - RayCon Failed Alert Backfill
 
 Confirmed PR #127 was merged at `cefda5c` and tested the production RayCon

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -322,8 +322,17 @@ def _raycon_followup_notification_succeeded(row: dict[str, Any]) -> bool:
         return False
     if event_status.get("owner_notification") == "mentioned":
         return True
+    if _row_has_site_owner(row):
+        return False
     google_chat = event_status.get("google_chat")
     return isinstance(google_chat, dict) and google_chat.get("status") == "posted"
+
+
+def _row_has_site_owner(row: dict[str, Any]) -> bool:
+    return bool(
+        str(row.get("p1_assignee_user_id") or "").strip()
+        or str(row.get("p1_assignee_email") or "").strip()
+    )
 
 
 def _mark_notified_alerts(
@@ -609,7 +618,7 @@ def _notify_raycon_followup_rows(
     alert_type: str,
     message_field: str,
     heading: str,
-) -> None:
+) -> list[dict[str, Any]]:
     chat_bodies: list[str] = []
     chat_rows: list[dict[str, Any]] = []
     for row in rows:
@@ -623,12 +632,20 @@ def _notify_raycon_followup_rows(
             message=message,
         )
         row["raycon_followup_event"] = event_status
+        logger.info(
+            "RayCon follow-up notification status: %s",
+            json.dumps(_notification_status_summary(row, event_status), default=str),
+        )
         if should_alert_google_chat(event_status):
             chat_bodies.append(body)
             chat_rows.append(row)
 
     if not chat_bodies:
-        return
+        return [
+            row
+            for row in rows
+            if row.get(message_field) and not _raycon_followup_notification_succeeded(row)
+        ]
 
     webhook_url = str(getattr(settings, "google_chat_webhook_url", "") or "").strip()
     chat_result: dict[str, str]
@@ -642,6 +659,36 @@ def _notify_raycon_followup_rows(
         stored_event_status = row.get("raycon_followup_event")
         if isinstance(stored_event_status, dict):
             stored_event_status["google_chat"] = chat_result
+            logger.info(
+                "RayCon follow-up Chat fallback status: %s",
+                json.dumps(
+                    _notification_status_summary(row, stored_event_status),
+                    default=str,
+                ),
+            )
+
+    return [
+        row
+        for row in rows
+        if row.get(message_field) and not _raycon_followup_notification_succeeded(row)
+    ]
+
+
+def _notification_status_summary(
+    row: dict[str, Any],
+    event_status: dict[str, Any],
+) -> dict[str, Any]:
+    google_chat = event_status.get("google_chat")
+    return {
+        "site": row.get("site"),
+        "site_id": row.get("site_id"),
+        "owner_assigned": _row_has_site_owner(row),
+        "status": event_status.get("status"),
+        "reason": event_status.get("reason"),
+        "owner_notification": event_status.get("owner_notification"),
+        "rhodes_note_id": event_status.get("rhodes_note_id"),
+        "google_chat": google_chat if isinstance(google_chat, dict) else None,
+    }
 
 
 def _dispatch_raycon_job(
@@ -1516,17 +1563,20 @@ def main(argv: list[str] | None = None) -> int:
 
     alert_state_changed = False
     dedup_state = _load_alert_state() if alerts or errors else {}
+    notification_failures: list[dict[str, Any]] = []
 
     if alerts:
         fresh_alerts = _fresh_dedup_alerts(alerts, dedup_state)
         if fresh_alerts:
-            _notify_raycon_followup_rows(
-                fresh_alerts,
-                settings,
-                run_id=event_run_id,
-                alert_type="stuck_site",
-                message_field="alert",
-                heading="RayCon scenario follow-up: stuck sites",
+            notification_failures.extend(
+                _notify_raycon_followup_rows(
+                    fresh_alerts,
+                    settings,
+                    run_id=event_run_id,
+                    alert_type="stuck_site",
+                    message_field="alert",
+                    heading="RayCon scenario follow-up: stuck sites",
+                )
             )
             new_state = _mark_notified_alerts(fresh_alerts, dedup_state)
             alert_state_changed = alert_state_changed or new_state != dedup_state
@@ -1544,13 +1594,15 @@ def main(argv: list[str] | None = None) -> int:
             row["alert_dedup_key"] = _error_alert_dedup_key(row)
         fresh_errors = _fresh_dedup_alerts(errors, dedup_state)
         if fresh_errors:
-            _notify_raycon_followup_rows(
-                fresh_errors,
-                settings,
-                run_id=event_run_id,
-                alert_type="error",
-                message_field="error",
-                heading="RayCon scenario follow-up: errors",
+            notification_failures.extend(
+                _notify_raycon_followup_rows(
+                    fresh_errors,
+                    settings,
+                    run_id=event_run_id,
+                    alert_type="error",
+                    message_field="error",
+                    heading="RayCon scenario follow-up: errors",
+                )
             )
             new_state = _mark_notified_alerts(fresh_errors, dedup_state)
             alert_state_changed = alert_state_changed or new_state != dedup_state
@@ -1566,6 +1618,21 @@ def main(argv: list[str] | None = None) -> int:
     if alert_state_changed:
         _save_alert_state(dedup_state)
 
+    if notification_failures:
+        for row in notification_failures:
+            logger.error(
+                "RayCon follow-up notification delivery failed: %s",
+                json.dumps(
+                    {
+                        "site": row.get("site"),
+                        "site_id": row.get("site_id"),
+                        "owner_assigned": _row_has_site_owner(row),
+                        "raycon_followup_event": row.get("raycon_followup_event"),
+                    },
+                    default=str,
+                ),
+            )
+
     logger.info(
         "Run complete: published=%d dispatched=%d alerts=%d errors=%d total_sites=%d",
         len(published),
@@ -1574,7 +1641,7 @@ def main(argv: list[str] | None = None) -> int:
         len(errors),
         len(results),
     )
-    return 0 if not errors else 1
+    return 0 if not errors and not notification_failures else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -1130,6 +1130,14 @@ class TestNotificationDedupState:
                 },
             },
             {
+                "site": "Owner Failed Chat Posted",
+                "p1_assignee_user_id": "user-1",
+                "raycon_followup_event": {
+                    "owner_notification": "none",
+                    "google_chat": {"status": "posted"},
+                },
+            },
+            {
                 "site": "Not Delivered",
                 "raycon_followup_event": {
                     "owner_notification": "none",
@@ -1142,6 +1150,7 @@ class TestNotificationDedupState:
 
         assert new_state["Owner Mentioned"] == now.isoformat()
         assert new_state["Chat Posted"] == now.isoformat()
+        assert "Owner Failed Chat Posted" not in new_state
         assert "Not Delivered" not in new_state
 
 
@@ -1172,7 +1181,7 @@ class TestRayConFollowupEventNotification:
             }
         ]
 
-        _notify_raycon_followup_rows(
+        failures = _notify_raycon_followup_rows(
             rows,
             SimpleNamespace(google_chat_webhook_url="https://chat.example/hook"),
             run_id="raycon-followup-20260527213000",
@@ -1186,6 +1195,7 @@ class TestRayConFollowupEventNotification:
         assert mock_add_note.call_args.kwargs["owner_user_id"] == "user-1"
         assert "Kind: raycon_followup_alert" in mock_add_note.call_args.kwargs["body"]
         mock_post_chat.assert_not_called()
+        assert failures == []
         assert rows[0]["raycon_followup_event"]["rhodes_note_id"] == "note-1"
         assert rows[0]["raycon_followup_event"]["owner_notification"] == "mentioned"
 
@@ -1211,7 +1221,7 @@ class TestRayConFollowupEventNotification:
             }
         ]
 
-        _notify_raycon_followup_rows(
+        failures = _notify_raycon_followup_rows(
             rows,
             SimpleNamespace(google_chat_webhook_url="https://chat.example/hook"),
             run_id="raycon-followup-20260527213000",
@@ -1227,6 +1237,48 @@ class TestRayConFollowupEventNotification:
         assert "Kind: raycon_followup_alert" in chat_body
         assert "Mutation status: error" in chat_body
         assert "Message: raycon dispatch: RayCon 503" in chat_body
+        assert rows[0]["raycon_followup_event"]["google_chat"] == {
+            "status": "posted"
+        }
+        assert failures == []
+
+    @patch("scripts.raycon_followup._post_chat")
+    @patch("scripts.raycon_followup.add_rhodes_site_note")
+    def test_owner_note_failure_remains_delivery_failure_even_with_chat(
+        self,
+        mock_add_note,
+        mock_post_chat,
+    ):
+        mock_add_note.return_value = {
+            "status": "failed",
+            "reason": "rhodes_error",
+            "error": "Rhodes MCP returned 403",
+            "owner_user_id": "user-1",
+            "owner_notification": "none",
+        }
+        rows = [
+            {
+                "site": "Alpha Keller",
+                "site_id": "SITE1",
+                "alert": "raycon run failed: validation rejected capacity",
+                "drive_folder_url": "https://drive.google.com/drive/folders/abc123",
+                "p1_assignee_user_id": "user-1",
+                "p1_assignee_email": "owner@example.com",
+            }
+        ]
+
+        failures = _notify_raycon_followup_rows(
+            rows,
+            SimpleNamespace(google_chat_webhook_url="https://chat.example/hook"),
+            run_id="raycon-followup-20260527213000",
+            alert_type="stuck_site",
+            message_field="alert",
+            heading="RayCon scenario follow-up: stuck sites",
+        )
+
+        mock_add_note.assert_called_once()
+        mock_post_chat.assert_called_once()
+        assert failures == rows
         assert rows[0]["raycon_followup_event"]["google_chat"] == {
             "status": "posted"
         }


### PR DESCRIPTION
## What changed
- Logs sanitized RayCon alert notification status for each fresh alert/error row.
- Treats owner-assigned alerts as delivered only when Rhodes creates the note and mentions the owner.
- Keeps Chat as the no-owner fallback, but no longer lets Chat posting suppress future owner retries when an owner was assigned.
- Fails the workflow when fresh alert/error notification delivery fails, so the run cannot finish green without an owner note or valid no-owner Chat fallback.

## Why
Testing PR #128 on Tulsa and Santa Clara showed the failed RayCon scenarios were detected and Devin was resolved as P1 owner, but no Rhodes note was created and the workflow still completed successfully with `alerts=1 errors=0`.

## Validation
- `uv run pytest tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-followup`
- `uv run ruff check scripts/raycon_followup.py tests/test_raycon_followup.py`
- `uv run mypy scripts/raycon_followup.py`