### PR TITLE
Handle nested Rhodes record IDs

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,47 @@
 # Due Diligence Reporter Handoff
 
+## 2026-05-28 - Nested Rhodes Record IDs
+
+Continued the non-blocked Phase 3 adapter-alignment work.
+
+Branch: `codex/ddr-nested-rhodes-record-ids`
+
+Current state: implementation complete locally; commit/PR pending.
+
+Changed:
+
+- Added shared nested response ID extraction in `rhodes.py`.
+- DDR note creation now accepts Rhodes note IDs returned in nested response
+  shapes such as `{note: {id: ...}}`, `{result: {...}}`, `{record: {...}}`,
+  or `{data: {...}}`.
+- Owner user resolution now accepts nested user ID response shapes too.
+- Added regression coverage proving nested note IDs do not trigger readback or
+  retry, and nested owner IDs still produce `@` mentions.
+
+Verification:
+
+```powershell
+uv run pytest --basetemp C:\tmp\ddr-nested-rhodes-ids-focused tests/test_rhodes.py::test_add_rhodes_site_note_accepts_nested_note_id_response tests/test_rhodes.py::test_add_rhodes_site_note_resolves_nested_owner_user_id tests/test_rhodes.py::test_add_rhodes_site_note_requires_returned_note_id -q
+uv run pytest --basetemp C:\tmp\ddr-nested-rhodes-ids-broad tests/test_rhodes.py tests/test_rhodes_events.py -q
+uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py
+uv run mypy src\due_diligence_reporter\rhodes.py
+git diff --check
+```
+
+Results:
+
+- Focused nested-ID tests: 3 passed.
+- Broader Rhodes/Rhodes-event suite: 26 passed.
+- Ruff on touched code/tests: passed.
+- Mypy on touched Rhodes module: passed.
+- Diff check: passed with expected Windows LF-to-CRLF warnings only.
+
+Next:
+
+- Commit, push, and open PR.
+- After merge, continue the next non-blocked task: another adapter alignment
+  slice or the portfolio automation-gap snapshot.
+
 ## 2026-05-28 - DDR Report Event Test Gap
 
 Confirmed PR #137 was merged:

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -215,20 +215,26 @@ def _document_drive_file_id(document: dict[str, Any]) -> str:
     return ""
 
 
-def _note_id(note: dict[str, Any]) -> str:
-    for key in ("noteId", "_id", "id"):
-        value = note.get(key)
+def _response_id(payload: Any, keys: tuple[str, ...]) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    for key in keys:
+        value = payload.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
+    for nested_key in ("note", "user", "record", "result", "data"):
+        nested_id = _response_id(payload.get(nested_key), keys)
+        if nested_id:
+            return nested_id
     return ""
+
+
+def _note_id(note: dict[str, Any]) -> str:
+    return _response_id(note, ("noteId", "_id", "id"))
 
 
 def _user_id(user: dict[str, Any]) -> str:
-    for key in ("userId", "_id", "id"):
-        value = user.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return ""
+    return _response_id(user, ("userId", "_id", "id"))
 
 
 @dataclass(frozen=True)

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -530,6 +530,32 @@ def test_add_rhodes_site_note_mentions_owner_and_extra_users() -> None:
     assert client.notes[0]["mentions"] == ["OWNER1", "GREG1"]
 
 
+def test_add_rhodes_site_note_accepts_nested_note_id_response() -> None:
+    client = FakeRhodesClient(note_response={"note": {"id": "NOTE-NESTED"}})
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        body="AutomationEvent v1\nKind: raycon_followup_alert",
+        owner_user_id="OWNER1",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["rhodes_note_id"] == "NOTE-NESTED"
+    assert result["owner_notification"] == "mentioned"
+    assert client.calls == [
+        (
+            "add_site_note",
+            {
+                "site_id": "SITE1",
+                "site_slug": "",
+                "body": "AutomationEvent v1\nKind: raycon_followup_alert",
+                "mentions": "OWNER1",
+            },
+        )
+    ]
+
+
 def test_add_rhodes_site_note_requires_returned_note_id() -> None:
     client = FakeRhodesClient(
         note_response={
@@ -642,3 +668,22 @@ def test_add_rhodes_site_note_resolves_owner_email() -> None:
     assert result["owner_user_id"] == "USER2"
     assert result["owner_resolution"] == "resolved_from_email"
     assert client.notes[0]["mentions"] == ["USER2"]
+
+
+def test_add_rhodes_site_note_resolves_nested_owner_user_id() -> None:
+    client = FakeRhodesClient()
+    client.users_by_email["owner@example.com"] = {
+        "result": {"userId": "USER-NESTED"},
+    }
+
+    result = add_rhodes_site_note(
+        site_id="SITE1",
+        body="AutomationEvent v1\nKind: document_registration_failed",
+        owner_email="owner@example.com",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["owner_user_id"] == "USER-NESTED"
+    assert result["owner_resolution"] == "resolved_from_email"
+    assert client.notes[0]["mentions"] == ["USER-NESTED"]


### PR DESCRIPTION
## Summary
- add nested Rhodes response ID extraction for DDR note and user responses
- accept note IDs returned under note/result/record/data wrappers without readback or retry
- accept nested owner user IDs so owner mentions still work when Rhodes wraps responses

## Verification
- uv run pytest --basetemp C:\tmp\ddr-nested-rhodes-ids-focused tests/test_rhodes.py::test_add_rhodes_site_note_accepts_nested_note_id_response tests/test_rhodes.py::test_add_rhodes_site_note_resolves_nested_owner_user_id tests/test_rhodes.py::test_add_rhodes_site_note_requires_returned_note_id -q
- uv run pytest --basetemp C:\tmp\ddr-nested-rhodes-ids-broad tests/test_rhodes.py tests/test_rhodes_events.py -q
- uv run ruff check src\due_diligence_reporter\rhodes.py tests\test_rhodes.py
- uv run mypy src\due_diligence_reporter\rhodes.py
- git diff --check