### PR TITLE
Emit DDR actions for portfolio document gaps

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,43 @@
 # Due Diligence Reporter Handoff
 
+## 2026-06-08 - Portfolio Document Gap Action Telemetry
+
+Portfolio Gaps already routes missing P1 DRI and Drive-folder alerts to AADP,
+but missing current-milestone document alerts were still falling back to the
+dashboard's `Not routed yet` state. The enrichment wrapper now emits a
+DDR-owned ActionRecord v1 row for those document gaps, so operators can see the
+owning workflow, status, action taken, and as-of time.
+
+Changed:
+
+- `scripts/run_aadp_portfolio_gap_remediation.py` now appends DDR-owned
+  `needs_review` actions for `missing_current_milestone_documents` after AADP
+  remediation enrichment runs.
+- The action text is sanitized and does not enumerate missing document names in
+  the public action row; it states that DDR flagged current-milestone source
+  document follow-up and no document readback has been verified yet.
+- Existing AADP P1 DRI / Drive-folder remediation actions are preserved because
+  action replacement is now scoped by both gap type and source workflow.
+- `tests/test_aadp_portfolio_gap_remediation_trigger.py` covers DDR document
+  gap action emission and preservation of existing AADP actions.
+
+Verification:
+
+```powershell
+uv run pytest tests/test_aadp_portfolio_gap_remediation_trigger.py tests/test_workflow_contracts.py -q --basetemp C:\tmp\ddr-doc-gap-actions-tests-2
+uv run ruff check scripts/run_aadp_portfolio_gap_remediation.py tests/test_aadp_portfolio_gap_remediation_trigger.py tests/test_workflow_contracts.py
+uv run mypy scripts/run_aadp_portfolio_gap_remediation.py
+git diff --check
+```
+
+Results:
+
+- Focused pytest: 13 passed.
+- Ruff: all checks passed.
+- Mypy: no issues in the enrichment wrapper; the repo still prints the known
+  unused pyproject override note.
+- `git diff --check`: passed with expected Windows LF-to-CRLF notices only.
+
 ## 2026-06-08 - DDR ActionRecord v1 Manifest Emission
 
 Greg wants the dashboard to show not only workflow health, but the actual alert,

--- a/scripts/run_aadp_portfolio_gap_remediation.py
+++ b/scripts/run_aadp_portfolio_gap_remediation.py
@@ -14,10 +14,14 @@ from pathlib import Path
 from typing import Any, cast
 
 AADP_SOURCE = "alpha-analysis-downstream-processing"
+DDR_SOURCE = "due-diligence-reporter"
 PORTFOLIO_GAPS_SOURCE = "portfolio-gaps"
 ACTION_LABELS = {
     "missing_p1_dri": "Missing P1 DRI",
     "missing_drive_folder": "Missing Drive folder",
+}
+DDR_ACTION_LABELS = {
+    "missing_current_milestone_documents": "Missing current-milestone documents",
 }
 MAX_ERROR_LENGTH = 240
 
