### PR TITLE
Alert on Firestore state-store fallback to local JSON (ddr-yda)

### DIFF
--- a/src/due_diligence_reporter/dd_republish_state_store.py
+++ b/src/due_diligence_reporter/dd_republish_state_store.py
@@ -17,6 +17,7 @@ from .dd_republish import (
 )
 from .firestore_state import (
     DEFAULT_FIRESTORE_DATABASE,
+    alert_firestore_fallback,
     build_authorized_session,
     decode_firestore_fields,
     encode_firestore_fields,
@@ -81,6 +82,7 @@ class FirestoreDDRepublishStateStore:
             firestore_state = self._load_firestore_state()
         except Exception as exc:  # noqa: BLE001 - local JSON remains the safe fallback
             logger.warning("Failed to load DD republish state from Firestore: %s", exc)
+            alert_firestore_fallback("dd_republish_state", "load", exc)
             return self.fallback.load()
         if firestore_state:
             return firestore_state
@@ -91,6 +93,7 @@ class FirestoreDDRepublishStateStore:
             self._save_firestore_state(state)
         except Exception as exc:  # noqa: BLE001 - preserve progress locally
             logger.warning("Failed to save DD republish state to Firestore: %s", exc)
+            alert_firestore_fallback("dd_republish_state", "save", exc)
             self.fallback.save(state)
             return
         self.fallback.save(state)

--- a/src/due_diligence_reporter/firestore_state.py
+++ b/src/due_diligence_reporter/firestore_state.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any
 
 import google.auth
@@ -9,6 +11,41 @@ from google.auth.transport.requests import AuthorizedSession
 
 FIRESTORE_SCOPE = "https://www.googleapis.com/auth/datastore"
 DEFAULT_FIRESTORE_DATABASE = "(default)"
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_ALERTS_SENT: set[str] = set()
+
+
+def alert_firestore_fallback(store_name: str, operation: str, error: Exception | str) -> None:
+    """Post a Google Chat alert when a Firestore state store degrades to local fallback.
+
+    Fallback degradation is otherwise silent: runs keep succeeding on the
+    JSON/cache fallback while durable dedupe and progress state quietly stops
+    persisting (this ran unnoticed for six weeks before 2026-07-07). One alert
+    per store+operation per process keeps scheduled runs from spamming the
+    webhook; the alert must never break the run it fires from.
+    """
+
+    key = f"{store_name}:{operation}"
+    if key in _FALLBACK_ALERTS_SENT:
+        return
+    _FALLBACK_ALERTS_SENT.add(key)
+    webhook_url = os.environ.get("GOOGLE_CHAT_WEBHOOK_URL", "").strip()
+    if not webhook_url:
+        return
+    message = (
+        f"DDR state-store degradation: {store_name} failed to {operation} "
+        f"Firestore state and is running on the local JSON/cache fallback. "
+        f"Durable dedupe/progress state stops persisting until Firestore "
+        f"access is repaired. Error: {str(error)[:300]}"
+    )
+    try:
+        from .utils import post_google_chat_message
+
+        post_google_chat_message(webhook_url, message)
+    except Exception:  # noqa: BLE001 - alerting must never break the run
+        logger.warning("Failed to post Firestore fallback alert for %s", key)
 
 
 def encode_firestore_fields(data: dict[str, Any]) -> dict[str, Any]:

--- a/src/due_diligence_reporter/m2_pipeline.py
+++ b/src/due_diligence_reporter/m2_pipeline.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 
 from .firestore_state import (
     DEFAULT_FIRESTORE_DATABASE,
+    alert_firestore_fallback,
     build_authorized_session,
     decode_firestore_fields,
     encode_firestore_fields,
@@ -144,6 +145,7 @@ class FirestoreM2StateStore:
             firestore_state = self._load_firestore_state()
         except Exception as exc:  # noqa: BLE001 - local JSON remains the safe fallback
             logger.warning("Failed to load M2 state from Firestore: %s", exc)
+            alert_firestore_fallback("m2_state", "load", exc)
             return self.fallback.load()
         if firestore_state:
             return firestore_state
@@ -155,6 +157,7 @@ class FirestoreM2StateStore:
             self._save_firestore_state(clean_state)
         except Exception as exc:  # noqa: BLE001 - preserve progress locally
             logger.warning("Failed to save M2 state to Firestore: %s", exc)
+            alert_firestore_fallback("m2_state", "save", exc)
             self.fallback.save(clean_state)
             return
         self.fallback.save(clean_state)

--- a/src/due_diligence_reporter/raycon_runtime_state_store.py
+++ b/src/due_diligence_reporter/raycon_runtime_state_store.py
@@ -12,6 +12,7 @@ from urllib.parse import quote
 
 from .firestore_state import (
     DEFAULT_FIRESTORE_DATABASE,
+    alert_firestore_fallback,
     build_authorized_session,
     decode_firestore_fields,
     encode_firestore_fields,
@@ -122,6 +123,7 @@ class FirestoreRayConDispatchStateStore:
             firestore_state = self._load_firestore_state()
         except Exception as exc:  # noqa: BLE001 - local JSON remains the safe fallback
             logger.warning("Failed to load RayCon dispatch state from Firestore: %s", exc)
+            alert_firestore_fallback("raycon_dispatch_state", "load", exc)
             return self.fallback.load()
         if firestore_state:
             return firestore_state
@@ -132,6 +134,7 @@ class FirestoreRayConDispatchStateStore:
             self._save_firestore_state(state)
         except Exception as exc:  # noqa: BLE001 - preserve progress locally
             logger.warning("Failed to save RayCon dispatch state to Firestore: %s", exc)
+            alert_firestore_fallback("raycon_dispatch_state", "save", exc)
             self.fallback.save(state)
             return
         self.fallback.save(state)
@@ -209,6 +212,7 @@ class FirestoreRayConAlertStateStore:
             firestore_state = self._load_firestore_state()
         except Exception as exc:  # noqa: BLE001 - local JSON remains the safe fallback
             logger.warning("Failed to load RayCon alert state from Firestore: %s", exc)
+            alert_firestore_fallback("raycon_alert_state", "load", exc)
             return self.fallback.load()
         if firestore_state:
             return firestore_state
@@ -219,6 +223,7 @@ class FirestoreRayConAlertStateStore:
             self._save_firestore_state(state)
         except Exception as exc:  # noqa: BLE001 - preserve progress locally
             logger.warning("Failed to save RayCon alert state to Firestore: %s", exc)
+            alert_firestore_fallback("raycon_alert_state", "save", exc)
             self.fallback.save(state)
             return
         self.fallback.save(state)

--- a/src/due_diligence_reporter/rhodes_retry_state_store.py
+++ b/src/due_diligence_reporter/rhodes_retry_state_store.py
@@ -12,6 +12,7 @@ from urllib.parse import quote
 
 from .firestore_state import (
     DEFAULT_FIRESTORE_DATABASE,
+    alert_firestore_fallback,
     build_authorized_session,
     decode_firestore_fields,
     encode_firestore_fields,
@@ -84,6 +85,7 @@ class FirestoreRhodesRetryStateStore:
             firestore_state = self._load_firestore_state()
         except Exception as exc:  # noqa: BLE001 - local JSON remains the safe fallback
             logger.warning("Failed to load Rhodes retry state from Firestore: %s", exc)
+            alert_firestore_fallback("rhodes_retry_state", "load", exc)
             return self.fallback.load()
         if firestore_state:
             return firestore_state
@@ -94,6 +96,7 @@ class FirestoreRhodesRetryStateStore:
             self._save_firestore_state(state)
         except Exception as exc:  # noqa: BLE001 - preserve progress locally
             logger.warning("Failed to save Rhodes retry state to Firestore: %s", exc)
+            alert_firestore_fallback("rhodes_retry_state", "save", exc)
             self.fallback.save(state)
             return
         self.fallback.save(state)

--- a/tests/test_firestore_fallback_alert.py
+++ b/tests/test_firestore_fallback_alert.py
@@ -1,0 +1,72 @@
+"""Tests for the Firestore fallback degradation alert."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from due_diligence_reporter import firestore_state
+from due_diligence_reporter.firestore_state import alert_firestore_fallback
+
+
+def _reset_dedupe() -> None:
+    firestore_state._FALLBACK_ALERTS_SENT.clear()
+
+
+def test_alert_posts_once_per_store_and_operation(monkeypatch) -> None:
+    _reset_dedupe()
+    monkeypatch.setenv("GOOGLE_CHAT_WEBHOOK_URL", "https://chat.example/webhook")
+
+    with patch("due_diligence_reporter.utils.post_google_chat_message") as mock_post:
+        alert_firestore_fallback("dd_republish_state", "save", RuntimeError("404 Not Found"))
+        alert_firestore_fallback("dd_republish_state", "save", RuntimeError("404 Not Found"))
+        alert_firestore_fallback("dd_republish_state", "load", RuntimeError("404 Not Found"))
+
+    assert mock_post.call_count == 2
+    message = mock_post.call_args_list[0].args[1]
+    assert "dd_republish_state" in message
+    assert "save" in message
+    assert "404 Not Found" in message
+    assert "fallback" in message
+
+
+def test_alert_skips_without_webhook(monkeypatch) -> None:
+    _reset_dedupe()
+    monkeypatch.delenv("GOOGLE_CHAT_WEBHOOK_URL", raising=False)
+
+    with patch("due_diligence_reporter.utils.post_google_chat_message") as mock_post:
+        alert_firestore_fallback("m2_state", "load", RuntimeError("boom"))
+
+    mock_post.assert_not_called()
+
+
+def test_alert_failure_never_raises(monkeypatch) -> None:
+    _reset_dedupe()
+    monkeypatch.setenv("GOOGLE_CHAT_WEBHOOK_URL", "https://chat.example/webhook")
+
+    with patch(
+        "due_diligence_reporter.utils.post_google_chat_message",
+        side_effect=RuntimeError("webhook down"),
+    ):
+        alert_firestore_fallback("rhodes_retry_state", "save", RuntimeError("boom"))
+
+
+def test_dd_republish_store_save_failure_triggers_alert(monkeypatch, tmp_path) -> None:
+    _reset_dedupe()
+    monkeypatch.setenv("GOOGLE_CHAT_WEBHOOK_URL", "https://chat.example/webhook")
+    from due_diligence_reporter.dd_republish_state_store import (
+        FirestoreDDRepublishStateStore,
+        JsonDDRepublishStateStore,
+    )
+
+    store = FirestoreDDRepublishStateStore(
+        project_id="proj",
+        fallback=JsonDDRepublishStateStore(tmp_path / "state.json"),
+    )
+
+    with patch.object(
+        store, "_save_firestore_state", side_effect=RuntimeError("404 Not Found")
+    ), patch("due_diligence_reporter.utils.post_google_chat_message") as mock_post:
+        store.save({})
+
+    assert mock_post.call_count == 1
+    assert "dd_republish_state" in mock_post.call_args.args[1]


### PR DESCRIPTION
## Why

Today's gate flip surfaced that the DD-republish state store had been silently failing Firestore saves since May 28 (the `(default)` database never existed in the project) — running entirely on the Actions-cache JSON fallback. A cache eviction would have silently lost dedupe state, which now means duplicate proposals in the LocationOS approval queue. The config is fixed (repo variables repointed to the `edu-ops-email-router` database), but the class of failure must never be invisible again.

## What

New `alert_firestore_fallback()` in `firestore_state.py`, wired into all ten load/save fallback catch blocks across the five Firestore-backed stores (DD republish dedupe, M2 state, RayCon dispatch, RayCon alert, Rhodes registration retry). When a fallback activates it posts one concise Google Chat line per store+operation per process (scheduled runs are short-lived, so this is one alert per run at most), never raises, and no-ops when `GOOGLE_CHAT_WEBHOOK_URL` isn't configured.

## Verification

- Full suite: 1368 passed, 13 skipped (+4 tests: once-per-key dedupe, no-webhook skip, never-raises, and end-to-end store-save-failure → alert)
- ruff clean, mypy clean
- Review: skipped subagent pass — 53-line mechanical alert addition with no core-flow behavior change and direct test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)