### PR TITLE
Log sanitized Rhodes note response diagnostics

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,65 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Note Response Diagnostics
+
+Confirmed PR #133 merged at `41709ae` and retested on `main`.
+
+Live test:
+
+- Deleted only the two stale RayCon runtime caches from the failed PR #132
+  retest runs:
+  - `raycon-runtime-state-26583402921`
+  - `raycon-runtime-state-26583402885`
+- Santa Clara run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26584277976
+- Tulsa run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26584277931
+- Both runs failed closed with `missing_note_id`.
+- Both runs included Devin Bates plus Greg Foote in `mentioned_user_ids`.
+- Both runs posted the Google Chat fallback.
+- Live Rhodes `listNotes` and audit-log readback still showed no new RayCon
+  note on either site.
+- The failure now survives explicit `anchorType: "site"` / `anchorId` payloads
+  as well as prior site-ID, site-slug, and readback recovery paths.
+
+Branch: `codex/raycon-note-response-diagnostics`
+
+Changed:
+
+- Missing-note failures now include `note_response_summaries`, a sanitized
+  shape-only summary of each `addNote` response attempt.
+- The summary includes attempt name, Python type, response keys, whether a note
+  ID was present, and a capped text prefix only when the MCP returned plain text.
+- It does not log the generated RayCon note body or secrets.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-response-diagnostics
+uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py scripts\raycon_followup.py src\due_diligence_reporter\rhodes_events.py
+uv run mypy src/
+uv run mypy scripts/raycon_followup.py
+```
+
+Results:
+
+- Focused Rhodes/RayCon suite: 83 passed.
+- Ruff on touched code/tests: passed.
+- Source Mypy: no issues in 38 source files.
+- Script Mypy: no issues.
+
+Next:
+
+- Open PR for `codex/raycon-note-response-diagnostics`.
+- After merge, clear the fresh RayCon runtime caches from the failed PR #133
+  retest runs if they would suppress the new test:
+  - `raycon-runtime-state-26584277976`
+  - `raycon-runtime-state-26584277931`
+- Rerun RayCon Follow-up for Tulsa/Santa Clara.
+- Use `note_response_summaries` in the workflow logs to decide the actual
+  hosted Rhodes MCP/API fix. If the response is empty or confirmation-shaped,
+  the durable fix belongs in the deployed Rhodes MCP write surface.
+
 ## 2026-05-28 - RayCon Explicit Rhodes Note Anchor
 
 Confirmed PR #132 merged at `98d31ad` and retested on `main`.

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -878,11 +878,18 @@ def add_rhodes_site_note(
                 *(extra_mention_user_ids or []),
             ]
         )
+        note_response_summaries: list[dict[str, Any]] = []
         note = rhodes.add_site_note(
             site_id=clean_site_id,
             site_slug=clean_site_slug,
             body=clean_body,
             mentions=mention_user_ids,
+        )
+        note_response_summaries.append(
+            _summarize_note_response(
+                note,
+                attempt="site_id" if clean_site_id else "site_slug",
+            )
         )
         note_id = _note_id(note)
         if not note_id:
@@ -892,6 +899,7 @@ def add_rhodes_site_note(
                 site_slug=clean_site_slug,
                 body=clean_body,
                 mentions=mention_user_ids,
+                response_summaries=note_response_summaries,
             )
             note_id = _note_id(note)
     except RhodesError as exc:
@@ -909,6 +917,7 @@ def add_rhodes_site_note(
             "owner_user_id": resolved_owner_user_id,
             "owner_resolution": owner_resolution,
             "mentioned_user_ids": mention_user_ids,
+            "note_response_summaries": note_response_summaries,
         }
 
     return {
@@ -930,6 +939,7 @@ def _recover_note_without_id(
     site_slug: str,
     body: str,
     mentions: Iterable[str],
+    response_summaries: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Recover a note ID after an empty addNote response, then retry by slug."""
 
@@ -944,6 +954,9 @@ def _recover_note_without_id(
 
     if site_slug:
         note = rhodes.add_site_note(site_slug=site_slug, body=body, mentions=mentions)
+        response_summaries.append(
+            _summarize_note_response(note, attempt="site_slug_retry")
+        )
         if _note_id(note):
             return note
         recovered = _find_note_after_empty_response(
@@ -972,6 +985,29 @@ def _find_note_after_empty_response(
         )
     except RhodesError:
         return None
+
+
+def _summarize_note_response(
+    note: dict[str, Any],
+    *,
+    attempt: str,
+) -> dict[str, Any]:
+    """Return a safe shape summary for diagnosing no-ID addNote responses."""
+
+    summary: dict[str, Any] = {
+        "attempt": attempt,
+        "type": type(note).__name__,
+        "has_note_id": bool(_note_id(note)),
+    }
+    if isinstance(note, dict):
+        summary["keys"] = sorted(str(key) for key in note.keys())
+        text = note.get("text")
+        if isinstance(text, str) and text.strip():
+            summary["text_prefix"] = text.strip()[:240]
+        nested_note = note.get("note")
+        if isinstance(nested_note, dict):
+            summary["note_keys"] = sorted(str(key) for key in nested_note.keys())
+    return summary
 
 
 def _unique_nonempty(values: Iterable[str]) -> list[str]:

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -546,6 +546,15 @@ def test_add_rhodes_site_note_requires_returned_note_id() -> None:
     assert result["owner_notification"] == "none"
     assert result["rhodes_note_id"] == ""
     assert result["mentioned_user_ids"] == ["OWNER1", "GREG1"]
+    assert result["note_response_summaries"] == [
+        {
+            "attempt": "site_id",
+            "type": "dict",
+            "has_note_id": False,
+            "keys": ["text"],
+            "text_prefix": "created",
+        }
+    ]
 
 
 def test_add_rhodes_site_note_recovers_note_id_from_readback() -> None:
@@ -595,6 +604,7 @@ def test_add_rhodes_site_note_retries_by_slug_when_site_id_returns_no_id() -> No
             "mentions": "OWNER1",
         },
     )
+    assert result.get("note_response_summaries") is None
     assert client.calls[2] == (
         "add_site_note",
         {


### PR DESCRIPTION
## Summary
- add sanitized addNote response-shape diagnostics when Rhodes note creation cannot be verified
- include attempt name, response type, keys, note-id presence, and capped plain-text prefix when present
- document the PR #133 live retest results and next cache-clearing step in HANDOFF.md

## Production finding
After PR #133 merged, Tulsa and Santa Clara RayCon Follow-up reruns still failed closed with missing_note_id. Explicit site anchors did not produce a Rhodes note, and live listNotes/audit-log readback still showed no note.added entry. At this point the durable fix likely belongs in the hosted Rhodes MCP/API write surface, but we need the raw response shape from GitHub Actions before patching blindly.

## Safety
The diagnostic does not log the generated RayCon note body or secrets. It logs only response shape, keys, has_note_id, and a 240-character text prefix if the MCP returned plain text.

## Validation
- uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-response-diagnostics
- uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py scripts\raycon_followup.py src\due_diligence_reporter\rhodes_events.py
- uv run mypy src/
- uv run mypy scripts/raycon_followup.py
- git diff --check
- git diff --cached --check

## Next after merge
Clear raycon-runtime-state-26584277976 and raycon-runtime-state-26584277931 if they would suppress the next test, then rerun Tulsa and Santa Clara. Use note_response_summaries in the logs to decide the actual Rhodes MCP/API write fix.