### PR TITLE
Recover Rhodes note IDs after empty addNote responses

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,69 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Rhodes Note Readback / Slug Fallback
+
+Confirmed PR #131 merged at `c71de5e` and retested the merged fail-closed
+behavior on `main`.
+
+Live test:
+
+- Cleared only the relevant `raycon-runtime-state-*` cache entries from the
+  prior false-green test runs.
+- Tulsa run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26581936544
+- Santa Clara run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26581936500
+- Both runs failed closed with `missing_note_id`.
+- Both runs included Devin Bates plus Greg Foote in `mentioned_user_ids`.
+- Both runs posted the Google Chat fallback.
+- Live Rhodes `listNotes` and audit-log readback still showed no new RayCon
+  note on either site.
+
+Branch: `codex/raycon-rhodes-note-readback`
+
+Changed:
+
+- `RhodesClient` can now create/list notes by either `siteId` or `siteSlug`.
+- `add_rhodes_site_note` now attempts to recover a note ID from `listNotes`
+  after an `addNote` response with no ID.
+- If the site-ID write path still returns no ID and a slug is available, the
+  helper retries the note write with `siteSlug`, then reads back by slug.
+- RayCon follow-up now carries Rhodes `site_slug` through site context and into
+  the Rhodes note helper.
+- Regression tests cover no-ID failure, readback recovery, slug retry, and the
+  RayCon caller passing `site_slug`.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-readback
+uv run ruff check src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\rhodes_events.py scripts\raycon_followup.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py
+uv run mypy src/
+uv run mypy scripts/raycon_followup.py
+```
+
+Results:
+
+- Focused Rhodes/RayCon suite: 82 passed.
+- Ruff on touched code/tests: passed.
+- Source Mypy: no issues in 38 source files.
+- Script Mypy: no issues.
+
+Next:
+
+- Open PR for `codex/raycon-rhodes-note-readback`.
+- After merge, clear the fresh `raycon-runtime-state-*` cache entries for the
+  failed PR #131 retest runs if they would suppress the new test.
+- Rerun RayCon Follow-up for Tulsa/Santa Clara.
+- Expected outcomes:
+  - If `addNote` created a note but returned no ID, readback should recover the
+    ID and the workflow should succeed.
+  - If the `siteId` write path is the issue, the `siteSlug` retry may create the
+    note.
+  - If the remote MCP/API note-write path is truly no-op, confirmation-gated, or
+    blocked, the workflow should still fail with `missing_note_id` and post Chat
+    fallback; that would move the remaining fix to the Rhodes MCP/write surface.
+
 ## 2026-05-28 - RayCon Note ID Verification
 
 Confirmed PR #130 was merged at `e7227be` and tested the merged RayCon

--- a/scripts/raycon_followup.py
+++ b/scripts/raycon_followup.py
@@ -408,12 +408,14 @@ def _site_summary_from_rhodes_record(record: dict[str, Any]) -> dict[str, Any]:
         drive_folder_id = extract_folder_id_from_url(drive_folder_url) or ""
     site_id = str(record.get("site_id") or record.get("id") or "").strip()
     title = str(record.get("title") or record.get("name") or "").strip()
+    slug = str(record.get("slug") or "").strip()
     return {
         "id": site_id,
         "site_id": site_id,
         "title": title,
         "name": title,
-        "slug": str(record.get("slug") or "").strip(),
+        "slug": slug,
+        "site_slug": slug,
         "address": str(record.get("address") or record.get("site_address") or "").strip(),
         "drive_folder_id": drive_folder_id,
         "drive_folder_url": drive_folder_url,
@@ -567,6 +569,7 @@ def _with_site_context(
     for key in (
         "drive_folder_url",
         "drive_folder_id",
+        "site_slug",
         "p1_assignee_user_id",
         "p1_assignee_email",
         "p1_assignee_name",
@@ -611,6 +614,7 @@ def _record_raycon_followup_event(
         event,
         owner_user_id=str(row.get("p1_assignee_user_id") or "").strip(),
         owner_email=str(row.get("p1_assignee_email") or "").strip(),
+        site_slug=str(row.get("site_slug") or "").strip(),
         extra_mention_user_ids=extra_mention_user_ids,
         add_note=add_rhodes_site_note,
     )

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -173,6 +173,17 @@ def _coerce_note(payload: Any) -> dict[str, Any]:
     return {}
 
 
+def _coerce_note_list(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("notes", "data", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
 def _coerce_user(payload: Any) -> dict[str, Any]:
     if isinstance(payload, list):
         first = next((item for item in payload if isinstance(item, dict)), {})
@@ -616,20 +627,61 @@ class RhodesClient:
     def add_site_note(
         self,
         *,
-        site_id: str,
+        site_id: str = "",
+        site_slug: str = "",
         body: str,
         mentions: Iterable[str] | None = None,
     ) -> dict[str, Any]:
-        if not site_id.strip():
-            raise RhodesError("site_id is required")
+        clean_site_id = site_id.strip()
+        clean_site_slug = site_slug.strip()
+        if not clean_site_id and not clean_site_slug:
+            raise RhodesError("site_id or site_slug is required")
         if not body.strip():
             raise RhodesError("body is required")
 
-        payload: dict[str, Any] = {"siteId": site_id.strip(), "body": body.strip()}
+        payload: dict[str, Any] = {"body": body.strip()}
+        if clean_site_id:
+            payload["siteId"] = clean_site_id
+        else:
+            payload["siteSlug"] = clean_site_slug
         clean_mentions = [m.strip() for m in (mentions or []) if m.strip()]
         if clean_mentions:
             payload["mentions"] = clean_mentions
         return _coerce_note(self.call_tool("addNote", payload))
+
+    def list_notes(
+        self,
+        *,
+        site_id: str = "",
+        site_slug: str = "",
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        clean_site_id = site_id.strip()
+        clean_site_slug = site_slug.strip()
+        if not clean_site_id and not clean_site_slug:
+            raise RhodesError("site_id or site_slug is required")
+        payload: dict[str, Any] = {"limit": limit}
+        if clean_site_id:
+            payload["siteId"] = clean_site_id
+        else:
+            payload["siteSlug"] = clean_site_slug
+        return _coerce_note_list(self.call_tool("listNotes", payload))
+
+    def find_site_note_by_body(
+        self,
+        *,
+        site_id: str = "",
+        site_slug: str = "",
+        body: str,
+    ) -> dict[str, Any] | None:
+        clean_body = body.strip()
+        if not clean_body:
+            return None
+        notes = self.list_notes(site_id=site_id, site_slug=site_slug, limit=50)
+        for note in notes:
+            if str(note.get("body") or "").strip() == clean_body:
+                return note
+        return None
 
     def get_user(
         self,
@@ -778,6 +830,7 @@ def lookup_rhodes_site_owner(
 def add_rhodes_site_note(
     *,
     site_id: str,
+    site_slug: str = "",
     body: str,
     owner_user_id: str = "",
     owner_email: str = "",
@@ -786,17 +839,19 @@ def add_rhodes_site_note(
 ) -> dict[str, Any]:
     """Create a Rhodes site note and mention the owner when possible."""
     clean_site_id = site_id.strip()
+    clean_site_slug = site_slug.strip()
     clean_body = body.strip()
     clean_owner_user_id = owner_user_id.strip()
     clean_owner_email = owner_email.strip()
     base = {
         "rhodes_site_id": clean_site_id,
+        "rhodes_site_slug": clean_site_slug,
         "owner_user_id": clean_owner_user_id,
         "owner_email": clean_owner_email,
         "owner_notification": "none",
     }
-    if not clean_site_id:
-        return {**base, "status": "skipped", "reason": "missing_site_id"}
+    if not clean_site_id and not clean_site_slug:
+        return {**base, "status": "skipped", "reason": "missing_site_identity"}
     if not clean_body:
         return {**base, "status": "skipped", "reason": "missing_body"}
 
@@ -821,15 +876,25 @@ def add_rhodes_site_note(
         )
         note = rhodes.add_site_note(
             site_id=clean_site_id,
+            site_slug=clean_site_slug,
             body=clean_body,
             mentions=mention_user_ids,
         )
+        note_id = _note_id(note)
+        if not note_id:
+            note = _recover_note_without_id(
+                rhodes,
+                site_id=clean_site_id,
+                site_slug=clean_site_slug,
+                body=clean_body,
+                mentions=mention_user_ids,
+            )
+            note_id = _note_id(note)
     except RhodesError as exc:
         return {**base, "status": "failed", "reason": "rhodes_error", "error": str(exc)}
     except Exception as exc:  # noqa: BLE001 - non-fatal scanner side effect
         return {**base, "status": "failed", "reason": "unexpected_error", "error": str(exc)}
 
-    note_id = _note_id(note)
     if not note_id:
         return {
             **base,
@@ -852,6 +917,57 @@ def add_rhodes_site_note(
         "owner_notification": "mentioned" if resolved_owner_user_id else "none",
         "mentioned_user_ids": mention_user_ids,
     }
+
+
+def _recover_note_without_id(
+    rhodes: RhodesClient,
+    *,
+    site_id: str,
+    site_slug: str,
+    body: str,
+    mentions: Iterable[str],
+) -> dict[str, Any]:
+    """Recover a note ID after an empty addNote response, then retry by slug."""
+
+    recovered = _find_note_after_empty_response(
+        rhodes,
+        site_id=site_id,
+        site_slug=site_slug,
+        body=body,
+    )
+    if recovered is not None:
+        return recovered
+
+    if site_slug:
+        note = rhodes.add_site_note(site_slug=site_slug, body=body, mentions=mentions)
+        if _note_id(note):
+            return note
+        recovered = _find_note_after_empty_response(
+            rhodes,
+            site_id="",
+            site_slug=site_slug,
+            body=body,
+        )
+        if recovered is not None:
+            return recovered
+    return {}
+
+
+def _find_note_after_empty_response(
+    rhodes: RhodesClient,
+    *,
+    site_id: str,
+    site_slug: str,
+    body: str,
+) -> dict[str, Any] | None:
+    try:
+        return rhodes.find_site_note_by_body(
+            site_id=site_id,
+            site_slug=site_slug,
+            body=body,
+        )
+    except RhodesError:
+        return None
 
 
 def _unique_nonempty(values: Iterable[str]) -> list[str]:

--- a/src/due_diligence_reporter/rhodes_events.py
+++ b/src/due_diligence_reporter/rhodes_events.py
@@ -18,6 +18,7 @@ def record_rhodes_automation_event(
     *,
     owner_user_id: str = "",
     owner_email: str = "",
+    site_slug: str = "",
     extra_mention_user_ids: Iterable[str] | None = None,
     body: str | None = None,
     add_note: AddRhodesSiteNote = add_rhodes_site_note,
@@ -32,6 +33,8 @@ def record_rhodes_automation_event(
             "owner_user_id": owner_user_id,
             "owner_email": owner_email,
         }
+        if site_slug.strip():
+            note_kwargs["site_slug"] = site_slug.strip()
         extra_ids = [uid.strip() for uid in (extra_mention_user_ids or []) if uid.strip()]
         if extra_ids:
             note_kwargs["extra_mention_user_ids"] = extra_ids

--- a/tests/test_raycon_followup.py
+++ b/tests/test_raycon_followup.py
@@ -91,6 +91,7 @@ def test_load_site_summaries_prefers_rhodes_records_with_site_address(mock_recor
             "title": "Alpha Keller",
             "name": "Alpha Keller",
             "slug": "",
+            "site_slug": "",
             "address": "123 Main St, Keller, TX 76248",
             "drive_folder_id": "drive-root-1",
             "drive_folder_url": "https://drive.google.com/drive/folders/drive-root-1",
@@ -1231,6 +1232,7 @@ class TestRayConFollowupEventNotification:
             {
                 "site": "Alpha Keller",
                 "site_id": "SITE1",
+                "site_slug": "alpha-keller",
                 "alert": "raycon run failed: validation rejected capacity",
                 "drive_folder_url": "https://drive.google.com/drive/folders/abc123",
                 "p1_assignee_user_id": "user-1",
@@ -1254,6 +1256,7 @@ class TestRayConFollowupEventNotification:
             "greg-user",
             "other-user",
         ]
+        assert mock_add_note.call_args.kwargs["site_slug"] == "alpha-keller"
         mock_post_chat.assert_not_called()
         assert failures == []
 

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -19,11 +19,13 @@ class FakeRhodesClient:
         sites: list[dict[str, Any]] | None = None,
         drive_root: tuple[str, str] | Exception | None = None,
         note_response: dict[str, Any] | None = None,
+        note_responses: list[dict[str, Any] | None] | None = None,
     ) -> None:
         self.site = site or {}
         self.sites = sites or []
         self.drive_root = drive_root
         self.note_response = note_response
+        self.note_responses = list(note_responses or [])
         self.documents: list[dict[str, Any]] = []
         self.registered_documents: list[dict[str, Any]] = []
         self.notes: list[dict[str, Any]] = []
@@ -130,7 +132,8 @@ class FakeRhodesClient:
     def add_site_note(
         self,
         *,
-        site_id: str,
+        site_id: str = "",
+        site_slug: str = "",
         body: str,
         mentions: list[str] | None = None,
     ) -> dict[str, Any]:
@@ -139,21 +142,68 @@ class FakeRhodesClient:
                 "add_site_note",
                 {
                     "site_id": site_id,
+                    "site_slug": site_slug,
                     "body": body,
                     "mentions": ",".join(mentions or []),
                 },
             )
         )
+        if self.note_responses:
+            response = self.note_responses.pop(0)
+            if response is not None:
+                return response
         if self.note_response is not None:
             return self.note_response
         note = {
             "_id": f"NOTE{len(self.notes) + 1}",
             "siteId": site_id,
+            "siteSlug": site_slug,
             "body": body,
             "mentions": mentions or [],
         }
         self.notes.append(note)
         return note
+
+    def list_notes(
+        self,
+        *,
+        site_id: str = "",
+        site_slug: str = "",
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        self.calls.append(
+            (
+                "list_notes",
+                {
+                    "site_id": site_id,
+                    "site_slug": site_slug,
+                    "limit": str(limit),
+                },
+            )
+        )
+        return self.notes[:limit]
+
+    def find_site_note_by_body(
+        self,
+        *,
+        site_id: str = "",
+        site_slug: str = "",
+        body: str,
+    ) -> dict[str, Any] | None:
+        self.calls.append(
+            (
+                "find_site_note_by_body",
+                {
+                    "site_id": site_id,
+                    "site_slug": site_slug,
+                    "body": body,
+                },
+            )
+        )
+        for note in self.notes:
+            if str(note.get("body") or "").strip() == body.strip():
+                return note
+        return None
 
 
 def test_lookup_rhodes_site_owner_returns_p1_report_fields() -> None:
@@ -462,6 +512,64 @@ def test_add_rhodes_site_note_requires_returned_note_id() -> None:
     assert result["owner_notification"] == "none"
     assert result["rhodes_note_id"] == ""
     assert result["mentioned_user_ids"] == ["OWNER1", "GREG1"]
+
+
+def test_add_rhodes_site_note_recovers_note_id_from_readback() -> None:
+    body = "AutomationEvent v1\nKind: raycon_followup_alert"
+    client = FakeRhodesClient(note_response={"text": "created"})
+    client.notes = [{"_id": "NOTE-READBACK", "siteId": "SITE1", "body": body}]
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        body=body,
+        owner_user_id="OWNER1",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["rhodes_note_id"] == "NOTE-READBACK"
+    assert result["owner_notification"] == "mentioned"
+    assert (
+        "find_site_note_by_body",
+        {
+            "site_id": "SITE1",
+            "site_slug": "",
+            "body": body,
+        },
+    ) in client.calls
+
+
+def test_add_rhodes_site_note_retries_by_slug_when_site_id_returns_no_id() -> None:
+    client = FakeRhodesClient(note_responses=[{"text": "created"}, None])
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        site_slug="alpha-test",
+        body="AutomationEvent v1\nKind: raycon_followup_alert",
+        owner_user_id="OWNER1",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["rhodes_note_id"] == "NOTE1"
+    assert client.calls[0] == (
+        "add_site_note",
+        {
+            "site_id": "SITE1",
+            "site_slug": "alpha-test",
+            "body": "AutomationEvent v1\nKind: raycon_followup_alert",
+            "mentions": "OWNER1",
+        },
+    )
+    assert client.calls[2] == (
+        "add_site_note",
+        {
+            "site_id": "",
+            "site_slug": "alpha-test",
+            "body": "AutomationEvent v1\nKind: raycon_followup_alert",
+            "mentions": "OWNER1",
+        },
+    )
 
 
 def test_add_rhodes_site_note_resolves_owner_email() -> None:


### PR DESCRIPTION
## Summary
- add Rhodes note readback recovery when addNote returns no concrete note ID
- retry RayCon owner notes by siteSlug when the siteId write path still cannot confirm a note
- pass Rhodes site_slug through RayCon follow-up alert context

## Production finding
After PR #131 merged, Tulsa and Santa Clara RayCon follow-up runs failed closed with missing_note_id, posted Google Chat fallback, and still showed no new Rhodes note/audit entry. This PR keeps that fail-closed behavior while adding the two likely recovery paths before giving up.

## Validation
- uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-readback
- uv run ruff check src\due_diligence_reporter\rhodes.py src\due_diligence_reporter\rhodes_events.py scripts\raycon_followup.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py
- uv run mypy src/
- uv run mypy scripts/raycon_followup.py
- git diff --check
- git diff --cached --check

## Next after merge
Clear the fresh RayCon runtime-state cache entries for the failed PR #131 retest runs if needed, then rerun Tulsa and Santa Clara. If Rhodes note creation is still a remote no-op, the workflow should continue to fail with missing_note_id and Chat fallback, which would move the remaining fix to the Rhodes MCP/write surface.