### PR TITLE
Require verified Rhodes note IDs

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,63 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Note ID Verification
+
+Confirmed PR #130 was merged at `e7227be` and tested the merged RayCon
+extra-mention path on `main`.
+
+Live test:
+
+- First rerun pair was dedup-suppressed by restored RayCon runtime alert state.
+- Cleared only the four relevant `raycon-runtime-state-*` GitHub Actions cache
+  entries from today's test runs.
+- Second Tulsa run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26580325911
+- Second Santa Clara run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26580325718
+- Both second runs completed successfully and logged
+  `owner_notification: mentioned` with Devin Bates plus Greg Foote in
+  `mentioned_user_ids`.
+- The log status also had an empty `rhodes_note_id`, and live Rhodes
+  `listNotes` / audit-log checks showed no new RayCon note on either site.
+  The workflow was therefore falsely treating a no-ID `addNote` response as a
+  verified owner notification.
+
+Branch: `codex/raycon-note-id-required`
+
+Changed:
+
+- `add_rhodes_site_note` now treats an `addNote` response without a concrete
+  note ID as `failed` with reason `missing_note_id`.
+- Shared Rhodes/Chat fallback logic now requires a created Rhodes note ID before
+  considering an owner mention delivered.
+- RayCon alert dedupe now advances only when the owner mention has a concrete
+  Rhodes note ID, or when the no-owner Chat fallback posts.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-id
+uv run ruff check src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\rhodes_events.py scripts\raycon_followup.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py
+uv run mypy src/
+uv run mypy scripts/raycon_followup.py
+```
+
+Results:
+
+- Focused Rhodes/RayCon suite: 80 passed.
+- Ruff on touched code/tests: passed.
+- Source Mypy: no issues in 38 source files.
+- Script Mypy: no issues.
+
+Next:
+
+- Open PR for `codex/raycon-note-id-required`.
+- After merge, rerun RayCon Follow-up for Tulsa/Santa Clara again. Expected
+  behavior if Rhodes still returns no note ID: workflow fails and posts Chat
+  fallback instead of suppressing future retries.
+- Keep `RAYCON_FOLLOWUP_EXTRA_MENTION_USER_IDS` set to Greg's user ID until a
+  retest confirms the notification is actually delivered; then clear it.
+
 ## 2026-05-28 - RayCon Test Extra Mention
 
 Confirmed PR #129 merged at `d54462d` and continued from updated `main`.

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -320,7 +320,11 @@ def _raycon_followup_notification_succeeded(row: dict[str, Any]) -> bool:
     event_status = row.get("raycon_followup_event")
     if not isinstance(event_status, dict):
         return False
-    if event_status.get("owner_notification") == "mentioned":
+    if (
+        event_status.get("status") == "created"
+        and event_status.get("owner_notification") == "mentioned"
+        and str(event_status.get("rhodes_note_id") or "").strip()
+    ):
         return True
     if _row_has_site_owner(row):
         return False

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -829,11 +829,24 @@ def add_rhodes_site_note(
     except Exception as exc:  # noqa: BLE001 - non-fatal scanner side effect
         return {**base, "status": "failed", "reason": "unexpected_error", "error": str(exc)}
 
+    note_id = _note_id(note)
+    if not note_id:
+        return {
+            **base,
+            "status": "failed",
+            "reason": "missing_note_id",
+            "error": "Rhodes addNote returned no note ID; delivery could not be verified",
+            "rhodes_note_id": "",
+            "owner_user_id": resolved_owner_user_id,
+            "owner_resolution": owner_resolution,
+            "mentioned_user_ids": mention_user_ids,
+        }
+
     return {
         **base,
         "status": "created",
         "reason": "ok",
-        "rhodes_note_id": _note_id(note),
+        "rhodes_note_id": note_id,
         "owner_user_id": resolved_owner_user_id,
         "owner_resolution": owner_resolution,
         "owner_notification": "mentioned" if resolved_owner_user_id else "none",

--- a/src/due_diligence_reporter/rhodes_events.py
+++ b/src/due_diligence_reporter/rhodes_events.py
@@ -63,9 +63,13 @@ def should_alert_google_chat(
 
     if not decision_required:
         return False
-    return event_status.get("status") != "created" or (
-        event_status.get("owner_notification") != "mentioned"
+    note_id = str(event_status.get("rhodes_note_id") or "").strip()
+    owner_notified = (
+        event_status.get("status") == "created"
+        and event_status.get("owner_notification") == "mentioned"
+        and bool(note_id)
     )
+    return not owner_notified
 
 
 def post_google_chat_to_configured_webhooks(

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -1120,7 +1120,19 @@ class TestNotificationDedupState:
         rows = [
             {
                 "site": "Owner Mentioned",
-                "raycon_followup_event": {"owner_notification": "mentioned"},
+                "raycon_followup_event": {
+                    "status": "created",
+                    "owner_notification": "mentioned",
+                    "rhodes_note_id": "NOTE1",
+                },
+            },
+            {
+                "site": "Owner Mentioned Without Note ID",
+                "raycon_followup_event": {
+                    "status": "created",
+                    "owner_notification": "mentioned",
+                    "rhodes_note_id": "",
+                },
             },
             {
                 "site": "Chat Posted",
@@ -1150,6 +1162,7 @@ class TestNotificationDedupState:
 
         assert new_state["Owner Mentioned"] == now.isoformat()
         assert new_state["Chat Posted"] == now.isoformat()
+        assert "Owner Mentioned Without Note ID" not in new_state
         assert "Owner Failed Chat Posted" not in new_state
         assert "Not Delivered" not in new_state
 

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -18,10 +18,12 @@ class FakeRhodesClient:
         site: dict[str, Any] | None = None,
         sites: list[dict[str, Any]] | None = None,
         drive_root: tuple[str, str] | Exception | None = None,
+        note_response: dict[str, Any] | None = None,
     ) -> None:
         self.site = site or {}
         self.sites = sites or []
         self.drive_root = drive_root
+        self.note_response = note_response
         self.documents: list[dict[str, Any]] = []
         self.registered_documents: list[dict[str, Any]] = []
         self.notes: list[dict[str, Any]] = []
@@ -142,6 +144,8 @@ class FakeRhodesClient:
                 },
             )
         )
+        if self.note_response is not None:
+            return self.note_response
         note = {
             "_id": f"NOTE{len(self.notes) + 1}",
             "siteId": site_id,
@@ -440,6 +444,24 @@ def test_add_rhodes_site_note_mentions_owner_and_extra_users() -> None:
     assert result["owner_notification"] == "mentioned"
     assert result["mentioned_user_ids"] == ["OWNER1", "GREG1"]
     assert client.notes[0]["mentions"] == ["OWNER1", "GREG1"]
+
+
+def test_add_rhodes_site_note_requires_returned_note_id() -> None:
+    client = FakeRhodesClient(note_response={"text": "created"})
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        body="AutomationEvent v1\nKind: raycon_followup_alert",
+        owner_user_id="OWNER1",
+        extra_mention_user_ids=["GREG1"],
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "failed"
+    assert result["reason"] == "missing_note_id"
+    assert result["owner_notification"] == "none"
+    assert result["rhodes_note_id"] == ""
+    assert result["mentioned_user_ids"] == ["OWNER1", "GREG1"]
 
 
 def test_add_rhodes_site_note_resolves_owner_email() -> None:

--- a/tests/test_rhodes_events.py
+++ b/tests/test_rhodes_events.py
@@ -95,7 +95,18 @@ def test_record_rhodes_automation_event_skips_missing_site_id() -> None:
 
 def test_should_alert_google_chat_requires_decision_and_owner_notification() -> None:
     assert not should_alert_google_chat(
-        {"status": "created", "owner_notification": "mentioned"}
+        {
+            "status": "created",
+            "owner_notification": "mentioned",
+            "rhodes_note_id": "NOTE1",
+        }
+    )
+    assert should_alert_google_chat(
+        {
+            "status": "created",
+            "owner_notification": "mentioned",
+            "rhodes_note_id": "",
+        }
     )
     assert should_alert_google_chat({"status": "failed", "owner_notification": "none"})
     assert should_alert_google_chat(


### PR DESCRIPTION
## Summary
- Treat Rhodes addNote responses without a concrete note ID as failed instead of created.
- Require a Rhodes note ID before owner mentions satisfy Chat fallback or RayCon alert dedupe.
- Record the live Tulsa/Santa Clara false-positive test evidence in HANDOFF.md.

## Live finding
The merged PR #130 test logged owner_notification=mentioned for Devin plus Greg, but rhodes_note_id was empty and live Rhodes listNotes/audit showed no new RayCon note on either site. This PR fails closed so the next rerun will fail and/or Chat-fallback instead of suppressing retries when note delivery is unverifiable.

## Verification
- uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-id
- uv run ruff check src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\rhodes_events.py scripts\raycon_followup.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py
- uv run mypy src/
- uv run mypy scripts/raycon_followup.py