@@ -119,6 +123,68 @@ def mark_aadp_remediation_unavailable(
     return enriched
 
 
+def mark_ddr_document_gap_actions(
+    snapshot: dict[str, Any],
+    *,
+    as_of: str,
+) -> dict[str, Any]:
+    """Emit DDR-owned action telemetry for current-milestone document gaps."""
+
+    enriched = copy.deepcopy(snapshot)
+    remediation: dict[str, Any] = {
+        "source": DDR_SOURCE,
+        "status": "skipped",
+        "as_of": as_of,
+        "attempted_count": 0,
+        "needs_review_count": 0,
+    }
+    for site in _list_dicts(enriched.get("sites")):
+        for gap_type, label in DDR_ACTION_LABELS.items():
+            if gap_type not in _gap_reasons(site):
+                continue
+            remediation["attempted_count"] = int(remediation["attempted_count"]) + 1
+            action = {
+                "schema_version": "action_record.v1",
+                "source": DDR_SOURCE,
+                "source_workflow": PORTFOLIO_GAPS_SOURCE,
+                "owning_workflow": "ddr",
+                "workflow_owner": "ddr",
+                "gap_type": gap_type,
+                "alert": label,
+                "status": "needs_review",
+                "as_of": as_of,
+                "site_id": _site_id(site),
+                "site_name": _site_name(site),
+                "current_milestone": _current_milestone_label(site),
+                "action_requested": (
+                    "Review or associate the missing current-milestone source "
+                    "documents for this site."
+                ),
+                "action_taken": (
+                    "DDR flagged current-milestone source document follow-up; "
+                    "no document readback has been verified yet."
+                ),
+                "remediation_summary": (
+                    "DDR flagged current-milestone source document follow-up; "
+                    "no document readback has been verified yet."
+                ),
+                "review_required": True,
+                "review_reason": (
+                    "Current-milestone source documents are missing or not associated "
+                    "in Rhodes/Drive."
+                ),
+                "error_summary": "",
+                "retryable": False,
+            }
+            _replace_action(site, action)
+            remediation["needs_review_count"] = int(remediation["needs_review_count"]) + 1
+
+    if int(remediation["attempted_count"]):
+        remediation["status"] = "needs_review"
+    enriched["document_gap_remediation"] = remediation
+    return enriched
+
+
 def _load_aadp_remediator(aadp_repo: Path) -> Callable[..., dict[str, Any]] | None:
     src = aadp_repo / "src"
     if not src.is_dir():
@@ -137,12 +203,13 @@ def _load_aadp_remediator(aadp_repo: Path) -> Callable[..., dict[str, Any]] | No
 def _replace_action(site: dict[str, Any], action: dict[str, Any]) -> None:
     existing = _list_dicts(site.get("remediation_actions"))
     key = _action_key(action)
+    source = str(action.get("source") or "")
     site["remediation_actions"] = [
         item
         for item in existing
         if not (
             _action_key(item) == key
-            and str(item.get("source") or "") == AADP_SOURCE
+            and str(item.get("source") or "") == source
         )
     ]
     site["remediation_actions"].append(action)
@@ -163,6 +230,13 @@ def _site_id(site: dict[str, Any]) -> str:
 
 def _site_name(site: dict[str, Any]) -> str:
     return _first_str(site, "site_name", "name", "title", "marketingName") or "Unknown site"
+
+
+def _current_milestone_label(site: dict[str, Any]) -> str:
+    current = _dict(site.get("current_milestone"))
+    required_documents = _dict(site.get("required_documents"))
+    milestone = current or _dict(required_documents.get("milestone"))
+    return _first_str(milestone, "label", "key")
 
 
 def _first_str(value: dict[str, Any], *keys: str) -> str:
@@ -235,8 +309,10 @@ def main(argv: list[str] | None = None) -> int:
         dry_run=bool(args.dry_run),
         max_actions=max(0, int(args.max_actions)),
     )
+    enriched = mark_ddr_document_gap_actions(enriched, as_of=_iso(_utc_now()))
     _write_json(output_path, enriched)
     remediation = _dict(enriched.get("remediation"))
+    document_gap_remediation = _dict(enriched.get("document_gap_remediation"))
     print(
         "AADP remediation trigger "
         f"status={remediation.get('status', 'unknown')} "
@@ -244,6 +320,11 @@ def main(argv: list[str] | None = None) -> int:
         f"success={remediation.get('success_count', 0)} "
         f"needs_review={remediation.get('needs_review_count', 0)} "
         f"errors={remediation.get('error_count', 0)}"
+    )
+    print(
+        "DDR document gap action emission "
+        f"status={document_gap_remediation.get('status', 'unknown')} "
+        f"needs_review={document_gap_remediation.get('needs_review_count', 0)}"
     )
     return 0
 

