### PR TITLE
Pass Rhodes env to portfolio gap workflow

### DIFF
--- a/.github/workflows/portfolio-automation-gaps.yml
+++ b/.github/workflows/portfolio-automation-gaps.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Build portfolio gap snapshot
         env:
+          RHODES_API_KEY: ${{ secrets.RHODES_API_KEY }}
+          RHODES_MCP_URL: ${{ secrets.RHODES_MCP_URL }}
           INPUT_MAX_SITES: ${{ inputs.max_sites }}
           INPUT_INCLUDE_CLEAN: ${{ inputs.include_clean }}
         run: |

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -100,6 +100,11 @@ def test_portfolio_gap_snapshot_is_read_only_rhodes_workflow() -> None:
     text = _workflow_text("portfolio-automation-gaps.yml")
 
     assert "RHODES_API_KEY" in text
+    assert (
+        "name: Build portfolio gap snapshot\n"
+        "        env:\n"
+        "          RHODES_API_KEY: ${{ secrets.RHODES_API_KEY }}"
+    ) in text
     assert "GOOGLE_CHAT_WEBHOOK_URL" in text
     assert "portfolio-gaps" in text
     assert "portfolio-automation-gaps.json" in text


### PR DESCRIPTION
## Summary
- pass `RHODES_API_KEY` and `RHODES_MCP_URL` directly into the Portfolio Automation Gaps snapshot step
- add a workflow contract assertion so the read-only portfolio CLI step cannot regress to relying on an unloaded `.env`

## Why
Manual smoke run `26600215412` failed with `due_diligence_reporter.rhodes.RhodesError: Missing RHODES_API_KEY env var` even though the secret exists. The workflow wrote `.env`, but the `ddr portfolio-gaps` CLI process did not load it.

## Verification
- `uv run pytest --basetemp C:\tmp\ddr-portfolio-env-fix tests/test_workflow_contracts.py -q`
- `git diff --check`