### PR TITLE
Treat approval-queued DD writes as submitted proposals

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,36 @@
 # Due Diligence Reporter Handoff
 
+## 2026-07-07 - Approval-queued DD writes are successful submissions
+
+- Per Greg's direction, DD field writes that land in the LocationOS approval
+  queue are now the expected execution path: DDR executes the write, logs the
+  action, and leaves status tracking to the site owner. Confirmation/readback
+  after the approval decision is a deferred slice (see `ddr-dzc`).
+- New contract in `rhodes.update_rhodes_due_diligence`: a response carrying an
+  approval artifact (`pendingMutationId`, `approvalSessionId`, or `reviewUrl`)
+  returns `status=proposal_submitted` / `reason=approval_queue` with an
+  `approval` metadata block, posts an owner note asking to review/approve the
+  pending change (with field -> source-document evidence and the review link),
+  and records the manifest step as succeeded. A pending-approval status
+  WITHOUT an artifact is not proof a pending change persisted and stays on the
+  legacy copy/paste manual-handoff path (`pending_user_action`).
+- M2 executor completes proposal runs with
+  `completion_mode=due_diligence_proposal_submitted`,
+  `human_followup_type=due_diligence_approval`, packet status
+  `proposal_awaiting_approval`, and field rows marked `proposal_submitted`;
+  the legacy `due_diligence_update_handoff` completion mode still covers
+  manual-handoff cases. `mark_written_fields_from_update_result` and the DD
+  summary event render the proposal state ("Submitted for approval") on the
+  site-pipeline path too.
+- Known deferred items: post-approval readback and rejection handling
+  (`ddr-dzc`), approval-queue dedupe on note-failure retries, and the
+  resume-mcp-write verify path still classifying queued writes by readback
+  only.
+- Validation: full DDR pytest passed (`1364 passed, 13 skipped`); full Ruff
+  passed; full mypy passed (`52 source files`); independent reviewer pass —
+  blocking finding (status-only detection) fixed, medium findings (event
+  rendering, site-pipeline packet marking) fixed in the same change.
+
 ## 2026-07-05 - Portfolio Remediation Checkout Fails Closed
 
 - Removed `continue-on-error: true` from the

--- a/src/due_diligence_reporter/automation_event.py
+++ b/src/due_diligence_reporter/automation_event.py
@@ -332,6 +332,8 @@ def _dd_report_rhodes_fields_line(rhodes_update: str) -> str:
         return ""
     if rhodes_update.startswith("failed"):
         return "Did not update. Technical details are in the run record."
+    if rhodes_update.startswith("submitted for approval"):
+        return "Submitted for approval; pending in the LocationOS approval queue."
     return "Updated."
 
 
@@ -339,6 +341,8 @@ def _dd_report_next_steps(open_count: int, rhodes_update: str) -> list[str]:
     steps = ["- Review the DD report."]
     if rhodes_update.startswith("failed"):
         steps.append("- Confirm the Rhodes field update is repaired.")
+    elif rhodes_update.startswith("submitted for approval"):
+        steps.append("- Review and approve or reject the pending due diligence change.")
     elif rhodes_update:
         steps.append("- Confirm the Rhodes fields are correct.")
     if open_count > 0:
@@ -528,6 +532,7 @@ def build_dd_report_summary_event(
     )
     due_diligence_written = due_diligence_status == "updated"
     due_diligence_failed = due_diligence_status == "failed"
+    due_diligence_proposed = due_diligence_status == "proposal_submitted"
     artifact_ids = {
         "Run ID": run_id,
     }
@@ -545,7 +550,7 @@ def build_dd_report_summary_event(
         "Closed item count": str(len(closed_items)),
         "Outstanding vendor docs": _format_missing_docs(missing_vendor_docs),
     }
