### PR TITLE
Auto-accept phasing recommendations and notify P2 DRI for review

### DIFF
--- a/src/due_diligence_reporter/alpha_phasing_plan.py
+++ b/src/due_diligence_reporter/alpha_phasing_plan.py
@@ -122,7 +122,7 @@ def build_alpha_phasing_report_fields(
         gap_count = len(_normalize_list(deferred_scopes))
         plural = "" if gap_count == 1 else "s"
         quality_status = (
-            f"{quality_bar_target.strip()} target with {gap_count} confirmed "
+            f"{quality_bar_target.strip()} target with {gap_count} deferred "
             f"Phase II gap{plural}."
         )
 
@@ -279,7 +279,7 @@ def _quality_bar_rows(quality_bar_target: str, deferred_scopes: Any) -> list[lis
             quality_bar_target,
             "Gap remains after Phase I",
             "Planned for Phase II pending budget approval",
-            "Confirmed deferred scope; pricing must stay tied to source notes.",
+            "Deferred scope; pricing must stay tied to source notes.",
         ])
     return rows
 
@@ -548,6 +548,12 @@ def _normalize_records(value: Any) -> list[dict[str, str]]:
         elif str(item).strip():
             records.append({"name": str(item).strip()})
     return records
+
+
+def normalize_phasing_list(value: Any) -> list[str]:
+    """Normalize a deferred-scope/list input the same way the workbook does."""
+
+    return _normalize_list(value)
 
 
 def _normalize_list(value: Any) -> list[str]:

