### PR TITLE
Emit DDR action records in run manifests

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,39 @@
 # Due Diligence Reporter Handoff
 
+## 2026-06-08 - DDR ActionRecord v1 Manifest Emission
+
+Greg wants the dashboard to show not only workflow health, but the actual alert,
+owning workflow, action taken, status, and as-of time for operator-visible
+issues. DDR run manifests now emit sanitized `action_records` alongside the
+existing step and open-question summary.
+
+Changed:
+
+- `src/due_diligence_reporter/pipeline_contracts.py` now includes
+  `action_records` in `PipelineRun.to_dict()`.
+- Failed or blocked DDR steps emit an ActionRecord v1 row with the DDR run ID,
+  step, site, status, operator action, readback evidence, and retryability.
+- Open DDR verification items emit sanitized `needs_review` ActionRecord rows
+  without duplicating the open-question display text into the dashboard action
+  surface.
+- `tests/test_pipeline_contracts.py` covers failed-step and open-question
+  ActionRecord serialization.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_report_pipeline.py tests/test_pipeline_contracts.py -q --basetemp C:\tmp\ddr-action-records-report-pipeline-clean
+uv run ruff check src/due_diligence_reporter/pipeline_contracts.py tests/test_pipeline_contracts.py
+uv run mypy src/due_diligence_reporter/pipeline_contracts.py
+```
+
+Results:
+
+- Focused pytest: 62 passed.
+- Ruff: all checks passed.
+- Mypy: no issues in `pipeline_contracts.py`; the repo still prints the known
+  unused pyproject override note.
+
 ## 2026-06-05 - Portfolio Gaps AADP Remediation Trigger
 
 Greg wanted Portfolio Gaps alerts to show what action agents took instead of

--- a/src/due_diligence_reporter/pipeline_contracts.py
+++ b/src/due_diligence_reporter/pipeline_contracts.py
@@ -166,7 +166,119 @@ class PipelineRun:
             "manifest_url": self.manifest_url,
             "failed_step": failed_step_name(self.steps),
             "next_operator_action": next_operator_action(self.steps),
+            "action_records": action_records_for_run(self),
         }
+
+
+def action_records_for_run(run: PipelineRun) -> list[dict[str, Any]]:
+    """Return dashboard-ready ActionRecord v1 facts for operator-visible issues."""
+
+    records: list[dict[str, Any]] = []
+    for step in run.steps:
+        if step.status not in {"failed", "blocked"}:
+            continue
+        records.append(_step_action_record(run, step))
+    for index, item in enumerate(run.open_questions, start=1):
+        records.append(_open_question_action_record(run, item, index))
+    return records
+
+
+def _step_action_record(run: PipelineRun, step: StepResult) -> dict[str, Any]:
+    error = step.error
+    alert_type = error.code if error else step.step
+    status = "blocked" if step.status == "blocked" else "error"
+    return {
+        "schema_version": "action_record.v1",
+        "action_id": f"ddr:{run.run_id}:step:{step.step}",
+        "source_workflow": "ddr",
+        "owning_workflow": "ddr",
+        "alert_type": _action_token(alert_type),
+        "site": _site_payload(run),
+        "severity": "critical" if step.status == "blocked" else "high",
+        "status": status,
+        "action_requested": (
+            error.operator_action
+            if error and error.operator_action
+            else step.rerun_command
+            or f"Review DDR step {step.step}."
+        ),
+        "action_taken": (
+            f"DDR recorded {step.status} step {step.step}; "
+            "no completed remediation has been verified yet."
+        ),
+        "as_of": step.ended_at or run.ended_at or run.started_at,
+        "owner": {
+            "workflow_owner": "ddr",
+            "human_owner": "",
+        },
+        "evidence": {
+            "readback": f"DDR run manifest {run.run_id} recorded step {step.step}={step.status}.",
+        },
+        "review": {
+            "required": True,
+            "reason": error.message if error else f"DDR step {step.step} needs review.",
+            "review_url": "",
+        },
+        "error": {
+            "summary": error.message if error else "",
+            "retryable": bool(error.retryable) if error else True,
+        },
+    }
+
+
+def _open_question_action_record(
+    run: PipelineRun,
+    item: dict[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    question_id = str(item.get("open_question_id") or item.get("id") or index)
+    return {
+        "schema_version": "action_record.v1",
+        "action_id": f"ddr:{run.run_id}:open_question:{_action_token(question_id)}",
+        "source_workflow": "ddr",
+        "owning_workflow": "ddr",
+        "alert_type": "open_verification_item",
+        "site": _site_payload(run),
+        "severity": "medium",
+        "status": "needs_review",
+        "action_requested": "Resolve DDR verification item and rerun or republish if needed.",
+        "action_taken": (
+            "DDR captured an unresolved verification item; no completed remediation "
+            "has been verified yet."
+        ),
+        "as_of": run.ended_at or run.started_at,
+        "owner": {
+            "workflow_owner": "ddr",
+            "human_owner": "",
+        },
+        "evidence": {
+            "readback": f"DDR run manifest {run.run_id} contains an open verification item.",
+        },
+        "review": {
+            "required": True,
+            "reason": "DDR open verification item needs operator review.",
+            "review_url": "",
+        },
+        "error": {
+            "summary": "",
+            "retryable": False,
+        },
+    }
+
+
+def _site_payload(run: PipelineRun) -> dict[str, str]:
+    return {
+        "site_id": run.site_id or "",
+        "name": run.site_title,
+        "current_milestone": "",
+    }
+
+
+def _action_token(value: str) -> str:
+    token = "".join(ch.lower() if ch.isalnum() else "_" for ch in value).strip("_")
+    while "__" in token:
+        token = token.replace("__", "_")
+    return token or "unknown"
 
 
 def failed_step_name(steps: list[StepResult]) -> str | None:

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -72,6 +72,73 @@ def test_pipeline_run_serializes_to_json() -> None:
     assert parsed["quality"]["score"] == 100
 
 
+def test_pipeline_run_emits_action_record_for_failed_step() -> None:
+    err = PipelineError(
+        code="report_generation_failed",
+        message="Agent completed without creating a report",
+        retryable=True,
+        operator_action="ddr rerun --run-id run-1 --step report.generate",
+    )
+    run = PipelineRun(
+        run_id="run-1",
+        site_title="Alpha Keller",
+        site_id="SITE1",
+        started_at="2026-05-14T00:00:00+00:00",
+        ended_at="2026-05-14T00:00:02+00:00",
+        final_status="generation_failed",
+        steps=[_step("failed", step="report.generate", error=err)],
+    )
+
+    record = run.to_dict()["action_records"][0]
+
+    assert record["schema_version"] == "action_record.v1"
+    assert record["action_id"] == "ddr:run-1:step:report.generate"
+    assert record["source_workflow"] == "ddr"
+    assert record["owning_workflow"] == "ddr"
+    assert record["alert_type"] == "report_generation_failed"
+    assert record["site"] == {
+        "site_id": "SITE1",
+        "name": "Alpha Keller",
+        "current_milestone": "",
+    }
+    assert record["status"] == "error"
+    assert record["review"]["required"] is True
+    assert record["error"] == {
+        "summary": "Agent completed without creating a report",
+        "retryable": True,
+    }
+
+
+def test_pipeline_run_emits_sanitized_action_record_for_open_question() -> None:
+    run = PipelineRun(
+        run_id="run-1",
+        site_title="Alpha Keller",
+        site_id="SITE1",
+        started_at="2026-05-14T00:00:00+00:00",
+        ended_at="2026-05-14T00:00:02+00:00",
+        final_status="report_incomplete",
+        steps=[_step("succeeded", step="report.generate")],
+        open_questions=[
+            {
+                "open_question_id": "zoning-use",
+                "display_text": "Confirm zoning use from the vendor SIR",
+            }
+        ],
+    )
+
+    record = run.to_dict()["action_records"][0]
+    serialized = json.dumps(record)
+
+    assert record["action_id"] == "ddr:run-1:open_question:zoning_use"
+    assert record["alert_type"] == "open_verification_item"
+    assert record["status"] == "needs_review"
+    assert record["action_requested"] == (
+        "Resolve DDR verification item and rerun or republish if needed."
+    )
+    assert record["review"]["reason"] == "DDR open verification item needs operator review."
+    assert "Confirm zoning use" not in serialized
+
+
 def test_quality_caps_failed_step_without_operator_action() -> None:
     run = PipelineRun(
         run_id="run-1",


### PR DESCRIPTION
## Summary
- Add ActionRecord v1 rows to DDR PipelineRun manifests for failed/blocked steps and open verification items
- Keep open-question ActionRecords sanitized so the dashboard action surface does not duplicate detailed review text
- Add contract tests and handoff notes

## Verification
- uv run pytest tests/test_report_pipeline.py tests/test_pipeline_contracts.py -q --basetemp C:\tmp\ddr-action-records-report-pipeline-clean
- uv run ruff check src/due_diligence_reporter/pipeline_contracts.py tests/test_pipeline_contracts.py
- uv run mypy src/due_diligence_reporter/pipeline_contracts.py
- git diff --check