### PR TITLE
Log Rhodes note rejection reasons

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,67 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - RayCon Note Rejection Diagnostics
+
+Confirmed PR #134 merged at `7f1aa37` and retested on `main`.
+
+Live test:
+
+- Deleted only the two stale RayCon runtime caches from the failed PR #133
+  retest runs:
+  - `raycon-runtime-state-26584277976`
+  - `raycon-runtime-state-26584277931`
+- Tulsa run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26585081257
+- Santa Clara run:
+  https://github.com/GFooteGK1/due-diligence-reporter/actions/runs/26585081215
+- Both runs failed closed with `missing_note_id`.
+- Both runs posted Google Chat fallback.
+- Live Rhodes `listNotes` still showed no new RayCon note on either site.
+- New diagnostic showed both the site-ID attempt and site-slug retry returned
+  dicts with keys `["rejectionReason", "status"]`, no note ID. The actual values
+  were not logged yet, so the next slice must expose those safe scalar fields.
+
+Branch: `codex/raycon-note-rejection-diagnostics`
+
+Changed:
+
+- `note_response_summaries` now includes capped scalar values for:
+  - `status`
+  - `reason`
+  - `rejectionReason`
+  - `message`
+  - `error`
+- This keeps note body and secrets out of logs while surfacing the hosted MCP
+  write rejection reason.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-rejection-diagnostics
+uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py scripts\raycon_followup.py src\due_diligence_reporter\rhodes_events.py
+uv run mypy src/
+uv run mypy scripts/raycon_followup.py
+```
+
+Results:
+
+- Focused Rhodes/RayCon suite: 83 passed.
+- Ruff on touched code/tests: passed.
+- Source Mypy: no issues in 38 source files.
+- Script Mypy: no issues.
+
+Next:
+
+- Open PR for `codex/raycon-note-rejection-diagnostics`.
+- After merge, clear the fresh RayCon runtime caches from the failed PR #134
+  retest runs if they would suppress the new test:
+  - `raycon-runtime-state-26585081257`
+  - `raycon-runtime-state-26585081215`
+- Rerun RayCon Follow-up for Tulsa/Santa Clara.
+- Use the logged `status` / `rejectionReason` values to decide whether the
+  durable fix is a caller payload change or a deployed Rhodes MCP write-surface
+  change.
+
 ## 2026-05-28 - RayCon Note Response Diagnostics
 
 Confirmed PR #133 merged at `41709ae` and retested on `main`.

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -1001,6 +1001,10 @@ def _summarize_note_response(
     }
     if isinstance(note, dict):
         summary["keys"] = sorted(str(key) for key in note.keys())
+        for key in ("status", "reason", "rejectionReason", "message", "error"):
+            value = _safe_note_response_scalar(note.get(key))
+            if value:
+                summary[key] = value
         text = note.get("text")
         if isinstance(text, str) and text.strip():
             summary["text_prefix"] = text.strip()[:240]
@@ -1008,6 +1012,16 @@ def _summarize_note_response(
         if isinstance(nested_note, dict):
             summary["note_keys"] = sorted(str(key) for key in nested_note.keys())
     return summary
+
+
+def _safe_note_response_scalar(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()[:240]
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int | float):
+        return str(value)
+    return ""
 
 
 def _unique_nonempty(values: Iterable[str]) -> list[str]:

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -531,7 +531,13 @@ def test_add_rhodes_site_note_mentions_owner_and_extra_users() -> None:
 
 
 def test_add_rhodes_site_note_requires_returned_note_id() -> None:
-    client = FakeRhodesClient(note_response={"text": "created"})
+    client = FakeRhodesClient(
+        note_response={
+            "status": "rejected",
+            "rejectionReason": "Action requires confirmation",
+            "text": "created",
+        }
+    )
 
     result = add_rhodes_site_note(
         site_id="SITE1",
@@ -551,7 +557,9 @@ def test_add_rhodes_site_note_requires_returned_note_id() -> None:
             "attempt": "site_id",
             "type": "dict",
             "has_note_id": False,
-            "keys": ["text"],
+            "keys": ["rejectionReason", "status", "text"],
+            "status": "rejected",
+            "rejectionReason": "Action requires confirmation",
             "text_prefix": "created",
         }
     ]


### PR DESCRIPTION
## Summary
- extend sanitized addNote diagnostics to include capped scalar values for status, reason, rejectionReason, message, and error
- document the PR #134 live retest result and next cache-clearing step in HANDOFF.md

## Production finding
After PR #134 merged, Tulsa and Santa Clara still failed closed with missing_note_id. The new diagnostics showed both the site_id attempt and the site_slug retry returned dictionaries with keys [rejectionReason, status] and no note ID. This PR exposes the safe values behind those keys so the next test can identify the actual hosted Rhodes MCP/API rejection.

## Safety
The diagnostic still does not log the generated RayCon note body or secrets. It only logs selected scalar response fields, capped at 240 characters.

## Validation
- uv run pytest tests/test_rhodes.py tests/test_rhodes_events.py tests/test_raycon_followup.py --basetemp C:\tmp\pytest-raycon-note-rejection-diagnostics
- uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py tests\test_rhodes_events.py tests\test_raycon_followup.py scripts\raycon_followup.py src\due_diligence_reporter\rhodes_events.py
- uv run mypy src/
- uv run mypy scripts/raycon_followup.py
- git diff --check
- git diff --cached --check

## Next after merge
Clear raycon-runtime-state-26585081257 and raycon-runtime-state-26585081215 if they would suppress the next test, then rerun Tulsa and Santa Clara. Use the logged status/rejectionReason values to decide whether the durable fix is a caller payload change or a deployed Rhodes MCP write-surface change.