### PR TITLE
Deliver field-to-source-doc evidence with every DD proposal (ddr-4q0)

### DIFF
--- a/src/due_diligence_reporter/m2_executor.py
+++ b/src/due_diligence_reporter/m2_executor.py
@@ -32,6 +32,7 @@ from .rhodes import (
 from .source_packet import (
     SourceDocumentRef,
     build_m2_source_packet,
+    dd_field_update_sources,
     mark_written_fields_from_update_result,
     source_packet_is_complete,
     source_packet_note_lines,
@@ -103,8 +104,18 @@ class M2ExecutorAdapters(Protocol):
     def run_alpha_capacity(self, state: dict[str, Any]) -> M2StepResult:
         """Run or reuse Alpha Capacity Analysis and return capacity fields."""
 
-    def write_due_diligence(self, site_id: str, fields: dict[str, Any]) -> dict[str, Any]:
-        """Write LocationOS/Rhodes due diligence fields with readback."""
+    def write_due_diligence(
+        self,
+        site_id: str,
+        fields: dict[str, Any],
+        field_sources: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Write LocationOS/Rhodes due diligence fields with readback.
+
+        ``field_sources`` maps each field to the registered source document
+        title backing it, so approval-queue handoff notes carry the
+        field -> source-document evidence the approval reviewer needs.
+        """
 
     def run_cost_timeline(self, state: dict[str, Any]) -> M2StepResult:
         """Run or reuse the cost/timeline estimate source."""
@@ -219,7 +230,11 @@ def execute_m2_state(
                 next_action="write_capacity_fields",
             )
             return _finish(updated, steps, timestamp)
-        write_result = adapters.write_due_diligence(_site_id(updated), capacity_fields)
+        write_result = adapters.write_due_diligence(
+            _site_id(updated),
+            capacity_fields,
+            field_sources=_capacity_field_sources(updated, capacity_fields),
+        )
         updated["capacity_write"] = write_result
         steps.append(_dict_step_row("write_capacity_fields", write_result))
         if write_result.get("status") != "updated":
@@ -333,7 +348,11 @@ def execute_m2_state(
             next_action="write_packet_approved_dd_fields",
         )
         return _finish(updated, steps, timestamp)
-    write_result = adapters.write_due_diligence(_site_id(updated), write_fields)
+    write_result = adapters.write_due_diligence(
+        _site_id(updated),
+        write_fields,
+        field_sources=_packet_field_sources(packet),
+    )
     steps.append(_dict_step_row("write_packet_approved_dd_fields", write_result))
     packet = mark_written_fields_from_update_result(
         source_packet=packet,
@@ -478,8 +497,17 @@ class LiveM2ExecutorAdapters:
             raw=result,
         )
 
-    def write_due_diligence(self, site_id: str, fields: dict[str, Any]) -> dict[str, Any]:
-        return update_rhodes_due_diligence(site_id=site_id, fields=fields)
+    def write_due_diligence(
+        self,
+        site_id: str,
+        fields: dict[str, Any],
+        field_sources: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return update_rhodes_due_diligence(
+            site_id=site_id,
+            fields=fields,
+            field_sources=field_sources,
+        )
 
     def run_cost_timeline(self, state: dict[str, Any]) -> M2StepResult:
         existing = _registered_doc(state, "cost_timeline_estimate")
@@ -996,6 +1024,21 @@ def _capacity_locationos_fields(state: dict[str, Any]) -> dict[str, Any]:
     ):
         fields["maxCapCapacity"] = value
     return fields
+
+
+def _capacity_field_sources(
+    state: dict[str, Any],
+    capacity_fields: Mapping[str, Any],
+) -> dict[str, str]:
+    doc = _registered_doc(state, "alpha_capacity_analysis")
+    title = _text(doc.get("title")) if doc else ""
+    if not title:
+        title = "Alpha Capacity Analysis"
+    return dict.fromkeys(capacity_fields, title)
+
+
+def _packet_field_sources(packet: Mapping[str, Any]) -> dict[str, str]:
+    return dd_field_update_sources(packet.get("dd_field_updates") or [])
 
 
 def _normalize_locationos_value(key: str, value: Any) -> Any:

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -81,6 +81,7 @@ from .rhodes_events import (
 )
 from .sir_learning import build_sir_learning_review
 from .source_packet import (
+    dd_field_update_sources,
     locationos_fields_allowed_by_source_packet,
     mark_written_fields_from_update_result,
     source_packet_is_complete,
@@ -2437,7 +2438,16 @@ def _record_rhodes_due_diligence_update_step(
             fields=fields,
         )
     else:
-        update_status = update_rhodes_due_diligence(site_id=site_id, fields=fields)
+        field_sources = (
+            dd_field_update_sources(source_packet.get("dd_field_updates") or [])
+            if source_packet is not None
+            else None
+        )
+        update_status = update_rhodes_due_diligence(
+            site_id=site_id,
+            fields=fields,
+            field_sources=field_sources,
+        )
         if (
             due_diligence_write_mode == "mcp_assisted"
             and _due_diligence_update_needs_locationos_mcp(update_status)

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -1194,8 +1194,17 @@ def update_rhodes_due_diligence(
     owner_user_id: str = "",
     owner_email: str = "",
     fallback_owner_email: str = DOCUMENT_REGISTRATION_FALLBACK_OWNER_EMAIL,
+    field_sources: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Update Rhodes due diligence fields through LocationOS."""
+    """Update Rhodes due diligence fields through LocationOS.
+
+    ``field_sources`` maps LocationOS field keys to the registered source
+    document title backing each proposed value. When the write lands in the
+    LocationOS approval queue, these lines go into the handoff note so the
+    approval reviewer can validate each proposed change against the
+    registered document. Fields without an entry are labeled workflow
+    fields with no source document.
+    """
 
     clean_site_id = site_id.strip()
     clean_fields = _clean_due_diligence_fields(fields)
@@ -1242,6 +1251,7 @@ def update_rhodes_due_diligence(
                 owner_user_id=owner_user_id,
                 owner_email=owner_email,
                 fallback_owner_email=fallback_owner_email,
+                field_sources=field_sources,
             )
             return _due_diligence_handoff_result(
                 base=base,
@@ -1285,6 +1295,7 @@ def update_rhodes_due_diligence(
             owner_user_id=owner_user_id,
             owner_email=owner_email,
             fallback_owner_email=fallback_owner_email,
+            field_sources=field_sources,
         )
         return _due_diligence_handoff_result(
             base=base,
@@ -1500,11 +1511,15 @@ def _due_diligence_field_handoff_value(value: Any) -> str:
     return text if len(text) <= 500 else f"{text[:497]}..."
 
 
+WORKFLOW_FIELD_SOURCE_LABEL = "workflow field - no source document"
+
+
 def _build_due_diligence_update_handoff_note_body(
     *,
     site_name: str,
     site_address: str,
     fields: dict[str, Any],
+    field_sources: Mapping[str, str] | None = None,
 ) -> str:
     lines = [
         f"Site Name: {site_name.strip()}",
@@ -1514,6 +1529,11 @@ def _build_due_diligence_update_handoff_note_body(
     ]
     for key in sorted(fields):
         lines.append(f"{key}: {_due_diligence_field_handoff_value(fields[key])}")
+    if field_sources is not None:
+        lines.append("Supporting documents (registered on this site record):")
+        for key in sorted(fields):
+            source = str(field_sources.get(key) or "").strip()
+            lines.append(f"{key}: {source or WORKFLOW_FIELD_SOURCE_LABEL}")
     return "\n".join(lines)
 
 
@@ -1549,6 +1569,7 @@ def _create_due_diligence_update_handoff(
     owner_user_id: str = "",
     owner_email: str = "",
     fallback_owner_email: str = DOCUMENT_REGISTRATION_FALLBACK_OWNER_EMAIL,
+    field_sources: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     clean_site_id = site_id.strip()
     clean_fields = _clean_due_diligence_fields(fields)
@@ -1606,6 +1627,7 @@ def _create_due_diligence_update_handoff(
         site_name=resolved_site_name,
         site_address=resolved_site_address,
         fields=clean_fields,
+        field_sources=field_sources,
     )
     note = add_rhodes_site_note(
         site_id=clean_site_id,
@@ -1647,6 +1669,7 @@ def _create_due_diligence_update_handoff(
             {
                 "name": key,
                 "value": _due_diligence_field_handoff_value(clean_fields[key]),
+                "source": str((field_sources or {}).get(key) or "").strip(),
             }
             for key in sorted(clean_fields)
         ],

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -4953,6 +4953,17 @@ async def apply_alpha_phasing_plan_skill(
     return await asyncio.to_thread(_work)
 
 
+SKILL_REPORT_DDR_DOC_TYPES = {
+    "e-occupancy": "e_occupancy_report",
+    "school approval": "school_approval_report",
+    "opening plan": "opening_plan_report",
+    "alpha capacity analysis": "alpha_capacity_analysis",
+    "outdoor play space": "outdoor_play_space_report",
+    "security due diligence": "security_due_diligence_report",
+    "alpha phasing plan": "alpha_phasing_plan_report",
+}
+
+
 @mcp.tool()
 async def save_skill_report(
     skill_name: str,
@@ -5023,10 +5034,13 @@ async def save_skill_report(
             doc_id = str(doc.get("id") or "").strip()
             doc_url = str(doc.get("webViewLink") or "").strip()
             rhodes_registration: dict[str, Any] | None = None
-            if site_id.strip() and ddr_doc_type.strip() and doc_id:
+            resolved_doc_type = ddr_doc_type.strip() or SKILL_REPORT_DDR_DOC_TYPES.get(
+                skill_name.strip().casefold(), ""
+            )
+            if site_id.strip() and resolved_doc_type and doc_id:
                 rhodes_registration = register_rhodes_document_for_upload(
                     site_id=site_id,
-                    ddr_doc_type=ddr_doc_type,
+                    ddr_doc_type=resolved_doc_type,
                     title=doc_name,
                     drive_file_id=doc_id,
                     drive_url=doc_url,
@@ -5034,6 +5048,19 @@ async def save_skill_report(
                     original_filename=doc_name,
                     source="save_skill_report",
                 )
+            elif doc_id:
+                # Registration is load-bearing for the DD approval flow: the
+                # approval agent validates proposed fields against documents
+                # registered on the site record, so a skipped registration
+                # must be visible to the caller, never silent.
+                rhodes_registration = {
+                    "status": "skipped",
+                    "reason": (
+                        "missing_site_id"
+                        if not site_id.strip()
+                        else "unmapped_skill_doc_type"
+                    ),
+                }
             result: dict[str, Any] = {
                 "status": "success",
                 "doc_id": doc_id,

--- a/src/due_diligence_reporter/source_packet.py
+++ b/src/due_diligence_reporter/source_packet.py
@@ -409,6 +409,29 @@ def source_packet_completion(
     }
 
 
+def dd_field_update_sources(
+    dd_field_updates: Sequence[DDFieldUpdate | dict[str, Any]],
+) -> dict[str, str]:
+    """Map LocationOS field keys to the registered source-doc titles backing them.
+
+    Used to put field -> source-document evidence into approval-queue
+    handoff notes so the approval reviewer can validate each proposed
+    change against the documents registered on the site record.
+    """
+
+    sources: dict[str, str] = {}
+    for raw in dd_field_updates:
+        update = _coerce_field_update(raw)
+        if not update.locationos_key:
+            continue
+        titles = [_safe_title(title) for title in update.source_titles if str(title).strip()]
+        if not titles:
+            titles = [str(name).strip() for name in update.required_source_docs if str(name).strip()]
+        if titles:
+            sources[update.locationos_key] = ", ".join(titles)
+    return sources
+
+
 def source_packet_note_lines(
     *,
     supporting_documents: Sequence[SourceDocumentRef | dict[str, Any]],

--- a/tests/test_dd_output_fixes.py
+++ b/tests/test_dd_output_fixes.py
@@ -1026,6 +1026,73 @@ class TestAsyncOffloading:
         gc.create_document.assert_called_once()
         gc.upload_file_to_folder.assert_not_called()
         mock_to_thread.assert_awaited_once()
+        assert result["rhodes_registration"] == {
+            "status": "skipped",
+            "reason": "missing_site_id",
+        }
+
+    def test_save_skill_report_infers_doc_type_from_skill_name(self) -> None:
+        from due_diligence_reporter.server import save_skill_report
+
+        gc = MagicMock()
+        gc.list_subfolders.return_value = [{"id": "m1-folder", "name": "M1 Property Acquired"}]
+        gc.create_document.return_value = {"id": "doc123", "webViewLink": "https://example.com/doc123"}
+
+        async def run_inline(func: Any, *args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        with patch(
+            "due_diligence_reporter.server.asyncio.to_thread",
+            new=AsyncMock(side_effect=run_inline),
+        ), patch(
+            "due_diligence_reporter.server._make_google_client",
+            return_value=gc,
+        ), patch(
+            "due_diligence_reporter.server.register_rhodes_document_for_upload",
+            return_value={"status": "registered"},
+        ) as mock_register:
+            result = asyncio.run(save_skill_report(
+                skill_name="E-Occupancy",
+                site_name="Alpha",
+                site_id="SITE1",
+                drive_folder_url="https://drive.google.com/drive/folders/folder123",
+                skill_data={"final_score": 90},
+            ))
+
+        assert result["status"] == "success"
+        assert result["rhodes_registration"] == {"status": "registered"}
+        assert mock_register.call_args.kwargs["ddr_doc_type"] == "e_occupancy_report"
+
+    def test_save_skill_report_reports_unmapped_doc_type_skip(self) -> None:
+        from due_diligence_reporter.server import save_skill_report
+
+        gc = MagicMock()
+        gc.list_subfolders.return_value = [{"id": "m1-folder", "name": "M1 Property Acquired"}]
+        gc.create_document.return_value = {"id": "doc123", "webViewLink": "https://example.com/doc123"}
+
+        async def run_inline(func: Any, *args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        with patch(
+            "due_diligence_reporter.server.asyncio.to_thread",
+            new=AsyncMock(side_effect=run_inline),
+        ), patch(
+            "due_diligence_reporter.server._make_google_client",
+            return_value=gc,
+        ):
+            result = asyncio.run(save_skill_report(
+                skill_name="Permit History",
+                site_name="Alpha",
+                site_id="SITE1",
+                drive_folder_url="https://drive.google.com/drive/folders/folder123",
+                skill_data={"summary": "clean"},
+            ))
+
+        assert result["status"] == "success"
+        assert result["rhodes_registration"] == {
+            "status": "skipped",
+            "reason": "unmapped_skill_doc_type",
+        }
 
     def test_create_dd_report_uses_to_thread(self) -> None:
         from due_diligence_reporter.server import create_dd_report

--- a/tests/test_m2_executor.py
+++ b/tests/test_m2_executor.py
@@ -89,6 +89,7 @@ class FakeAdapters:
         self.phase_source_type = phase_source_type
         self.calls: list[str] = []
         self.write_calls: list[dict[str, Any]] = []
+        self.write_field_sources: list[dict[str, str] | None] = []
 
     def run_alpha_capacity(self, state: dict[str, Any]) -> M2StepResult:
         del state
@@ -108,10 +109,16 @@ class FakeAdapters:
             ],
         )
 
-    def write_due_diligence(self, site_id: str, fields: dict[str, Any]) -> dict[str, Any]:
+    def write_due_diligence(
+        self,
+        site_id: str,
+        fields: dict[str, Any],
+        field_sources: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         del site_id
         self.calls.append("write")
         self.write_calls.append(dict(fields))
+        self.write_field_sources.append(dict(field_sources) if field_sources else None)
         status = (
             self.capacity_write_status
             if set(fields) <= {"foCapacity", "maxCapCapacity"}
@@ -284,6 +291,14 @@ def test_execute_ready_m2_state_completes_successfully(tmp_path) -> None:
     ]
     assert adapters.write_calls[0] == {"foCapacity": 36, "maxCapCapacity": 54}
     assert "foCapEx" in adapters.write_calls[1]
+    assert adapters.write_field_sources[0] == {
+        "foCapacity": "Alpha Capacity Analysis",
+        "maxCapCapacity": "Alpha Capacity Analysis",
+    }
+    packet_sources = adapters.write_field_sources[1]
+    assert packet_sources is not None
+    assert packet_sources["foCapacity"] == "Alpha Capacity Analysis"
+    assert set(packet_sources) >= set(adapters.write_calls[1])
 
 
 def test_execute_ready_dry_run_does_not_mutate_state(tmp_path) -> None:
@@ -449,6 +464,10 @@ def test_capacity_handoff_note_completes_manual_followup(tmp_path) -> None:
     assert adapters.calls == ["alpha", "write"]
     assert "cost" not in adapters.calls
     assert "note" not in adapters.calls
+    assert adapters.write_field_sources[0] == {
+        "foCapacity": "Alpha Capacity Analysis",
+        "maxCapCapacity": "Alpha Capacity Analysis",
+    }
 
 
 def test_failed_source_registration_blocks_before_packet_write(tmp_path) -> None:

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -37,7 +37,7 @@ def _isolate_report_event_manifest_dir(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("due_diligence_reporter.report_pipeline.RUN_MANIFEST_DIR", tmp_path)
     monkeypatch.setattr(
         "due_diligence_reporter.report_pipeline.update_rhodes_due_diligence",
-        lambda *, site_id, fields: {
+        lambda *, site_id, fields, field_sources=None: {
             "status": "skipped",
             "reason": "test_default",
             "rhodes_site_id": site_id,
@@ -131,9 +131,15 @@ def test_canonicalize_site_tool_input_adds_context_for_alpha_capacity() -> None:
 def test_record_due_diligence_update_respects_source_packet(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
-    def fake_update(*, site_id: str, fields: dict[str, Any]) -> dict[str, Any]:
+    def fake_update(
+        *,
+        site_id: str,
+        fields: dict[str, Any],
+        field_sources: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         captured["site_id"] = site_id
         captured["fields"] = dict(fields)
+        captured["field_sources"] = dict(field_sources) if field_sources else None
         return {
             "status": "updated",
             "updated_fields": sorted(fields),
@@ -196,6 +202,7 @@ def test_record_due_diligence_update_respects_source_packet(monkeypatch) -> None
 
     assert captured["fields"]["playAreaScore"] == 1
     assert "regulatoryScore" not in captured["fields"]
+    assert captured["field_sources"]["playAreaScore"] == "Outdoor Play Space Report"
     assert result.rhodes_due_diligence_update is not None
     assert result.rhodes_due_diligence_update["source_packet_status"] == "blocked"
     assert result.rhodes_due_diligence_update["m2_source_packet_complete"] is False

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -1205,11 +1205,49 @@ def test_update_rhodes_due_diligence_handoffs_browser_approval_response() -> Non
     assert handoff["rhodes_note_id"] == "NOTE1"
     assert handoff["field_count"] == 2
     assert handoff["fields"] == [
-        {"name": "foCapacity", "value": "36"},
-        {"name": "maxCapCapacity", "value": "54"},
+        {"name": "foCapacity", "value": "36", "source": ""},
+        {"name": "maxCapCapacity", "value": "54", "source": ""},
     ]
     assert client.notes[0]["body"] == expected_body
     assert client.notes[0]["mentions"] == ["OWNER1"]
+
+
+def test_update_rhodes_due_diligence_handoff_note_includes_field_sources() -> None:
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Test",
+            "slug": "alpha-test",
+            "address": "123 Main St, Denver, CO 80202",
+            "p1Dri": {"email": "owner@example.com", "userId": "OWNER1"},
+        },
+        due_diligence_response={
+            "status": "awaiting_browser_approval",
+            "pendingMutationId": "MUT1",
+        },
+    )
+
+    result = update_rhodes_due_diligence(
+        site_id="SITE1",
+        fields={"foCapacity": 36, "status": "data-gathering"},
+        client=client,  # type: ignore[arg-type]
+        field_sources={"foCapacity": "Alpha Capacity Analysis - Alpha Test.json"},
+    )
+
+    handoff = result["due_diligence_update_handoff"]
+    note_body = handoff["note_body"]
+    assert "Supporting documents (registered on this site record):" in note_body
+    assert "foCapacity: Alpha Capacity Analysis - Alpha Test.json" in note_body
+    assert "status: workflow field - no source document" in note_body
+    assert handoff["fields"] == [
+        {
+            "name": "foCapacity",
+            "value": "36",
+            "source": "Alpha Capacity Analysis - Alpha Test.json",
+        },
+        {"name": "status", "value": "data-gathering", "source": ""},
+    ]
+    assert client.notes[0]["body"] == note_body
 
 
 def test_update_rhodes_due_diligence_handoffs_elicitation_exception() -> None:

--- a/tests/test_source_packet.py
+++ b/tests/test_source_packet.py
@@ -8,6 +8,7 @@ from due_diligence_reporter.source_packet import (
     SourceDocumentRef,
     build_dd_field_updates,
     build_m2_source_packet,
+    dd_field_update_sources,
     locationos_fields_allowed_by_source_packet,
     m2_field_matrix,
     source_packet_completion,
@@ -334,3 +335,45 @@ def test_translate_outdoor_play_score_uses_confidence_and_review_rules() -> None
     assert "manual review" in yellow["comment"].lower()
     assert red["score"] == 3
     assert "No viable" in red["comment"]
+
+
+def test_dd_field_update_sources_maps_locationos_keys_to_doc_titles() -> None:
+    updates = [
+        {
+            "field": "fast_open_capacity",
+            "locationos_key": "foCapacity",
+            "value": 36,
+            "writer": "alpha_capacity_analysis",
+            "required_source_docs": ("Alpha Capacity Analysis",),
+            "write_status": "pending",
+            "readback_status": "",
+            "source_titles": ("Alpha Capacity Analysis - Site.json",),
+        },
+        {
+            "field": "building_score",
+            "locationos_key": "buildingScore",
+            "value": 1,
+            "writer": "phase_1_phase_2",
+            "required_source_docs": ("Phase 1 Phase 2 workbook",),
+            "write_status": "pending",
+            "readback_status": "",
+            "source_titles": (),
+        },
+        {
+            "field": "zoning_status_confirmed",
+            "locationos_key": None,
+            "value": True,
+            "writer": "regulatory_resolver",
+            "required_source_docs": ("SIR",),
+            "write_status": "held",
+            "readback_status": "",
+            "source_titles": ("Vendor SIR",),
+        },
+    ]
+
+    sources = dd_field_update_sources(updates)
+
+    assert sources == {
+        "foCapacity": "Alpha Capacity Analysis - Site.json",
+        "buildingScore": "Phase 1 Phase 2 workbook",
+    }


### PR DESCRIPTION
## Why

DD field writes route into a LocationOS approval queue where an approval agent validates each proposed change against the supporting documents registered on the site record. Before this change, the field → value → source-document evidence note was skipped in exactly that path: the M2 executor returned on handoff before `add_source_note`, and handoff note bodies carried field names and values only — leaving the approval reviewer nothing to validate against.

## What

- **rhodes.py** — `update_rhodes_due_diligence` accepts an optional `field_sources` map (LocationOS field key → registered source-doc title). Approval-queue handoff notes now include a **Supporting documents (registered on this site record)** section; fields with no source are labeled `workflow field - no source document` so the reviewer can tell deliberate workflow metadata from missing evidence. Handoff result `fields` rows carry a `source` key for telemetry.
- **source_packet.py** — new `dd_field_update_sources()` builds the map from packet `dd_field_updates` (source titles, falling back to required-source labels).
- **m2_executor.py** — both executor writes pass evidence: the capacity write maps to the registered Alpha Capacity Analysis title, the packet write to packet-derived sources.
- **report_pipeline.py** — the daily-sweep write passes packet-derived sources too, so its handoff notes carry the same evidence. Ungated system fields (status, recommendation, dateCompleted, ddReportLink) surface as workflow fields.
- **server.py** — `save_skill_report` resolves the Rhodes doc type from the skill name when the caller omits it (fixes e.g. silent skips), and returns an explicit `rhodes_registration: skipped` reason instead of registering nothing silently — registration is load-bearing for the approval flow.

## Verification

- Full suite: **1358 passed, 13 skipped** (baseline 1354; +4 new tests covering the note section, workflow-field labeling, source mapping, executor propagation, and save_skill_report skip visibility)
- ruff clean, mypy clean (52 files)
- Independent reviewer pass: no blocking findings; two follow-up candidates filed as beads

## Notes

- Merging to main deploys to MCP Hive via the publish workflow.
- Beads: closes `ddr-4q0`; follow-ups filed for MCP-assisted write-path evidence and fallback-label wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)