--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -318,7 +318,7 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     },
     {
         "name": "apply_alpha_phasing_plan_skill",
-        "description": "Create and publish the Phase 1 Phase 2 workbook after source reads, E-Occupancy, School Approval, and Cost/Timeline Estimate context are available. Pass only confirmed phasing inputs; if deferred Phase II scope is not confirmed, call the tool with the missing fields so it returns concrete verification.open_items instead of inventing scope. On success, copy returned report_data_fields into report_data before prepare_due_diligence_data, including sources.alpha_phasing_plan_link and exec.alpha_phasing_* summary fields.",
+        "description": "Create and publish the Phase 1 Phase 2 workbook after source reads, E-Occupancy, School Approval, and Cost/Timeline Estimate context are available. Only call this tool when you intend to publish: missing judgment inputs (source of truth, quality bar target, opening target date, Phase I scope, Phase II deferred scope) are auto-accepted from skill recommendations, recorded in auto_accepted_inputs, and the P2 DRI is notified for after-the-fact review - do not probe-call it to discover missing inputs. If a workbook already exists in M1 it is reused without a new notification. On success, copy returned report_data_fields into report_data before prepare_due_diligence_data, including sources.alpha_phasing_plan_link and exec.alpha_phasing_* summary fields.",
         "input_schema": {
             "type": "object",
             "properties": {

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -408,6 +408,23 @@ def _site_address(site: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_p2_dri(site: dict[str, Any]) -> dict[str, str]:
+    owner: dict[str, str] = {}
+    p2_dri = site.get("p2Dri")
+    if isinstance(p2_dri, dict):
+        for target, keys in {
+            "name": ("name", "fullName", "displayName"),
+            "email": ("email", "emailAddress", "primaryEmail"),
+            "userId": ("userId", "_id", "id"),
+        }.items():
+            for key in keys:
+                value = p2_dri.get(key)
+                if isinstance(value, str) and value.strip():
+                    owner[target] = value.strip()
+                    break
+    return owner
+
+
 def _extract_p1_dri(site: dict[str, Any]) -> dict[str, str]:
     owner: dict[str, str] = {}
     p1_dri = site.get("p1Dri")
@@ -3274,3 +3291,102 @@ def list_rhodes_site_records(
             continue
         records.append(record)
     return records
+
+
+def notify_rhodes_phasing_review(
+    *,
+    site_id: str,
+    workbook_name: str,
+    workbook_url: str,
+    auto_accepted_inputs: list[str] | None = None,
+    client: RhodesClient | None = None,
+    notes_client: AerieNotesClient | None = None,
+    fallback_owner_email: str = DOCUMENT_REGISTRATION_FALLBACK_OWNER_EMAIL,
+) -> dict[str, Any]:
+    """Notify the P2 DRI that a Phase 1 Phase 2 workbook is ready for review.
+
+    Phasing recommendations are auto-accepted at publish time, so the review
+    moves after the fact: this posts one site note mentioning the P2 DRI
+    (falling back to the P1 DRI, then the fallback owner) with the workbook
+    link and any auto-accepted inputs the reviewer should scrutinize.
+    """
+
+    clean_site_id = site_id.strip()
+    if not clean_site_id:
+        return {"status": "skipped", "reason": "missing_site_id"}
+
+    try:
+        rhodes = client or RhodesClient()
+    except RhodesError as exc:
+        reason = (
+            LOCATIONOS_NOT_CONFIGURED_REASON
+            if _is_locationos_not_configured_error(exc)
+            else "locationos_mcp_error"
+        )
+        status = "skipped" if reason == LOCATIONOS_NOT_CONFIGURED_REASON else "failed"
+        return {"status": status, "reason": reason, "error": str(exc)}
+
+    site: dict[str, Any] = {}
+    try:
+        site = rhodes.get_site(site_id=clean_site_id) or {}
+    except RhodesError as exc:
+        return {"status": "failed", "reason": "site_lookup_failed", "error": str(exc)}
+
+    p2_dri = _extract_p2_dri(site)
+    owner = _resolve_document_registration_handoff_owner(
+        site=site,
+        owner_user_id=p2_dri.get("userId", ""),
+        owner_email=p2_dri.get("email", ""),
+        fallback_owner_email=fallback_owner_email,
+        rhodes=rhodes,
+    )
+    if not owner["owner_user_id"]:
+        return {
+            "status": "failed",
+            "reason": "owner_route_unresolved",
+            "error": "Phasing review note requires a P2/P1 DRI or fallback owner user ID.",
+            "owner_email": owner["owner_email"],
+        }
+
+    site_name = str(site.get("name") or "site").strip()
+    accepted = [item.strip() for item in (auto_accepted_inputs or []) if str(item).strip()]
+    lines = [
+        "Phase 1 Phase 2 workbook review",
+        "Action needed: Review the completed Phase 1 Phase 2 workbook.",
+        f"Site: {site_name}",
+        "Status: Workbook published; skill recommendations were auto-accepted.",
+    ]
+    if workbook_url.strip():
+        lines.append(f"Workbook: {workbook_url.strip()}")
+    elif workbook_name.strip():
+        lines.append(f"Workbook: {workbook_name.strip()}")
+    if accepted:
+        lines.append("Auto-accepted inputs to scrutinize:")
+        lines.extend(f"- {item}" for item in accepted)
+    lines.extend(
+        [
+            "Next steps:",
+            "- Review the Phase I / Phase II scope split, budgets, and timing.",
+            "- Flag corrections; a rerun republishes the workbook.",
+        ]
+    )
+    note = add_rhodes_site_note(
+        site_id=clean_site_id,
+        site_slug=str(site.get("slug") or ""),
+        body="\n".join(lines),
+        owner_user_id=owner["owner_user_id"],
+        owner_email=owner["owner_email"],
+        client=client if client is not None and not isinstance(client, RhodesClient) else None,
+        notes_client=notes_client,
+        automation_source="alpha_phasing_plan_review",
+    )
+    return {
+        "status": "created" if note.get("status") == "created" else "failed",
+        "reason": str(note.get("reason") or note.get("status") or ""),
+        "rhodes_note_id": str(note.get("rhodes_note_id") or ""),
+        "note_readback_status": str(_dict_get(note.get("readback"), "status") or ""),
+        "mentioned_owner_user_id": owner["owner_user_id"],
+        "owner_email": owner["owner_email"],
+        "fallback_owner_used": owner["fallback_owner_used"],
+        "p2_dri_found": bool(p2_dri.get("userId") or p2_dri.get("email")),
+    }

--- a/src/due_diligence_reporter/server.py
+++ b/src/due_diligence_reporter/server.py
@@ -31,6 +31,7 @@ from .alpha_phasing_plan import (
     build_alpha_phasing_workbook,
     load_alpha_phasing_skill,
     missing_alpha_phasing_inputs,
+    normalize_phasing_list,
 )
 from .assignment import assign_p1
 from .classifier import (
@@ -83,6 +84,7 @@ from .report_schema import (
 from .retry import retry_config
 from .rhodes import (
     create_document_registration_handoff_for_uploads,
+    notify_rhodes_phasing_review,
     register_rhodes_document_for_upload,
 )
 from .rhodes import (
@@ -5073,10 +5075,14 @@ async def apply_alpha_phasing_plan_skill(
 ) -> dict[str, Any]:
     """Publish a Phase 1 Phase 2 workbook and return DDR-ready fields.
 
-    The tool is deliberately strict about minimum inputs: it does not invent
-    Phase II line items. When phasing inputs are incomplete, it returns concrete
-    verification open items for the DDR instead of publishing a placeholder
-    workbook.
+    Skill recommendations are auto-accepted: when a judgment input (source of
+    truth, quality-bar target, opening target, Phase I scope, Phase II deferred
+    scope) is not supplied, the tool fills it with the skill's standard
+    recommendation, records it in ``auto_accepted_inputs``, and publishes.
+    After publish the P2 DRI is notified via a site note that the workbook is
+    complete and ready for review; the review happens after the fact instead
+    of gating the publish. Only site identity and the Drive folder remain hard
+    requirements.
     """
 
     logger.info("Tool called: apply_alpha_phasing_plan_skill - site=%s", site_name)
@@ -5092,20 +5098,65 @@ async def apply_alpha_phasing_plan_skill(
     )
     if not drive_folder_url.strip():
         missing.append("site Drive folder URL")
-    if missing:
-        open_items = alpha_phasing_open_items(missing)
+    hard_missing = [
+        item
+        for item in missing
+        if item in {"site name", "site address", "site Drive folder URL"}
+    ]
+    if hard_missing:
+        open_items = alpha_phasing_open_items(hard_missing)
         return {
             "status": "blocked",
             "source_usable": False,
-            "missing_inputs": missing,
+            "missing_inputs": hard_missing,
             "report_data_fields": {
                 "verification.open_items": open_items,
             },
             "message": (
-                "Phase 1 Phase 2 workbook not published because minimum phasing "
-                "inputs are incomplete."
+                "Phase 1 Phase 2 workbook not published because site identity "
+                "or Drive folder context is missing."
             ),
         }
+
+    auto_accepted_inputs: list[str] = []
+
+    def _auto_accept(label: str, value: str) -> str:
+        auto_accepted_inputs.append(f"{label}: {value}")
+        return value
+
+    if not source_of_truth.strip():
+        source_of_truth = _auto_accept(
+            "source of truth", "Cost/Timeline Estimate and Alpha Capacity Analysis"
+        )
+    if not quality_bar_target.strip():
+        quality_bar_target = _auto_accept("quality bar target", "Alpha quality bars")
+    if not opening_target_date.strip():
+        opening_target_date = _auto_accept(
+            "opening target date", "TBD - confirm at P2 review"
+        )
+    if not must_complete_before_opening.strip():
+        must_complete_before_opening = _auto_accept(
+            "Phase I opening scope",
+            "Minimum buildout required to open (skill recommendation).",
+        )
+    if not normalize_phasing_list(deferred_scopes):
+        deferred_scopes = [
+            _auto_accept(
+                "Phase II deferred scope",
+                "Quality-bar completion items not required for opening "
+                "(skill recommendation).",
+            )
+        ]
+    if auto_accepted_inputs:
+        accepted_note = "Auto-accepted skill recommendations: " + "; ".join(
+            auto_accepted_inputs
+        )
+        if isinstance(source_notes, str):
+            source_notes = [source_notes, accepted_note]
+        elif isinstance(source_notes, list):
+            source_notes = [*source_notes, accepted_note]
+        else:
+            source_notes = [accepted_note]
 
     folder_id = extract_folder_id_from_url(drive_folder_url)
     if not folder_id:
@@ -5114,6 +5165,26 @@ async def apply_alpha_phasing_plan_skill(
             "error": "Invalid Drive folder URL",
             "message": f"Could not extract folder ID from: {drive_folder_url}",
         }
+
+    def _register_phasing_workbook(
+        *,
+        workbook_id: str,
+        workbook_url: str,
+        workbook_name: str,
+    ) -> dict[str, Any]:
+        return register_rhodes_document_for_upload(
+            site_id=site_id,
+            ddr_doc_type="alpha_phasing_plan_report",
+            title=workbook_name,
+            drive_file_id=workbook_id,
+            drive_url=workbook_url,
+            mime_type=(
+                "application/vnd.openxmlformats-officedocument."
+                "spreadsheetml.sheet"
+            ),
+            original_filename=workbook_name,
+            source="apply_alpha_phasing_plan_skill",
+        )
 
     def _work() -> dict[str, Any]:
         try:
@@ -5136,6 +5207,54 @@ async def apply_alpha_phasing_plan_skill(
                 "status": "error",
                 "error": "Failed to resolve M1 folder",
                 "message": str(e),
+            }
+
+        # Reuse an existing M1 workbook so sweep/executor reruns neither
+        # publish duplicate dated workbooks nor re-notify the P2 DRI.
+        try:
+            existing_docs = _list_m1_documents_by_type(gc, target_folder_id)
+            existing = existing_docs.get("alpha_phasing_plan_report")
+        except Exception as e:  # noqa: BLE001 - reuse inspection is best-effort
+            logger.warning(
+                "Failed to inspect existing Phase 1 Phase 2 workbook for '%s': %s",
+                site_name,
+                e,
+            )
+            existing = None
+        if existing is not None:
+            existing_url = str(existing.get("webViewLink") or "").strip()
+            existing_id = str(existing.get("id") or "").strip()
+            existing_name = str(existing.get("name") or "").strip()
+            return {
+                "status": "success",
+                "source_usable": True,
+                "doc_type": "alpha_phasing_plan_report",
+                "source_type": "alpha_phasing_plan_report",
+                "workbook_id": existing_id,
+                "workbook_url": existing_url,
+                "workbook_name": existing_name,
+                "reused_existing": True,
+                "rhodes_registration": _register_phasing_workbook(
+                    workbook_id=existing_id,
+                    workbook_url=existing_url,
+                    workbook_name=existing_name,
+                ),
+                "auto_accepted_inputs": [],
+                "p2_review_note": {"status": "skipped", "reason": "reused_existing"},
+                "skill_version": skill.version,
+                "skill_source": skill.source,
+                "scorecard_theme_id": skill.scorecard_theme_id,
+                "report_data_fields": build_alpha_phasing_report_fields(
+                    workbook_url=existing_url,
+                    phase_i_scope_summary=phase_i_scope_summary,
+                    must_complete_before_opening=must_complete_before_opening,
+                    deferred_scopes=deferred_scopes,
+                    phase_ii_budget_items=phase_ii_budget_items,
+                    phase_ii_total_allowance=phase_ii_total_allowance,
+                    recommended_timing=recommended_timing,
+                    quality_bar_target=quality_bar_target,
+                ),
+                "message": f"Reused existing '{existing_name}' in Drive",
             }
 
         workbook_bytes = build_alpha_phasing_workbook(
@@ -5180,18 +5299,10 @@ async def apply_alpha_phasing_plan_skill(
 
         workbook_url = str(workbook.get("webViewLink") or "").strip()
         workbook_id = str(workbook.get("id") or "").strip()
-        rhodes_registration = register_rhodes_document_for_upload(
-            site_id=site_id,
-            ddr_doc_type="alpha_phasing_plan_report",
-            title=workbook_name,
-            drive_file_id=workbook_id,
-            drive_url=workbook_url,
-            mime_type=(
-                "application/vnd.openxmlformats-officedocument."
-                "spreadsheetml.sheet"
-            ),
-            original_filename=workbook_name,
-            source="apply_alpha_phasing_plan_skill",
+        rhodes_registration = _register_phasing_workbook(
+            workbook_id=workbook_id,
+            workbook_url=workbook_url,
+            workbook_name=workbook_name,
         )
         report_fields = build_alpha_phasing_report_fields(
             workbook_url=workbook_url,
@@ -5203,6 +5314,34 @@ async def apply_alpha_phasing_plan_skill(
             recommended_timing=recommended_timing,
             quality_bar_target=quality_bar_target,
         )
+        # Notify the P2 DRI only for a fresh, successfully registered publish:
+        # unregistered publishes go through the registration-handoff machinery
+        # instead, and retries reuse the existing workbook without re-notifying.
+        registration_status = str(rhodes_registration.get("status") or "").strip()
+        p2_review_note: dict[str, Any] = {"status": "skipped", "reason": "missing_site_id"}
+        if site_id.strip():
+            if registration_status in {"registered", "already_registered"}:
+                try:
+                    p2_review_note = notify_rhodes_phasing_review(
+                        site_id=site_id,
+                        workbook_name=workbook_name,
+                        workbook_url=workbook_url,
+                        auto_accepted_inputs=auto_accepted_inputs,
+                    )
+                except Exception as e:  # noqa: BLE001 - note failure must not undo publish
+                    logger.warning(
+                        "Phasing P2 review note failed for '%s': %s", site_name, e
+                    )
+                    p2_review_note = {
+                        "status": "failed",
+                        "reason": "note_error",
+                        "error": str(e),
+                    }
+            else:
+                p2_review_note = {
+                    "status": "skipped",
+                    "reason": "registration_not_complete",
+                }
         return {
             "status": "success",
             "source_usable": True,
@@ -5212,6 +5351,8 @@ async def apply_alpha_phasing_plan_skill(
             "workbook_url": workbook_url,
             "workbook_name": workbook_name,
             "rhodes_registration": rhodes_registration,
+            "auto_accepted_inputs": auto_accepted_inputs,
+            "p2_review_note": p2_review_note,
             "skill_version": skill.version,
             "skill_source": skill.source,
             "scorecard_theme_id": skill.scorecard_theme_id,

--- a/tests/test_alpha_phasing_plan.py
+++ b/tests/test_alpha_phasing_plan.py
@@ -68,7 +68,7 @@ def test_alpha_phasing_report_fields_include_ddr_tokens() -> None:
     assert fields["sources.alpha_phasing_plan_link"] == "https://drive/phasing"
     assert fields["exec.alpha_phasing_phase_ii_allowance"] == "$65k"
     assert fields["exec.alpha_phasing_quality_bar_status"] == (
-        "Q1 target with 2 confirmed Phase II gaps."
+        "Q1 target with 2 deferred Phase II gaps."
     )
 
 
@@ -118,6 +118,10 @@ def test_apply_alpha_phasing_plan_skill_uploads_workbook(monkeypatch: pytest.Mon
     monkeypatch.setattr(
         "due_diligence_reporter.server._get_or_create_m1_folder",
         lambda _gc, _folder_id: {"id": "m1", "name": "M1 - Acquire Property"},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._list_m1_documents_by_type",
+        lambda _gc, _folder_id: {},
     )
     register_rhodes = MagicMock(
         return_value={
@@ -174,23 +178,216 @@ def test_apply_alpha_phasing_plan_skill_uploads_workbook(monkeypatch: pytest.Mon
     assert register_kwargs["source"] == "apply_alpha_phasing_plan_skill"
 
 
-def test_apply_alpha_phasing_plan_skill_returns_open_items_when_blocked() -> None:
+def test_apply_alpha_phasing_plan_skill_blocks_only_on_hard_requirements() -> None:
+    result = asyncio.run(
+        apply_alpha_phasing_plan_skill(
+            site_name="Alpha Test",
+            site_address="",
+            drive_folder_url="",
+            source_of_truth="Budget tracker",
+            quality_bar_target="Q1",
+            opening_target_date="08/12/2026",
+            must_complete_before_opening="Code-required opening scope",
+            deferred_scopes=["Lobby refresh"],
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "site address" in result["missing_inputs"]
+    assert "site Drive folder URL" in result["missing_inputs"]
+    assert "verification.open_items" in result["report_data_fields"]
+
+
+def test_apply_alpha_phasing_plan_skill_auto_accepts_recommendations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gc = MagicMock()
+    gc.upload_file_to_folder.return_value = {
+        "id": "file-1",
+        "webViewLink": "https://drive/phasing",
+    }
+    monkeypatch.setattr("due_diligence_reporter.server._make_google_client", lambda: gc)
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._get_or_create_m1_folder",
+        lambda _gc, _folder_id: {"id": "m1", "name": "M1 - Acquire Property"},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._list_m1_documents_by_type",
+        lambda _gc, _folder_id: {},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.register_rhodes_document_for_upload",
+        MagicMock(return_value={"status": "registered", "rhodes_doc_type": "other"}),
+    )
+    notify = MagicMock(
+        return_value={
+            "status": "created",
+            "rhodes_note_id": "NOTE-P2",
+            "p2_dri_found": True,
+        }
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.notify_rhodes_phasing_review", notify
+    )
+
     result = asyncio.run(
         apply_alpha_phasing_plan_skill(
             site_name="Alpha Test",
             site_address="123 Main St",
+            site_id="SITE1",
+            drive_folder_url="https://drive.google.com/drive/folders/root",
+        )
+    )
+
+    assert result["status"] == "success"
+    accepted = result["auto_accepted_inputs"]
+    assert any(item.startswith("source of truth:") for item in accepted)
+    assert any(item.startswith("quality bar target:") for item in accepted)
+    assert any(item.startswith("opening target date:") for item in accepted)
+    assert any(item.startswith("Phase I opening scope:") for item in accepted)
+    assert any(item.startswith("Phase II deferred scope:") for item in accepted)
+    assert result["p2_review_note"]["status"] == "created"
+    notify_kwargs = notify.call_args.kwargs
+    assert notify_kwargs["site_id"] == "SITE1"
+    assert notify_kwargs["workbook_url"] == "https://drive/phasing"
+    assert notify_kwargs["auto_accepted_inputs"] == accepted
+
+
+def test_apply_alpha_phasing_plan_skill_notifies_p2_dri_on_full_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gc = MagicMock()
+    gc.upload_file_to_folder.return_value = {
+        "id": "file-1",
+        "webViewLink": "https://drive/phasing",
+    }
+    monkeypatch.setattr("due_diligence_reporter.server._make_google_client", lambda: gc)
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._get_or_create_m1_folder",
+        lambda _gc, _folder_id: {"id": "m1", "name": "M1 - Acquire Property"},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._list_m1_documents_by_type",
+        lambda _gc, _folder_id: {},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.register_rhodes_document_for_upload",
+        MagicMock(return_value={"status": "registered", "rhodes_doc_type": "other"}),
+    )
+    notify = MagicMock(return_value={"status": "created", "rhodes_note_id": "NOTE-P2"})
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.notify_rhodes_phasing_review", notify
+    )
+
+    result = asyncio.run(
+        apply_alpha_phasing_plan_skill(
+            site_name="Alpha Test",
+            site_address="123 Main St",
+            site_id="SITE1",
             drive_folder_url="https://drive.google.com/drive/folders/root",
             source_of_truth="Budget tracker",
             quality_bar_target="Q1",
             opening_target_date="08/12/2026",
             must_complete_before_opening="Code-required opening scope",
-            deferred_scopes=[],
+            deferred_scopes=["Lobby refresh"],
         )
     )
 
-    assert result["status"] == "blocked"
-    assert "confirmed Phase II deferred scope" in result["missing_inputs"]
-    assert "verification.open_items" in result["report_data_fields"]
-    assert "Confirm Phase 1 Phase 2 workbook input" in result["report_data_fields"][
-        "verification.open_items"
-    ]
+    assert result["status"] == "success"
+    assert result["auto_accepted_inputs"] == []
+    assert notify.call_args.kwargs["auto_accepted_inputs"] == []
+    assert result["p2_review_note"]["status"] == "created"
+
+
+def test_apply_alpha_phasing_plan_skill_reuses_existing_workbook_without_notify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gc = MagicMock()
+    monkeypatch.setattr("due_diligence_reporter.server._make_google_client", lambda: gc)
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._get_or_create_m1_folder",
+        lambda _gc, _folder_id: {"id": "m1", "name": "M1 - Acquire Property"},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._list_m1_documents_by_type",
+        lambda _gc, _folder_id: {
+            "alpha_phasing_plan_report": {
+                "id": "existing-1",
+                "webViewLink": "https://drive/existing",
+                "name": "Phase 1 Phase 2 Workbook - Alpha Test - 2026-07-01.xlsx",
+            }
+        },
+    )
+    register = MagicMock(return_value={"status": "already_registered"})
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.register_rhodes_document_for_upload", register
+    )
+    notify = MagicMock()
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.notify_rhodes_phasing_review", notify
+    )
+
+    result = asyncio.run(
+        apply_alpha_phasing_plan_skill(
+            site_name="Alpha Test",
+            site_address="123 Main St",
+            site_id="SITE1",
+            drive_folder_url="https://drive.google.com/drive/folders/root",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["reused_existing"] is True
+    assert result["workbook_id"] == "existing-1"
+    assert result["p2_review_note"] == {"status": "skipped", "reason": "reused_existing"}
+    notify.assert_not_called()
+    gc.upload_file_to_folder.assert_not_called()
+    assert register.call_args.kwargs["drive_file_id"] == "existing-1"
+
+
+def test_apply_alpha_phasing_plan_skill_skips_notify_when_registration_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gc = MagicMock()
+    gc.upload_file_to_folder.return_value = {
+        "id": "file-1",
+        "webViewLink": "https://drive/phasing",
+    }
+    monkeypatch.setattr("due_diligence_reporter.server._make_google_client", lambda: gc)
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._get_or_create_m1_folder",
+        lambda _gc, _folder_id: {"id": "m1", "name": "M1 - Acquire Property"},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server._list_m1_documents_by_type",
+        lambda _gc, _folder_id: {},
+    )
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.register_rhodes_document_for_upload",
+        MagicMock(return_value={"status": "pending_user_action"}),
+    )
+    notify = MagicMock()
+    monkeypatch.setattr(
+        "due_diligence_reporter.server.notify_rhodes_phasing_review", notify
+    )
+
+    result = asyncio.run(
+        apply_alpha_phasing_plan_skill(
+            site_name="Alpha Test",
+            site_address="123 Main St",
+            site_id="SITE1",
+            drive_folder_url="https://drive.google.com/drive/folders/root",
+            source_of_truth="Budget tracker",
+            quality_bar_target="Q1",
+            opening_target_date="08/12/2026",
+            must_complete_before_opening="Code-required opening scope",
+            deferred_scopes=["Lobby refresh"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["p2_review_note"] == {
+        "status": "skipped",
+        "reason": "registration_not_complete",
+    }
+    notify.assert_not_called()

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -1872,3 +1872,63 @@ def test_add_rhodes_site_note_fails_when_aerie_readback_lacks_owner_mention() ->
     assert result["reason"] == "note_readback_failed"
     assert result["readback"]["reason"] == "note_mentions_missing"
     assert result["readback"]["missing_user_ids"] == ["OWNER1"]
+
+
+def test_notify_rhodes_phasing_review_mentions_p2_dri() -> None:
+    from due_diligence_reporter.rhodes import notify_rhodes_phasing_review
+
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Armonk 355 Main St",
+            "slug": "alpha-armonk",
+            "p1Dri": {"email": "p1@example.com", "userId": "P1USER"},
+            "p2Dri": {"email": "p2@example.com", "userId": "P2USER"},
+        }
+    )
+
+    result = notify_rhodes_phasing_review(
+        site_id="SITE1",
+        workbook_name="Phase 1 Phase 2 Workbook - Alpha Armonk - 2026-07-08.xlsx",
+        workbook_url="https://drive/phasing",
+        auto_accepted_inputs=["Phase II deferred scope: Quality-bar completion items"],
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["mentioned_owner_user_id"] == "P2USER"
+    assert result["p2_dri_found"] is True
+    assert result["fallback_owner_used"] is False
+    note = client.notes[0]
+    assert note["mentions"] == ["P2USER"]
+    assert note["body"].splitlines()[0] == "Phase 1 Phase 2 workbook review"
+    assert "Action needed: Review the completed Phase 1 Phase 2 workbook." in note["body"]
+    assert "Workbook: https://drive/phasing" in note["body"]
+    assert "Auto-accepted inputs to scrutinize:" in note["body"]
+    assert "- Phase II deferred scope: Quality-bar completion items" in note["body"]
+
+
+def test_notify_rhodes_phasing_review_falls_back_to_p1_dri() -> None:
+    from due_diligence_reporter.rhodes import notify_rhodes_phasing_review
+
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Test",
+            "slug": "alpha-test",
+            "p1Dri": {"email": "p1@example.com", "userId": "P1USER"},
+        }
+    )
+
+    result = notify_rhodes_phasing_review(
+        site_id="SITE1",
+        workbook_name="Workbook.xlsx",
+        workbook_url="https://drive/phasing",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "created"
+    assert result["mentioned_owner_user_id"] == "P1USER"
+    assert result["p2_dri_found"] is False
+    assert client.notes[0]["mentions"] == ["P1USER"]
+    assert "Auto-accepted inputs" not in client.notes[0]["body"]


### PR DESCRIPTION
## Why

Owner direction: the phasing skill should auto-accept all of its recommendations and publish, then notify the **P2 DRI** via `addNote` that the workbook is complete and ready for review. Review moves after publish instead of gating it — this also unblocks sites like Armonk that sat on an open Buildout Phasing item waiting for confirmed Phase II scope.

## What

- **`apply_alpha_phasing_plan_skill`** — hard requirements are now only site name, address, and Drive folder. Missing judgment inputs (source of truth, quality-bar target, opening target date, Phase I opening scope, Phase II deferred scope) fill with documented skill recommendations; each is recorded in `auto_accepted_inputs` and stamped into the workbook's Source Notes tab so the artifact itself discloses what was auto-accepted.
- **`notify_rhodes_phasing_review`** (new, rhodes.py) — posts a concise "Phase 1 Phase 2 workbook review" site note mentioning the **P2 DRI**, falling back to the P1 DRI and then the fallback owner; includes the workbook link, the auto-accepted-inputs list to scrutinize, and next steps. Note-mention readback verified via the existing note machinery.
- **Spam guards (reviewer-driven, both HIGH findings fixed):**
  - An existing M1 workbook is **reused** — no duplicate dated workbooks and no repeat notification on vendor-sweep or M2-executor reruns (same semantics as the Opening Plan). Regenerating after material input changes requires archiving the old workbook first.
  - The P2 note fires only for a **fresh publish whose Rhodes registration completed**; unregistered publishes route through the existing registration-handoff machinery instead.
  - The agent-facing tool description no longer invites probe-calls to discover missing inputs.
- **Evidence honesty** — "confirmed Phase II gap" / "Confirmed deferred scope" copy replaced with "deferred", so DD evidence and the workbook never claim a human confirmation that was auto-accepted.

## Verification

- Full suite: **1381 passed, 13 skipped** (+7 tests: hard-requirement block, auto-accept publish, full-inputs notify, reuse-without-notify, registration-incomplete skip, P2-mention, P1-fallback)
- ruff clean, mypy clean
- Independent reviewer pass: both HIGH findings (note spam, stale tool contract) and the MEDIUM-HIGH (confirmation overclaim) fixed in this change

## Accepted consequences / notes

- Open verification items for phasing inputs now close on publish with auto-accepted values — that's the intended policy shift; the P2 review note is the human checkpoint.
- The pre-existing vendor-sweep self-trigger pattern (generated artifacts creating new source fingerprints) is mitigated here by reuse but merits its own automation look.
- TBD opening-target-date flows into display fields only; verified it touches no DD date field writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)