### PR TITLE
Align report pipeline test with Rhodes event

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,48 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - DDR Report Event Test Gap
+
+Confirmed PR #137 was merged:
+
+- `due-diligence-reporter` PR #137 merged at `c8fcf1a`.
+
+Closed the local validation gap called out in the prior handoff where
+`tests/test_report_pipeline.py` was excluded because one success-path test did
+not stub the newer Rhodes report-event write.
+
+Branch: `codex/ddr-report-event-test-gap`
+
+Changed:
+
+- Updated `test_report_created_does_not_record_publish_step` so it stubs the
+  Rhodes report-event note, passes a site ID, and still verifies no legacy
+  publish/upload side effect happens.
+- This keeps the test aligned with the current contract: report-created success
+  writes a Rhodes `dd_report_created` event and should not resurrect the old
+  publish side effect.
+
+Verification:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-report-pipeline-fix tests/test_report_pipeline.py -q
+uv run ruff check tests\test_report_pipeline.py
+uv run pytest --basetemp C:\tmp\ddr-report-pipeline-gap-broad tests/test_automation_event.py tests/test_report_pipeline.py tests/test_dd_republish.py tests/test_vendor_doc_sweep.py tests/test_raycon_followup.py tests/test_inbox_scanner.py tests/test_workflow_contracts.py tests/test_rhodes_events.py -q
+git diff --check
+```
+
+Results:
+
+- Report pipeline suite: 44 passed.
+- Ruff on touched test: passed.
+- Broader affected DDR suite including report pipeline: 242 passed.
+- Diff check: passed with expected Windows LF-to-CRLF warnings only.
+
+Next:
+
+- Commit, push, and open the PR.
+- After merge, continue with the next remaining shared-adapter/record-completion
+  wrap-up item that is not blocked by the hosted Rhodes MCP `addNote` issue.
+
 ## 2026-05-28 - DDR Republish Failure Events
 
 Confirmed downstream PR #54 was merged, then continued the next DDR

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -926,6 +926,7 @@ class TestProcessSitePipeline:
         assert step.artifacts[0].metadata["event_type"] == "vendor_gate_review_required"
         assert step.artifacts[0].metadata["rhodes_note_id"] == "NOTE-VENDOR"
 
+    @patch("due_diligence_reporter.report_pipeline.add_rhodes_site_note")
     @patch("due_diligence_reporter.server.check_report_completeness")
     @patch("due_diligence_reporter.report_pipeline.run_dd_report_agent")
     @patch("due_diligence_reporter.report_pipeline.check_site_readiness_direct")
@@ -934,8 +935,9 @@ class TestProcessSitePipeline:
         mock_readiness,
         mock_agent,
         mock_completeness,
+        mock_rhodes_note,
     ):
-        """Success path does not record a publish side effect."""
+        """Success path records the Rhodes event but not the old publish side effect."""
         mock_readiness.return_value = {
             "sir_found": True,
             "isp_found": False,
@@ -959,15 +961,24 @@ class TestProcessSitePipeline:
             return {"ready_to_send": True, "pending_section_count": 0}
 
         mock_completeness.side_effect = fake_completeness
+        mock_rhodes_note.return_value = {
+            "status": "created",
+            "reason": "ok",
+            "rhodes_note_id": "NOTE1",
+            "owner_notification": "none",
+        }
         gc = MagicMock()
         result = process_site_pipeline(
             gc, "Alpha Keller", "https://drive.google.com/drive/folders/abc123",
             ["Alpha Keller"], {}, "system prompt", _make_settings(),
+            site_id="SITE1",
         )
 
         assert result.status == "report_created"
         assert result.run_id
         assert result.failed_step is None
+        assert result.rhodes_report_event is not None
+        assert result.rhodes_report_event["rhodes_note_id"] == "NOTE1"
         assert result.quality_band in {"green", "yellow", "orange", "red"}
         assert not any(step.step.startswith("publish.") for step in result.steps)
         gc.upload_file_to_folder.assert_not_called()


### PR DESCRIPTION
## Summary
- update the report-created success-path test to stub the current Rhodes report-event write
- keep the original no-publish-side-effect assertion intact
- document the validation gap closure in the DDR handoff

## Validation
- uv run pytest --basetemp C:\tmp\ddr-report-pipeline-fix tests/test_report_pipeline.py -q
- uv run ruff check tests\test_report_pipeline.py
- uv run pytest --basetemp C:\tmp\ddr-report-pipeline-gap-broad tests/test_automation_event.py tests/test_report_pipeline.py tests/test_dd_republish.py tests/test_vendor_doc_sweep.py tests/test_raycon_followup.py tests/test_inbox_scanner.py tests/test_workflow_contracts.py tests/test_rhodes_events.py -q
- git diff --check
- git diff --cached --check