--- a/tests/test_aadp_portfolio_gap_remediation_trigger.py
+++ b/tests/test_aadp_portfolio_gap_remediation_trigger.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 
 from scripts.run_aadp_portfolio_gap_remediation import (
     mark_aadp_remediation_unavailable,
+    mark_ddr_document_gap_actions,
     run_aadp_remediation,
 )
 
@@ -43,6 +44,83 @@ def test_unavailable_aadp_runner_marks_p1_and_drive_actions() -> None:
     assert result["sites"][0]["remediation_actions"][0]["status"] == "blocked"
     assert result["sites"][0]["remediation_actions"][0]["review_required"] is True
     assert result["sites"][1]["remediation_actions"][0]["gap_type"] == "missing_drive_folder"
+
+
+def test_ddr_document_gap_actions_mark_current_milestone_docs() -> None:
+    snapshot = {
+        "sites": [
+            {
+                "site_id": "SITE1",
+                "site_name": "Alpha Austin",
+                "gap_reasons": ["missing_current_milestone_documents"],
+                "required_documents": {
+                    "milestone": {"key": "acquireProperty", "label": "Acquiring Property"},
+                    "missing": ["lease"],
+                },
+            },
+            {
+                "site_id": "SITE2",
+                "site_name": "Alpha Tulsa",
+                "gap_reasons": ["missing_p1_dri"],
+            },
+        ]
+    }
+
+    result = mark_ddr_document_gap_actions(
+        snapshot,
+        as_of="2026-06-08T13:30:00+00:00",
+    )
+
+    assert result["document_gap_remediation"] == {
+        "source": "due-diligence-reporter",
+        "status": "needs_review",
+        "as_of": "2026-06-08T13:30:00+00:00",
+        "attempted_count": 1,
+        "needs_review_count": 1,
+    }
+    actions = result["sites"][0]["remediation_actions"]
+    assert len(actions) == 1
+    assert actions[0]["schema_version"] == "action_record.v1"
+    assert actions[0]["source_workflow"] == "portfolio-gaps"
+    assert actions[0]["owning_workflow"] == "ddr"
+    assert actions[0]["gap_type"] == "missing_current_milestone_documents"
+    assert actions[0]["status"] == "needs_review"
+    assert actions[0]["current_milestone"] == "Acquiring Property"
+    assert "lease" not in json.dumps(actions[0])
+    assert "remediation_actions" not in result["sites"][1]
+
+
+def test_ddr_document_gap_actions_preserve_aadp_actions() -> None:
+    snapshot = {
+        "sites": [
+            {
+                "site_id": "SITE1",
+                "site_name": "Alpha Austin",
+                "gap_reasons": [
+                    "missing_p1_dri",
+                    "missing_current_milestone_documents",
+                ],
+                "remediation_actions": [
+                    {
+                        "source": "alpha-analysis-downstream-processing",
+                        "gap_type": "missing_p1_dri",
+                        "status": "completed",
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = mark_ddr_document_gap_actions(
+        snapshot,
+        as_of="2026-06-08T13:30:00+00:00",
+    )
+
+    actions = result["sites"][0]["remediation_actions"]
+    assert [action["source"] for action in actions] == [
+        "alpha-analysis-downstream-processing",
+        "due-diligence-reporter",
+    ]
 
 
 def test_run_aadp_remediation_imports_checked_out_runner(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Add DDR-owned ActionRecord v1 rows for Portfolio Gaps missing current-milestone document alerts
- Preserve existing AADP P1/Drive remediation rows by scoping action replacement by source workflow
- Keep document-gap public action text sanitized and avoid enumerating missing docs in the action row

## Verification
- uv run pytest tests/test_aadp_portfolio_gap_remediation_trigger.py tests/test_workflow_contracts.py -q --basetemp C:\tmp\ddr-doc-gap-actions-tests-2
- uv run ruff check scripts/run_aadp_portfolio_gap_remediation.py tests/test_aadp_portfolio_gap_remediation_trigger.py tests/test_workflow_contracts.py
- uv run mypy scripts/run_aadp_portfolio_gap_remediation.py
- git diff --check