### PR TITLE
Send explicit Rhodes site anchors for notes

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,65 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Explicit Rhodes Note Anchor
+
+Confirmed PR #132 merged at `98d31ad` and retested on `main`.
+
+Live test:
+
+- Deleted only the two stale RayCon runtime caches from the failed PR #131
+  retest runs:
+  - `raycon-runtime-state-26581936544`
+  - `raycon-runtime-state-26581936500`
+- Santa Clara run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26583402921
+- Tulsa run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26583402885
+- Both runs failed closed with `missing_note_id`.
+- Both runs included Devin Bates plus Greg Foote in `mentioned_user_ids`.
+- Both runs posted the Google Chat fallback.
+- Live Rhodes `listNotes` and audit-log readback still showed no new RayCon
+  note on either site.
+- The failure now survives site-ID write, readback recovery, and site-slug
+  retry. That points to the hosted Rhodes MCP `addNote` write path rather than
+  RayCon alert dedupe.
+
+Branch: `codex/raycon-explicit-note-anchor`
+
+Changed:
+
+- `RhodesClient.add_site_note` now sends explicit site anchoring in the MCP
+  payload:
+  - `anchorType: "site"`
+  - `anchorId: <siteId>` when a Rhodes site ID is available
+- Added a client-level regression test for the exact `addNote` payload shape.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-explicit-note-anchor
+uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py scripts\raycon_followup.py src\due_diligence_reporter\rhodes_events.py
+uv run mypy src/
+uv run mypy scripts/raycon_followup.py
+```
+
+Results:
+
+- Focused Rhodes/RayCon suite: 83 passed.
+- Ruff on touched code/tests: passed.
+- Source Mypy: no issues in 38 source files.
+- Script Mypy: no issues.
+
+Next:
+
+- Open PR for `codex/raycon-explicit-note-anchor`.
+- After merge, clear the fresh RayCon runtime caches from the failed PR #132
+  retest runs if they would suppress the new test:
+  - `raycon-runtime-state-26583402921`
+  - `raycon-runtime-state-26583402885`
+- Rerun RayCon Follow-up for Tulsa/Santa Clara.
+- If explicit anchoring still produces `missing_note_id` and no Rhodes audit
+  entry, the fix needs to move to the deployed Rhodes MCP/API write surface.
+
 ## 2026-05-28 - RayCon Rhodes Note Readback / Slug Fallback
 
 Confirmed PR #131 merged at `c71de5e` and retested the merged fail-closed

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -639,9 +639,13 @@ class RhodesClient:
         if not body.strip():
             raise RhodesError("body is required")
 
-        payload: dict[str, Any] = {"body": body.strip()}
+        payload: dict[str, Any] = {
+            "anchorType": "site",
+            "body": body.strip(),
+        }
         if clean_site_id:
             payload["siteId"] = clean_site_id
+            payload["anchorId"] = clean_site_id
         else:
             payload["siteSlug"] = clean_site_slug
         clean_mentions = [m.strip() for m in (mentions or []) if m.strip()]

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from due_diligence_reporter.rhodes import (
+    RhodesClient,
     RhodesError,
     add_rhodes_site_note,
     list_rhodes_site_records,
@@ -204,6 +205,15 @@ class FakeRhodesClient:
             if str(note.get("body") or "").strip() == body.strip():
                 return note
         return None
+
+
+class RecordingRhodesClient(RhodesClient):
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        self.calls.append((name, arguments))
+        return {"_id": "NOTE1"}
 
 
 def test_lookup_rhodes_site_owner_returns_p1_report_fields() -> None:
@@ -461,6 +471,30 @@ def test_register_rhodes_document_for_upload_handles_missing_config(monkeypatch)
     assert result["status"] == "failed"
     assert result["reason"] == "rhodes_error"
     assert "RHODES_API_KEY" in result["error"]
+
+
+def test_rhodes_client_add_site_note_sends_explicit_site_anchor() -> None:
+    client = RecordingRhodesClient()
+
+    result = client.add_site_note(
+        site_id=" SITE1 ",
+        body=" Body ",
+        mentions=[" USER1 ", ""],
+    )
+
+    assert result["_id"] == "NOTE1"
+    assert client.calls == [
+        (
+            "addNote",
+            {
+                "anchorType": "site",
+                "body": "Body",
+                "siteId": "SITE1",
+                "anchorId": "SITE1",
+                "mentions": ["USER1"],
+            },
+        )
+    ]
 
 
 def test_add_rhodes_site_note_mentions_owner_user_id() -> None:


### PR DESCRIPTION
## Summary
- send explicit site anchoring on Rhodes addNote calls: anchorType site plus anchorId when a site ID is available
- add a client-level regression for the exact addNote payload shape
- document the PR #132 live retest and next cache-clearing step in HANDOFF.md

## Production finding
After PR #132 merged, focused Tulsa and Santa Clara RayCon Follow-up reruns still failed closed with missing_note_id. Both runs included Devin Bates and Greg Foote in mentioned_user_ids, posted Google Chat fallback, and live Rhodes listNotes/audit-log readback still showed no new note. The remaining plausible consumer-side issue is that the hosted MCP addNote path may not be applying its default site-level anchor for API-key clients.

## Validation
- uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-explicit-note-anchor
- uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py scripts\raycon_followup.py src\due_diligence_reporter\rhodes_events.py
- uv run mypy src/
- uv run mypy scripts/raycon_followup.py
- git diff --check
- git diff --cached --check

## Next after merge
Clear raycon-runtime-state-26583402921 and raycon-runtime-state-26583402885 if they would suppress the next test, then rerun Tulsa and Santa Clara. If explicit anchoring still produces missing_note_id and no Rhodes audit entry, the fix needs to move to the deployed Rhodes MCP/API write surface.