-    if due_diligence_written or due_diligence_failed:
+    if due_diligence_written or due_diligence_failed or due_diligence_proposed:
         assert due_diligence_update_data is not None
         details["Rhodes due diligence update"] = _format_due_diligence_update(
             due_diligence_update_data
@@ -610,6 +615,7 @@ def build_dd_report_republish_candidate_event(
     )
     due_diligence_written = due_diligence_status == "updated"
     due_diligence_failed = due_diligence_status == "failed"
+    due_diligence_proposed = due_diligence_status == "proposal_submitted"
     artifact_ids = {"Run ID": run_id}
     if candidate_doc_id:
         artifact_ids["Candidate DD report ID"] = candidate_doc_id
@@ -624,7 +630,7 @@ def build_dd_report_republish_candidate_event(
         "Candidate DD report URL": str(candidate_doc_url or "").strip(),
         "Guard reason": str(guard.get("reason") or "").strip(),
     }
-    if due_diligence_written or due_diligence_failed:
+    if due_diligence_written or due_diligence_failed or due_diligence_proposed:
         assert due_diligence_update_data is not None
         details["Rhodes due diligence update"] = _format_due_diligence_update(
             due_diligence_update_data
@@ -675,6 +681,10 @@ def _format_due_diligence_update(update: dict[str, Any]) -> str:
         if field_text:
             return f"failed to update {field_text}: {error}"
         return f"failed: {error}"
+    if status == "proposal_submitted":
+        if field_text:
+            return f"submitted for approval: {field_text}"
+        return "submitted for approval"
     if field_text:
         return f"updated {field_text}"
     return "updated"

--- a/src/due_diligence_reporter/m2_executor.py
+++ b/src/due_diligence_reporter/m2_executor.py
@@ -74,6 +74,8 @@ KNOWN_EXECUTOR_ACTIONS = frozenset(
 REGISTERED_STATUSES = frozenset({"registered", "already_registered"})
 DUE_DILIGENCE_HANDOFF_COMPLETION_MODE = "due_diligence_update_handoff"
 DUE_DILIGENCE_HANDOFF_PACKET_STATUS = "handoff_pending_manual_update"
+DUE_DILIGENCE_PROPOSAL_COMPLETION_MODE = "due_diligence_proposal_submitted"
+DUE_DILIGENCE_PROPOSAL_PACKET_STATUS = "proposal_awaiting_approval"
 SCORE_KEYS = frozenset(
     {
         "buildingScore",
@@ -920,11 +922,19 @@ def _pending_locationos_fields(packet: dict[str, Any]) -> dict[str, Any]:
     return fields
 
 
+def _due_diligence_write_is_proposal(result: Mapping[str, Any]) -> bool:
+    return (
+        _text(result.get("status")) == "proposal_submitted"
+        and _text(result.get("reason")) == "approval_queue"
+    )
+
+
 def _due_diligence_handoff_verified(result: Mapping[str, Any]) -> bool:
-    if _text(result.get("status")) != "pending_user_action":
-        return False
-    if _text(result.get("reason")) != "handoff_note_created":
-        return False
+    if not _due_diligence_write_is_proposal(result):
+        if _text(result.get("status")) != "pending_user_action":
+            return False
+        if _text(result.get("reason")) != "handoff_note_created":
+            return False
     handoff = _dict(result.get("due_diligence_update_handoff"))
     if _text(handoff.get("status")) != "created":
         return False
@@ -939,10 +949,15 @@ def _complete_with_due_diligence_handoff(
 ) -> None:
     handoff = _dict(write_result.get("due_diligence_update_handoff"))
     note_id = _text(handoff.get("rhodes_note_id"))
+    is_proposal = _due_diligence_write_is_proposal(write_result)
     state["status"] = "complete"
     state["m2_state"] = "complete"
     state["open_blockers"] = []
-    state["completion_mode"] = DUE_DILIGENCE_HANDOFF_COMPLETION_MODE
+    state["completion_mode"] = (
+        DUE_DILIGENCE_PROPOSAL_COMPLETION_MODE
+        if is_proposal
+        else DUE_DILIGENCE_HANDOFF_COMPLETION_MODE
+    )
     state["human_followup_required"] = True
     state["human_followup_type"] = (
         _text(write_result.get("human_followup_type"))
@@ -951,13 +966,14 @@ def _complete_with_due_diligence_handoff(
     )
     state["manual_handoff"] = _json_safe(
         {
-            "type": "due_diligence_update",
+            "type": "due_diligence_approval" if is_proposal else "due_diligence_update",
             "status": _text(handoff.get("status")) or "created",
             "reason": _text(write_result.get("reason") or handoff.get("reason")),
             "rhodes_note_id": note_id,
             "note_readback_status": _handoff_note_readback_status(handoff),
             "field_count": handoff.get("field_count"),
             "fields": _list_of_dicts(handoff.get("fields")),
+            "approval": _dict(write_result.get("approval")),
         }
     )
     state["manual_handoff_note_id"] = note_id
@@ -975,6 +991,8 @@ def _mark_packet_handoff_pending(
         return packet
     handoff = _dict(write_result.get("due_diligence_update_handoff"))
     note_id = _text(handoff.get("rhodes_note_id"))
+    is_proposal = _due_diligence_write_is_proposal(write_result)
+    field_status = "proposal_submitted" if is_proposal else "pending_user_action"
     updated_fields = {
         str(field).strip()
         for field in write_result.get("updated_fields", [])
@@ -985,17 +1003,24 @@ def _mark_packet_handoff_pending(
     for raw_update in raw_updates:
         row = dict(raw_update) if isinstance(raw_update, dict) else {}
         if _text(row.get("locationos_key")) in updated_fields:
-            row["write_status"] = "pending_user_action"
-            row["readback_status"] = "pending_user_action"
+            row["write_status"] = field_status
+            row["readback_status"] = field_status
             row["hold_reason"] = reason
             if note_id:
                 row["handoff_note_id"] = note_id
         next_updates.append(row)
     packet["dd_field_updates"] = next_updates
-    packet["status"] = DUE_DILIGENCE_HANDOFF_PACKET_STATUS
+    packet["status"] = (
+        DUE_DILIGENCE_PROPOSAL_PACKET_STATUS if is_proposal else DUE_DILIGENCE_HANDOFF_PACKET_STATUS
+    )
     packet["m2_source_packet_complete"] = False
     packet["open_items"] = [
-        "LocationOS due diligence fields require manual update from verified handoff note."
+        (
+            "LocationOS due diligence fields await the approval-queue decision; "
+            "site owner tracks the pending change."
+        )
+        if is_proposal
+        else "LocationOS due diligence fields require manual update from verified handoff note."
     ]
     packet["manual_handoff_note_id"] = note_id
     packet["manual_handoff_note_readback_status"] = _handoff_note_readback_status(handoff)

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -2484,7 +2484,10 @@ def _record_rhodes_due_diligence_update_step(
         metadata=update_status,
     )
     status = str(update_status.get("status") or "")
-    if status == "updated":
+    if status in {"updated", "proposal_submitted"}:
+        # proposal_submitted means the write entered the LocationOS approval
+        # queue and the owner note was verified: the action executed and is
+        # logged; the site owner tracks the pending change from here.
         recorder.record(
             DUE_DILIGENCE_UPDATE_STEP,
             started_at,

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -23,6 +23,8 @@ DOCUMENT_REGISTRATION_FOLLOWUP_TYPE = "document_registration"
 DOCUMENT_REGISTRATION_FALLBACK_OWNER_EMAIL = "greg.foote@trilogy.com"
 DUE_DILIGENCE_UPDATE_PENDING_USER_ACTION = "pending_user_action"
 DUE_DILIGENCE_UPDATE_FOLLOWUP_TYPE = "due_diligence_update"
+DUE_DILIGENCE_PROPOSAL_SUBMITTED = "proposal_submitted"
+DUE_DILIGENCE_APPROVAL_FOLLOWUP_TYPE = "due_diligence_approval"
 REQUEST_ID_RE = re.compile(r"Request ID:\s*([A-Za-z0-9-]+)")
 DOCUMENT_REGISTRATION_HANDOFF_ERROR_MARKERS = (
     "approval",
@@ -1281,6 +1283,26 @@ def update_rhodes_due_diligence(
             "error_summary": _summarize_locationos_write_error(str(exc)),
         }
 
+    if _due_diligence_response_approval_queued(response):
+        handoff = _create_due_diligence_update_handoff(
+            site_id=clean_site_id,
+            fields=clean_fields,
+            rhodes=rhodes,
+            mcp_note_client=mcp_note_client,
+            notes_client=notes_client,
+            owner_user_id=owner_user_id,
+            owner_email=owner_email,
+            fallback_owner_email=fallback_owner_email,
+            field_sources=field_sources,
+            proposal=True,
+            review_url=str(response.get("reviewUrl") or "").strip(),
+        )
+        return _due_diligence_proposal_result(
+            base=base,
+            response=response,
+            handoff=handoff,
+        )
+
     if _due_diligence_response_needs_handoff(response):
         error = (
             _due_diligence_response_error(response)
@@ -1537,23 +1559,74 @@ def _build_due_diligence_update_handoff_note_body(
     return "\n".join(lines)
 
 
+def _build_due_diligence_proposal_note_body(
+    *,
+    site_name: str,
+    site_address: str,
+    fields: dict[str, Any],
+    field_sources: Mapping[str, str] | None = None,
+    review_url: str = "",
+) -> str:
+    lines = [
+        f"Site Name: {site_name.strip()}",
+        f"Site Address: {site_address.strip()}",
+        (
+            "DDR submitted these due diligence field values to the LocationOS "
+            "approval queue. Please review the pending change and approve or "
+            "reject it:"
+        ),
+        "Due Diligence Fields proposed:",
+    ]
+    for key in sorted(fields):
+        lines.append(f"{key}: {_due_diligence_field_handoff_value(fields[key])}")
+    if field_sources is not None:
+        lines.append("Supporting documents (registered on this site record):")
+        for key in sorted(fields):
+            source = str(field_sources.get(key) or "").strip()
+            lines.append(f"{key}: {source or WORKFLOW_FIELD_SOURCE_LABEL}")
+    if review_url.strip():
+        lines.append(f"Review link: {review_url.strip()}")
+    return "\n".join(lines)
+
+
 def _due_diligence_update_error_is_handoff_eligible(error: str) -> bool:
     message = str(error or "").casefold()
     return any(marker in message for marker in DUE_DILIGENCE_UPDATE_HANDOFF_ERROR_MARKERS)
 
 
-def _due_diligence_response_needs_handoff(response: dict[str, Any]) -> bool:
-    status = str(response.get("status") or "").strip().casefold()
-    if status in {
+_DUE_DILIGENCE_PENDING_APPROVAL_STATUSES = frozenset(
+    {
         "awaiting_browser_approval",
         "awaiting_approval",
         "pending_approval",
         "pending_browser_approval",
         "pending_confirmation",
         "requires_approval",
-    }:
+    }
+)
+
+
+def _due_diligence_response_approval_queued(response: dict[str, Any]) -> bool:
+    """True when the response proves the write entered the LocationOS approval queue.
+
+    Requires an approval artifact identifier (pending mutation, approval
+    session, or review URL). A pending-approval status alone is not proof:
+    it can describe an interactive elicitation that never persisted a
+    pending change, so status-only responses stay on the manual handoff
+    path instead of being reported as submitted proposals.
+    """
+
+    return any(
+        str(response.get(key) or "").strip()
+        for key in ("pendingMutationId", "approvalSessionId", "reviewUrl")
+    )
+
+
+def _due_diligence_response_needs_handoff(response: dict[str, Any]) -> bool:
+    status = str(response.get("status") or "").strip().casefold()
+    if status in _DUE_DILIGENCE_PENDING_APPROVAL_STATUSES:
         return True
-    if any(str(response.get(key) or "").strip() for key in ("reviewUrl", "approvalSessionId")):
+    if _due_diligence_response_approval_queued(response):
         return True
     error = _due_diligence_response_error(response)
     return bool(error and _due_diligence_update_error_is_handoff_eligible(error))
@@ -1570,6 +1643,8 @@ def _create_due_diligence_update_handoff(
     owner_email: str = "",
     fallback_owner_email: str = DOCUMENT_REGISTRATION_FALLBACK_OWNER_EMAIL,
     field_sources: Mapping[str, str] | None = None,
+    proposal: bool = False,
+    review_url: str = "",
 ) -> dict[str, Any]:
     clean_site_id = site_id.strip()
     clean_fields = _clean_due_diligence_fields(fields)
@@ -1623,12 +1698,21 @@ def _create_due_diligence_update_handoff(
             "site_lookup_error": site_lookup_error,
         }
 
-    note_body = _build_due_diligence_update_handoff_note_body(
-        site_name=resolved_site_name,
-        site_address=resolved_site_address,
-        fields=clean_fields,
-        field_sources=field_sources,
-    )
+    if proposal:
+        note_body = _build_due_diligence_proposal_note_body(
+            site_name=resolved_site_name,
+            site_address=resolved_site_address,
+            fields=clean_fields,
+            field_sources=field_sources,
+            review_url=review_url,
+        )
+    else:
+        note_body = _build_due_diligence_update_handoff_note_body(
+            site_name=resolved_site_name,
+            site_address=resolved_site_address,
+            fields=clean_fields,
+            field_sources=field_sources,
+        )
     note = add_rhodes_site_note(
         site_id=clean_site_id,
         site_slug=resolved_site_slug,
@@ -1637,7 +1721,9 @@ def _create_due_diligence_update_handoff(
         owner_email=owner["owner_email"],
         client=mcp_note_client,
         notes_client=notes_client,
-        automation_source="due_diligence_update_handoff",
+        automation_source=(
+            "due_diligence_proposal_submitted" if proposal else "due_diligence_update_handoff"
+        ),
     )
     if note.get("status") != "created":
         return {
@@ -1674,8 +1760,12 @@ def _create_due_diligence_update_handoff(
             for key in sorted(clean_fields)
         ],
         "human_followup_required": True,
-        "human_followup_type": DUE_DILIGENCE_UPDATE_FOLLOWUP_TYPE,
-        "rhodes_due_diligence_status": DUE_DILIGENCE_UPDATE_PENDING_USER_ACTION,
+        "human_followup_type": (
+            DUE_DILIGENCE_APPROVAL_FOLLOWUP_TYPE if proposal else DUE_DILIGENCE_UPDATE_FOLLOWUP_TYPE
+        ),
+        "rhodes_due_diligence_status": (
+            DUE_DILIGENCE_PROPOSAL_SUBMITTED if proposal else DUE_DILIGENCE_UPDATE_PENDING_USER_ACTION
+        ),
         "remaining_work": [],
         "note_body": note_body,
         "site_name": resolved_site_name,
@@ -1683,6 +1773,54 @@ def _create_due_diligence_update_handoff(
         "site_slug": resolved_site_slug,
         "site_lookup_error": site_lookup_error,
     }
+
+
+def _due_diligence_proposal_result(
+    *,
+    base: dict[str, Any],
+    response: dict[str, Any],
+    handoff: dict[str, Any],
+) -> dict[str, Any]:
+    """Result for a write that entered the LocationOS approval queue.
+
+    The proposal was executed and logged; the site owner tracks the pending
+    change. This is a successful submission, not a failed write.
+    """
+
+    approval = {
+        "pending_mutation_id": str(response.get("pendingMutationId") or "").strip(),
+        "approval_session_id": str(response.get("approvalSessionId") or "").strip(),
+        "review_url": str(response.get("reviewUrl") or "").strip(),
+    }
+    result = {
+        **base,
+        "status": DUE_DILIGENCE_PROPOSAL_SUBMITTED,
+        "reason": "approval_queue",
+        "rhodes_due_diligence_status": DUE_DILIGENCE_PROPOSAL_SUBMITTED,
+        "human_followup_required": True,
+        "human_followup_type": DUE_DILIGENCE_APPROVAL_FOLLOWUP_TYPE,
+        "remaining_work": [],
+        "approval": approval,
+        "due_diligence_update_handoff": handoff,
+        "response": _summarize_due_diligence_response(response),
+    }
+    if handoff.get("status") != "created":
+        result["status"] = "failed"
+        result["reason"] = "proposal_note_failed"
+        result["rhodes_due_diligence_status"] = "failed"
+        result["error"] = str(handoff.get("error") or handoff.get("reason") or "note_write_failed")
+        result["error_summary"] = (
+            "DD fields were submitted to the LocationOS approval queue, but the "
+            "owner notification note could not be created."
+        )
+        result["remaining_work"] = [
+            {
+                "type": DUE_DILIGENCE_APPROVAL_FOLLOWUP_TYPE,
+                "status": "blocked",
+                "reason": str(handoff.get("reason") or "note_failed"),
+            }
+        ]
+    return result
 
 
 def _due_diligence_handoff_result(

--- a/src/due_diligence_reporter/source_packet.py
+++ b/src/due_diligence_reporter/source_packet.py
@@ -394,6 +394,9 @@ def source_packet_completion(
             open_items.append(f"{update.field}: {update.hold_reason or 'blocked'}")
             continue
         if update.locationos_key:
+            if update.write_status == "proposal_submitted":
+                open_items.append(f"{update.field}: awaiting approval-queue decision")
+                continue
             if update.write_status not in {"written", "updated"}:
                 open_items.append(f"{update.field}: write not completed")
             if update.readback_status != "verified":
@@ -530,6 +533,10 @@ def mark_written_fields_from_update_result(
             if status == "updated":
                 row["write_status"] = "written"
                 row["readback_status"] = "verified"
+            elif status == "proposal_submitted":
+                row["write_status"] = "proposal_submitted"
+                row["readback_status"] = "proposal_submitted"
+                row["hold_reason"] = "awaiting_approval_queue_decision"
             elif status == "failed":
                 row["write_status"] = "failed"
                 row["readback_status"] = "failed"

--- a/tests/test_automation_event.py
+++ b/tests/test_automation_event.py
@@ -514,3 +514,29 @@ def test_raycon_followup_alert_event_renders_review_context() -> None:
     assert "RayCon run ID:" not in note
     assert "no raycon_scenario.json" not in note
     assert "Drive folder:" not in note
+
+
+def test_dd_report_summary_event_renders_proposal_submitted() -> None:
+    event = build_dd_report_summary_event(
+        site_id="SITE1",
+        site_name="Alpha Keller",
+        run_id="run-1",
+        doc_id="doc-1",
+        doc_url="https://docs.google.com/document/d/doc-1",
+        due_diligence_update={
+            "status": "proposal_submitted",
+            "reason": "approval_queue",
+            "updated_fields": ["foCapacity", "maxCapCapacity"],
+        },
+        created_at="2026-07-07T18:15:00+00:00",
+    )
+
+    note = render_automation_event_note(event)
+
+    assert (
+        "Rhodes due diligence update: submitted for approval: foCapacity, maxCapCapacity"
+        not in note
+    )
+    assert "Rhodes fields: Submitted for approval; pending in the LocationOS approval queue." in note
+    assert "Rhodes fields: Updated." not in note
+    assert "- Review and approve or reject the pending due diligence change." in note

--- a/tests/test_m2_executor.py
+++ b/tests/test_m2_executor.py
@@ -125,6 +125,32 @@ class FakeAdapters:
             else self.packet_write_status
         )
         if status != "updated":
+            if status == "proposal_submitted":
+                return {
+                    "status": "proposal_submitted",
+                    "reason": "approval_queue",
+                    "updated_fields": sorted(fields),
+                    "rhodes_due_diligence_status": "proposal_submitted",
+                    "human_followup_required": True,
+                    "human_followup_type": "due_diligence_approval",
+                    "remaining_work": [],
+                    "approval": {
+                        "pending_mutation_id": "MUT1",
+                        "approval_session_id": "APPROVAL1",
+                        "review_url": "https://locationos.example/review",
+                    },
+                    "due_diligence_update_handoff": {
+                        "status": "created",
+                        "reason": "handoff_note_created",
+                        "note_readback_status": "verified",
+                        "rhodes_note_id": "proposal-note-1",
+                        "field_count": len(fields),
+                        "fields": [
+                            {"name": key, "value": str(fields[key]), "source": ""}
+                            for key in sorted(fields)
+                        ],
+                    },
+                }
             if status == "pending_user_action":
                 return {
                     "status": "pending_user_action",
@@ -468,6 +494,63 @@ def test_capacity_handoff_note_completes_manual_followup(tmp_path) -> None:
         "foCapacity": "Alpha Capacity Analysis",
         "maxCapCapacity": "Alpha Capacity Analysis",
     }
+
+
+def test_capacity_proposal_submission_completes_without_manual_update_ask(tmp_path) -> None:
+    store = _capacity_ready_store(tmp_path)
+    adapters = FakeAdapters(capacity_write_status="proposal_submitted")
+
+    result = execute_ready_m2_states(
+        state_store=store,
+        apply=True,
+        adapters=adapters,
+    )
+
+    state = store.load()["evt-1"]
+    row = result["rows"][0]
+    assert result["completed"] == 1
+    assert row["status"] == "complete"
+    assert state["m2_state"] == "complete"
+    assert state["completion_mode"] == "due_diligence_proposal_submitted"
+    assert state["human_followup_required"] is True
+    assert state["human_followup_type"] == "due_diligence_approval"
+    assert state["manual_handoff"]["type"] == "due_diligence_approval"
+    assert state["manual_handoff"]["approval"] == {
+        "pending_mutation_id": "MUT1",
+        "approval_session_id": "APPROVAL1",
+        "review_url": "https://locationos.example/review",
+    }
+    assert state["capacity_write"]["status"] == "proposal_submitted"
+    assert adapters.calls == ["alpha", "write"]
+
+
+def test_packet_proposal_submission_marks_fields_awaiting_approval(tmp_path) -> None:
+    store = _capacity_ready_store(tmp_path)
+    adapters = FakeAdapters(packet_write_status="proposal_submitted")
+
+    result = execute_ready_m2_states(
+        state_store=store,
+        apply=True,
+        adapters=adapters,
+    )
+
+    state = store.load()["evt-1"]
+    assert result["completed"] == 1
+    assert state["completion_mode"] == "due_diligence_proposal_submitted"
+    packet = state["source_packet"]
+    assert packet["status"] == "proposal_awaiting_approval"
+    assert packet["m2_source_packet_complete"] is False
+    assert packet["open_items"] == [
+        "LocationOS due diligence fields await the approval-queue decision; "
+        "site owner tracks the pending change."
+    ]
+    statuses = {
+        row["locationos_key"]: row["write_status"]
+        for row in packet["dd_field_updates"]
+        if row.get("locationos_key") and row.get("write_status") != "written"
+    }
+    assert statuses
+    assert set(statuses.values()) == {"proposal_submitted"}
 
 
 def test_failed_source_registration_blocks_before_packet_write(tmp_path) -> None:

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -1183,22 +1183,31 @@ def test_update_rhodes_due_diligence_handoffs_browser_approval_response() -> Non
     expected_body = (
         "Site Name: Alpha Test\n"
         "Site Address: 123 Main St, Denver, CO 80202\n"
-        "Copy/paste these field names and values into the LocationOS due diligence record:\n"
-        "Due Diligence Fields to update:\n"
+        "DDR submitted these due diligence field values to the LocationOS "
+        "approval queue. Please review the pending change and approve or "
+        "reject it:\n"
+        "Due Diligence Fields proposed:\n"
         "foCapacity: 36\n"
-        "maxCapCapacity: 54"
+        "maxCapCapacity: 54\n"
+        "Review link: https://locationos.example/review"
     )
     handoff = result["due_diligence_update_handoff"]
 
-    assert result["status"] == "pending_user_action"
-    assert result["reason"] == "handoff_note_created"
-    assert result["rhodes_due_diligence_status"] == "pending_user_action"
+    assert result["status"] == "proposal_submitted"
+    assert result["reason"] == "approval_queue"
+    assert result["rhodes_due_diligence_status"] == "proposal_submitted"
     assert result["human_followup_required"] is True
-    assert result["human_followup_type"] == "due_diligence_update"
+    assert result["human_followup_type"] == "due_diligence_approval"
     assert result["remaining_work"] == []
+    assert result["approval"] == {
+        "pending_mutation_id": "MUT1",
+        "approval_session_id": "APPROVAL1",
+        "review_url": "https://locationos.example/review",
+    }
     assert result["response"]["status"] == "awaiting_browser_approval"
     assert result["response"]["pendingMutationId"] == "MUT1"
     assert "readback" not in result
+    assert "error" not in result
     assert handoff["status"] == "created"
     assert handoff["note_body"] == expected_body
     assert handoff["note_readback_status"] == "verified"
@@ -1248,6 +1257,62 @@ def test_update_rhodes_due_diligence_handoff_note_includes_field_sources() -> No
         {"name": "status", "value": "data-gathering", "source": ""},
     ]
     assert client.notes[0]["body"] == note_body
+
+
+def test_status_only_approval_response_falls_back_to_manual_handoff() -> None:
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Test",
+            "slug": "alpha-test",
+            "address": "123 Main St, Denver, CO 80202",
+            "p1Dri": {"email": "owner@example.com", "userId": "OWNER1"},
+        },
+        due_diligence_response={"status": "awaiting_browser_approval"},
+    )
+
+    result = update_rhodes_due_diligence(
+        site_id="SITE1",
+        fields={"foCapacity": 36},
+        client=client,  # type: ignore[arg-type]
+    )
+
+    handoff = result["due_diligence_update_handoff"]
+    assert result["status"] == "pending_user_action"
+    assert result["reason"] == "handoff_note_created"
+    assert result["human_followup_type"] == "due_diligence_update"
+    assert "approval" not in result
+    assert "Due Diligence Fields to update:" in handoff["note_body"]
+    assert "approval queue" not in handoff["note_body"]
+
+
+def test_proposal_note_failure_reports_failed_submission() -> None:
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Test",
+            "slug": "alpha-test",
+            "address": "123 Main St, Denver, CO 80202",
+            "p1Dri": {"email": "owner@example.com", "userId": "OWNER1"},
+        },
+        due_diligence_response={
+            "status": "awaiting_browser_approval",
+            "pendingMutationId": "MUT1",
+        },
+        note_response={"error": "note write rejected"},
+    )
+
+    result = update_rhodes_due_diligence(
+        site_id="SITE1",
+        fields={"foCapacity": 36},
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "failed"
+    assert result["reason"] == "proposal_note_failed"
+    assert result["rhodes_due_diligence_status"] == "failed"
+    assert result["approval"]["pending_mutation_id"] == "MUT1"
+    assert result["remaining_work"][0]["type"] == "due_diligence_approval"
 
 
 def test_update_rhodes_due_diligence_handoffs_elicitation_exception() -> None:

--- a/tests/test_source_packet.py
+++ b/tests/test_source_packet.py
@@ -11,6 +11,7 @@ from due_diligence_reporter.source_packet import (
     dd_field_update_sources,
     locationos_fields_allowed_by_source_packet,
     m2_field_matrix,
+    mark_written_fields_from_update_result,
     source_packet_completion,
     source_packet_is_complete,
     source_packet_note_lines,
@@ -377,3 +378,40 @@ def test_dd_field_update_sources_maps_locationos_keys_to_doc_titles() -> None:
         "foCapacity": "Alpha Capacity Analysis - Site.json",
         "buildingScore": "Phase 1 Phase 2 workbook",
     }
+
+
+def test_mark_written_fields_proposal_submitted_awaits_approval() -> None:
+    packet = build_m2_source_packet(
+        values={
+            "exec.play_area_score": "1",
+            "exec.play_area_comment": "On-site playscape passes.",
+        },
+        supporting_documents=[
+            SourceDocumentRef(
+                source_type="outdoor_play_space_report",
+                title="Outdoor Play Space Report",
+                drive_url="https://drive.example/play",
+                rhodes_doc_type="other",
+                registration_status="registered",
+                fields_supported=("play_area_score", "play_area_comment"),
+            )
+        ],
+    )
+
+    marked = mark_written_fields_from_update_result(
+        source_packet=packet,
+        update_result={
+            "status": "proposal_submitted",
+            "reason": "approval_queue",
+            "updated_fields": ["playAreaScore", "playAreaComment"],
+        },
+    )
+
+    rows = {row["field"]: row for row in marked["dd_field_updates"]}
+    assert rows["play_area_score"]["write_status"] == "proposal_submitted"
+    assert rows["play_area_score"]["readback_status"] == "proposal_submitted"
+    assert rows["play_area_score"]["hold_reason"] == "awaiting_approval_queue_decision"
+    assert marked["m2_source_packet_complete"] is False
+    assert "play_area_score: awaiting approval-queue decision" in marked["open_items"]
+    assert "play_area_score: write not completed" not in marked["open_items"]
+    assert "play_area_score: readback not verified" not in marked["open_items"]


### PR DESCRIPTION
## Why

Per Greg's direction: DD field changes go into the LocationOS approval queue for another agent to review against the registered supporting documents. DDR's job in this slice is to **execute the write, log the action, and leave status tracking to the site owner** — confirmation/readback after the approval decision is a separate slice (`ddr-dzc`).

Previously an approval-queued write came back as `pending_user_action`: recorded as a **failed** manifest step, with an owner note asking them to copy/paste field values into Aerie by hand.

## What

- **`rhodes.py`** — a response carrying an approval artifact (`pendingMutationId`, `approvalSessionId`, or `reviewUrl`) now returns `status=proposal_submitted` / `reason=approval_queue` with an `approval` metadata block logged to the result and manifest. The owner note says the change was **submitted to the approval queue — review and approve or reject the pending change**, and carries the field→source-document evidence section plus the review link. Only `reviewUrl` appears in the note; mutation/session IDs stay in internal payloads.
- **Guardrail** — a pending-approval *status without an artifact* is not proof a pending change persisted (e.g. an interactive elicitation in a headless run). Those stay on the legacy copy/paste manual-handoff path.
- **`m2_executor.py`** — proposal runs complete as `completion_mode=due_diligence_proposal_submitted`, `human_followup_type=due_diligence_approval`, packet status `proposal_awaiting_approval`, field rows `proposal_submitted`.
- **`source_packet.py` / `automation_event.py`** — the site-pipeline path tells the same story: packet rows marked awaiting approval (open item "awaiting approval-queue decision"), DD summary notes render "Submitted for approval; pending in the LocationOS approval queue" instead of "Updated." or nothing.
- **`report_pipeline.py`** — `proposal_submitted` records the `rhodes.due_diligence_update` manifest step as **succeeded**.
- **`HANDOFF.md`** — new checkpoint documenting the contract and deferred items.

## Verification

- Full suite: **1364 passed, 13 skipped** (+6 tests: proposal contract, status-only fallback, note-failure shape, packet marking, event rendering, executor completion modes)
- ruff clean, mypy clean (52 files)
- Independent reviewer pass: 1 blocking + 2 medium findings — all fixed in this change (artifact-required detection, event-gate dead code, site-pipeline packet marking)

## Deferred (tracked)

- Post-approval readback and rejection handling → `ddr-dzc`
- Approval-queue dedupe on note-failure retries → noted in `ddr-dzc`
- `resume-mcp-write` verify path still classifies queued writes by readback only → follow-up bead

🤖 Generated with [Claude Code](https://claude.com/claude-code)