### PR TITLE
Daily digest of successful DD writes to the operating owner (ddr-8uc)

### DIFF
--- a/.github/workflows/daily-dd-check.yml
+++ b/.github/workflows/daily-dd-check.yml
@@ -146,9 +146,23 @@ jobs:
           "
           echo "[OK] Wrote .gcp-saved-tokens.json"
 
+      - name: Configure Firestore credentials for DD write log
+        env:
+          GCP_FIRESTORE_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_FIRESTORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "${GCP_FIRESTORE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "${GCP_FIRESTORE_SERVICE_ACCOUNT_JSON}" > gcp-firestore-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=${PWD}/gcp-firestore-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "::warning title=DD write log not durable::GCP_FIRESTORE_SERVICE_ACCOUNT_JSON is not configured; daily-check DD writes will not reach the digest write log."
+          fi
+
       - name: Run daily DD check
         env:
           INPUT_SITE: ${{ inputs.site }}
+          DD_WRITE_LOG_FIRESTORE_PROJECT_ID: ${{ vars.DD_WRITE_LOG_FIRESTORE_PROJECT_ID || vars.M2_DD_STATE_FIRESTORE_PROJECT_ID || vars.DD_REPUBLISH_STATE_FIRESTORE_PROJECT_ID }}
+          DD_WRITE_LOG_FIRESTORE_DATABASE: ${{ vars.DD_WRITE_LOG_FIRESTORE_DATABASE || vars.M2_DD_STATE_FIRESTORE_DATABASE || vars.DD_REPUBLISH_STATE_FIRESTORE_DATABASE }}
+          DD_WRITE_LOG_FIRESTORE_COLLECTION: ${{ vars.DD_WRITE_LOG_FIRESTORE_COLLECTION }}
         run: |
           set -euo pipefail
           ARGS=()

--- a/.github/workflows/dd-write-digest.yml
+++ b/.github/workflows/dd-write-digest.yml
@@ -1,0 +1,99 @@
+name: DD Write Digest
+
+on:
+  schedule:
+    # 22:30 UTC weekdays = 5:30 PM Central during DST
+    - cron: '30 22 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: 'Lookback window in hours'
+        required: false
+        default: '24'
+        type: string
+      dry_run:
+        description: 'Print the digest without sending email or Chat'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+concurrency:
+  group: dd-write-digest
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  dd-write-digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.14"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Configure Firestore credentials
+        env:
+          GCP_FIRESTORE_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_FIRESTORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "${GCP_FIRESTORE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "${GCP_FIRESTORE_SERVICE_ACCOUNT_JSON}" > gcp-firestore-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=${PWD}/gcp-firestore-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "::warning title=Write log not readable::GCP_FIRESTORE_SERVICE_ACCOUNT_JSON is not configured; the digest cannot read the Firestore write log."
+          fi
+
+      - name: Send DD write digest
+        env:
+          LOCATIONOS_MCP_API_KEY: ${{ secrets.LOCATIONOS_MCP_API_KEY }}
+          RHODES_API_KEY: ${{ secrets.RHODES_API_KEY }}
+          RHODES_MCP_URL: ${{ secrets.RHODES_MCP_URL }}
+          EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
+          EMAIL_APP_PASSWORD: ${{ secrets.EMAIL_APP_PASSWORD }}
+          GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.DDR_GOOGLE_CHAT_WEBHOOK_URL }}
+          DD_WRITE_DIGEST_RECIPIENTS: ${{ vars.DD_WRITE_DIGEST_RECIPIENTS }}
+          DD_WRITE_LOG_FIRESTORE_PROJECT_ID: ${{ vars.DD_WRITE_LOG_FIRESTORE_PROJECT_ID || vars.M2_DD_STATE_FIRESTORE_PROJECT_ID || vars.DD_REPUBLISH_STATE_FIRESTORE_PROJECT_ID }}
+          DD_WRITE_LOG_FIRESTORE_DATABASE: ${{ vars.DD_WRITE_LOG_FIRESTORE_DATABASE || vars.M2_DD_STATE_FIRESTORE_DATABASE || vars.DD_REPUBLISH_STATE_FIRESTORE_DATABASE }}
+          DD_WRITE_LOG_FIRESTORE_COLLECTION: ${{ vars.DD_WRITE_LOG_FIRESTORE_COLLECTION }}
+          INPUT_HOURS: ${{ inputs.hours }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          default_hours=24
+          # Monday's run must cover the weekend gap (Sat 00:15-02:15 UTC M2
+          # cycles land after Friday's cutoff and before a 24h Monday window).
+          if [ -z "${INPUT_HOURS:-}" ] && [ "$(date -u +%u)" = "1" ]; then
+            default_hours=72
+          fi
+          args=(--hours "${INPUT_HOURS:-$default_hours}")
+          if [ "${INPUT_DRY_RUN:-false}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          uv run ddr dd-write-digest "${args[@]}" | tee dd-write-digest.txt
+          {
+            echo "## DD Write Digest"
+            echo
+            echo '```text'
+            cat dd-write-digest.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload digest artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dd-write-digest
+          if-no-files-found: warn
+          path: dd-write-digest.txt

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ credentials/
 oauth_response.json
 .raycon_*_state.json
 .dd_republish_state.json
+.dd_write_log.json
 .m2_direct_dd_state.json
 .rhodes_registration_retry_state.json
 

--- a/src/due_diligence_reporter/dd_write_digest.py
+++ b/src/due_diligence_reporter/dd_write_digest.py
@@ -1,0 +1,333 @@
+"""Durable log of successful DD field writes plus the daily operator digest.
+
+Every successful ``updateDueDiligence`` outcome (direct update or
+approval-queue proposal) is appended to a Firestore-backed write log so a
+scheduled digest can tell the operating owner what the automation did that
+day. Recording is strictly best-effort: a log failure must never fail the
+write it describes.
+
+Known exclusion: DD writes completed through the MCP-assisted resume path
+(operator approves in the browser, DDR only verifies readback) are not
+logged - the owner performed those interactively and already knows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .firestore_state import (
+    DEFAULT_FIRESTORE_DATABASE,
+    alert_firestore_fallback,
+    build_authorized_session,
+    decode_firestore_fields,
+    encode_firestore_fields,
+)
+from .utils import escape_html_text, sanitize_http_url
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WRITE_LOG_COLLECTION = "ddrDdWriteEvents"
+DEFAULT_WRITE_LOG_FALLBACK_PATH = ".dd_write_log.json"
+DIGEST_STATUSES = ("updated", "proposal_submitted")
+
+
+def _env_chain(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def write_log_project_id() -> str:
+    return _env_chain(
+        "DD_WRITE_LOG_FIRESTORE_PROJECT_ID",
+        "M2_DD_STATE_FIRESTORE_PROJECT_ID",
+        "DD_REPUBLISH_STATE_FIRESTORE_PROJECT_ID",
+    )
+
+
+def write_log_database() -> str:
+    return (
+        _env_chain(
+            "DD_WRITE_LOG_FIRESTORE_DATABASE",
+            "M2_DD_STATE_FIRESTORE_DATABASE",
+            "DD_REPUBLISH_STATE_FIRESTORE_DATABASE",
+        )
+        or DEFAULT_FIRESTORE_DATABASE
+    )
+
+
+def write_log_collection() -> str:
+    return (
+        os.environ.get("DD_WRITE_LOG_FIRESTORE_COLLECTION", "").strip()
+        or DEFAULT_WRITE_LOG_COLLECTION
+    )
+
+
+def _documents_url(project_id: str, database: str, collection: str) -> str:
+    return (
+        "https://firestore.googleapis.com/v1/projects/"
+        f"{project_id}/databases/{database}/documents/{collection}"
+    )
+
+
+def build_dd_write_event(
+    *,
+    site_id: str,
+    status: str,
+    fields: dict[str, Any],
+    field_sources: dict[str, str] | None = None,
+    review_url: str = "",
+    run_source: str = "",
+    created_at: str | None = None,
+) -> dict[str, str]:
+    """Build the flat event row recorded for one successful DD write."""
+
+    return {
+        "created_at": created_at or datetime.now(UTC).isoformat(),
+        "site_id": site_id.strip(),
+        "status": status.strip(),
+        "fields": json.dumps(
+            {key: str(value) for key, value in sorted(fields.items())},
+            sort_keys=True,
+        ),
+        "field_sources": json.dumps(dict(sorted((field_sources or {}).items()))),
+        "review_url": review_url.strip(),
+        "run_source": run_source.strip()
+        or os.environ.get("GITHUB_WORKFLOW", "").strip()
+        or "local",
+    }
+
+
+def record_dd_write_event(event: dict[str, str]) -> None:
+    """Persist one write event; best-effort, never raises."""
+
+    try:
+        project_id = write_log_project_id()
+        if project_id:
+            _save_event_to_firestore(event)
+            return
+        _append_event_to_fallback(event)
+    except Exception as exc:  # noqa: BLE001 - logging must never fail the write
+        logger.warning("Failed to record DD write event: %s", exc)
+        alert_firestore_fallback("dd_write_log", "save", exc)
+        try:
+            _append_event_to_fallback(event)
+        except Exception:  # noqa: BLE001
+            logger.warning("DD write event fallback append also failed.")
+
+
+def _event_document_id(event: dict[str, str]) -> str:
+    seed = "|".join(
+        (
+            event.get("created_at", ""),
+            event.get("site_id", ""),
+            event.get("status", ""),
+            event.get("fields", ""),
+        )
+    )
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
+
+
+def _save_event_to_firestore(event: dict[str, str]) -> None:
+    session = build_authorized_session()
+    url = _documents_url(
+        write_log_project_id(), write_log_database(), write_log_collection()
+    )
+    response = session.patch(
+        f"{url}/{_event_document_id(event)}",
+        json={"fields": encode_firestore_fields(dict(event))},
+        timeout=10,
+    )
+    response.raise_for_status()
+
+
+def _fallback_path() -> Path:
+    return Path(
+        os.environ.get("DD_WRITE_LOG_FALLBACK_PATH", "").strip()
+        or DEFAULT_WRITE_LOG_FALLBACK_PATH
+    )
+
+
+def _append_event_to_fallback(event: dict[str, str]) -> None:
+    path = _fallback_path()
+    events: list[dict[str, str]] = []
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(payload, list):
+                events = [item for item in payload if isinstance(item, dict)]
+        except (OSError, ValueError):
+            events = []
+    events.append(event)
+    path.write_text(json.dumps(events, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def collect_dd_write_events(*, since_iso: str) -> list[dict[str, str]]:
+    """Return logged write events created at or after ``since_iso``."""
+
+    events: list[dict[str, str]] = []
+    project_id = write_log_project_id()
+    if project_id:
+        events.extend(_load_events_from_firestore())
+    else:
+        events.extend(_load_events_from_fallback())
+    return sorted(
+        (
+            event
+            for event in events
+            if str(event.get("created_at") or "") >= since_iso
+            and str(event.get("status") or "") in DIGEST_STATUSES
+        ),
+        key=lambda event: (
+            str(event.get("site_id") or ""),
+            str(event.get("created_at") or ""),
+        ),
+    )
+
+
+def _load_events_from_firestore() -> list[dict[str, str]]:
+    session = build_authorized_session()
+    url = _documents_url(
+        write_log_project_id(), write_log_database(), write_log_collection()
+    )
+    events: list[dict[str, str]] = []
+    page_token = ""
+    while True:
+        params: dict[str, str] = {"pageSize": "300"}
+        if page_token:
+            params["pageToken"] = page_token
+        response = session.get(url, params=params, timeout=15)
+        if response.status_code == 404:
+            raise RuntimeError(
+                "DD write log Firestore path not found (404): check "
+                "DD_WRITE_LOG_FIRESTORE_PROJECT_ID/DATABASE/COLLECTION - a "
+                "missing collection lists as empty, so 404 means a bad "
+                "project or database path."
+            )
+        response.raise_for_status()
+        payload = response.json() if response.content else {}
+        for document in payload.get("documents", []) or []:
+            fields = document.get("fields")
+            if isinstance(fields, dict):
+                decoded = decode_firestore_fields(fields)
+                events.append({key: str(value) for key, value in decoded.items()})
+        page_token = str(payload.get("nextPageToken") or "")
+        if not page_token:
+            return events
+
+
+def _load_events_from_fallback() -> list[dict[str, str]]:
+    path = _fallback_path()
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [
+        {key: str(value) for key, value in item.items()}
+        for item in payload
+        if isinstance(item, dict)
+    ]
+
+
+def build_dd_write_digest(
+    events: list[dict[str, str]],
+    *,
+    resolve_site_name: Callable[[str], str] | None = None,
+    period_label: str = "last 24 hours",
+) -> dict[str, Any]:
+    """Compose the operator digest from logged write events.
+
+    Returns ``{"subject", "text", "html", "event_count", "site_count"}``.
+    """
+
+    by_site: dict[str, list[dict[str, str]]] = {}
+    for event in events:
+        by_site.setdefault(str(event.get("site_id") or "unknown"), []).append(event)
+
+    site_names: dict[str, str] = {}
+    for site_id in by_site:
+        name = ""
+        if resolve_site_name is not None:
+            try:
+                name = str(resolve_site_name(site_id) or "").strip()
+            except Exception:  # noqa: BLE001 - digest must render without lookups
+                name = ""
+        site_names[site_id] = name or site_id
+
+    updated_count = sum(1 for event in events if event.get("status") == "updated")
+    proposal_count = len(events) - updated_count
+    subject = (
+        f"DDR DD write digest: {len(events)} write(s) across "
+        f"{len(by_site)} site(s) ({period_label})"
+    )
+
+    text_lines = [
+        f"DDR due diligence write digest - {period_label}.",
+        f"{updated_count} field update(s) applied, "
+        f"{proposal_count} proposal(s) submitted for approval.",
+        "",
+    ]
+    html_parts = [
+        f"<p>DDR due diligence write digest &mdash; {period_label}.<br>"
+        f"{updated_count} field update(s) applied, "
+        f"{proposal_count} proposal(s) submitted for approval.</p>"
+    ]
+    for site_id in sorted(by_site, key=lambda key: site_names[key].lower()):
+        site_label = site_names[site_id]
+        text_lines.append(site_label)
+        html_parts.append(f"<h3>{escape_html_text(site_label)}</h3><ul>")
+        for event in by_site[site_id]:
+            status = (
+                "updated"
+                if event.get("status") == "updated"
+                else "submitted for approval"
+            )
+            try:
+                fields = json.loads(event.get("fields") or "{}")
+            except ValueError:
+                fields = {}
+            field_text = ", ".join(
+                f"{key}={value}" for key, value in sorted(fields.items())
+            )
+            line = f"- {status}: {field_text}" if field_text else f"- {status}"
+            review_url = sanitize_http_url(str(event.get("review_url") or "")) or ""
+            if review_url:
+                line += f" (review: {review_url})"
+            text_lines.append(line)
+            safe_field_text = escape_html_text(field_text)
+            html_line = (
+                f"<li>{status}: {safe_field_text}" if field_text else f"<li>{status}"
+            )
+            if review_url:
+                html_line += (
+                    f' &mdash; <a href="{escape_html_text(review_url)}">review</a>'
+                )
+            html_parts.append(html_line + "</li>")
+        text_lines.append("")
+        html_parts.append("</ul>")
+
+    if not events:
+        text_lines = [f"No DD field writes in the {period_label}."]
+        html_parts = [f"<p>No DD field writes in the {period_label}.</p>"]
+        subject = f"DDR DD write digest: no writes ({period_label})"
+
+    return {
+        "subject": subject,
+        "text": "\n".join(text_lines).strip(),
+        "html": "".join(html_parts),
+        "event_count": len(events),
+        "site_count": len(by_site),
+    }

--- a/src/due_diligence_reporter/ddr_cli.py
+++ b/src/due_diligence_reporter/ddr_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import time
 from pathlib import Path
 from types import ModuleType
@@ -234,6 +235,23 @@ def main(argv: list[str] | None = None) -> int:
     review_execution_parser.add_argument("--max-actions", type=int, default=0)
     review_execution_parser.add_argument("--dry-run", action="store_true")
 
+    digest_parser = subparsers.add_parser(
+        "dd-write-digest",
+        help="Send the daily digest of successful DD field writes/proposals",
+    )
+    digest_parser.add_argument("--hours", type=int, default=24)
+    digest_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the digest without sending email or Chat messages",
+    )
+    digest_parser.add_argument(
+        "--skip-empty",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Skip sending when there were no writes in the period",
+    )
+
     args = parser.parse_args(argv)
     if args.command == "status":
         _print_status(load_run_manifest(args.run_id))
@@ -270,6 +288,8 @@ def main(argv: list[str] | None = None) -> int:
         _print_portfolio_gaps(args)
     elif args.command == "review-execution":
         _run_review_execution(args)
+    elif args.command == "dd-write-digest":
+        return _run_dd_write_digest(args)
     return 0
 
 
@@ -997,3 +1017,104 @@ def _doc_label(name: str, file_id: str, uri: str) -> str:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+
+def _run_dd_write_digest(args: argparse.Namespace) -> int:
+    """Compose and deliver the daily DD write digest to the operating owner."""
+
+    from datetime import UTC, datetime, timedelta
+
+    from .config import get_settings
+    from .dd_write_digest import (
+        build_dd_write_digest,
+        collect_dd_write_events,
+        write_log_project_id,
+    )
+    from .utils import post_google_chat_message, send_email
+
+    hours = max(int(args.hours), 1)
+    if not write_log_project_id():
+        print(
+            "DD write log Firestore project is not configured "
+            "(DD_WRITE_LOG/M2_DD_STATE/DD_REPUBLISH_STATE project vars all "
+            "empty); the digest would silently read an empty local fallback."
+        )
+        if not args.dry_run:
+            return 1
+    since_iso = (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+    events = collect_dd_write_events(since_iso=since_iso)
+
+    resolver = None
+    try:
+        from .rhodes import RhodesClient
+
+        rhodes = RhodesClient()
+
+        def _resolve(site_id: str) -> str:
+            site = rhodes.get_site(site_id=site_id) or {}
+            return str(site.get("name") or "")
+
+        resolver = _resolve
+    except Exception:  # noqa: BLE001 - digest renders with site IDs if lookup is down
+        resolver = None
+
+    digest = build_dd_write_digest(
+        events,
+        resolve_site_name=resolver,
+        period_label=f"last {hours} hours",
+    )
+    print(digest["text"])
+    print(
+        f"\nDigest events={digest['event_count']} sites={digest['site_count']}"
+    )
+
+    if args.dry_run:
+        print("Dry run: no email or Chat message sent.")
+        return 0
+    if digest["event_count"] == 0 and args.skip_empty:
+        print("No writes in period: skipping delivery (--skip-empty).")
+        return 0
+
+    settings = get_settings()
+    recipients = [
+        addr.strip()
+        for addr in os.environ.get(
+            "DD_WRITE_DIGEST_RECIPIENTS", "greg.foote@trilogy.com"
+        ).split(",")
+        if addr.strip()
+    ]
+    delivered = 0
+    delivery_failures: list[str] = []
+    if settings.email_sender and settings.email_app_password and recipients:
+        try:
+            send_email(
+                settings.email_sender,
+                settings.email_app_password,
+                recipients,
+                digest["subject"],
+                digest["html"],
+            )
+            delivered += 1
+            print(f"Digest emailed to: {', '.join(recipients)}")
+        except Exception as exc:  # noqa: BLE001 - report and continue to Chat
+            delivery_failures.append(f"email: {exc}")
+    else:
+        delivery_failures.append("email: sender credentials not configured")
+    webhook_url = str(getattr(settings, "google_chat_webhook_url", "") or "").strip()
+    if webhook_url:
+        try:
+            post_google_chat_message(
+                webhook_url, f"{digest['subject']}\n{digest['text']}"
+            )
+            delivered += 1
+            print("Digest posted to Google Chat.")
+        except Exception as exc:  # noqa: BLE001
+            delivery_failures.append(f"chat: {exc}")
+    else:
+        delivery_failures.append("chat: webhook not configured")
+    for failure in delivery_failures:
+        print(f"Delivery issue: {failure}")
+    if delivered == 0:
+        print("Digest delivery failed: the owner was not informed.")
+        return 1
+    return 0

--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -1314,11 +1314,19 @@ def update_rhodes_due_diligence(
             proposal=True,
             review_url=str(response.get("reviewUrl") or "").strip(),
         )
-        return _due_diligence_proposal_result(
+        proposal_result = _due_diligence_proposal_result(
             base=base,
             response=response,
             handoff=handoff,
         )
+        if proposal_result.get("status") == DUE_DILIGENCE_PROPOSAL_SUBMITTED:
+            _record_dd_write_digest_event(
+                result=proposal_result,
+                site_id=clean_site_id,
+                fields=clean_fields,
+                field_sources=field_sources,
+            )
+        return proposal_result
 
     if _due_diligence_response_needs_handoff(response):
         error = (
@@ -1375,13 +1383,45 @@ def update_rhodes_due_diligence(
             "readback": readback,
         }
 
-    return {
+    result = {
         **base,
         "status": "updated",
         "reason": "ok",
         "response": _summarize_due_diligence_response(response),
         "readback": readback,
     }
+    _record_dd_write_digest_event(
+        result=result,
+        site_id=clean_site_id,
+        fields=clean_fields,
+        field_sources=field_sources,
+    )
+    return result
+
+
+def _record_dd_write_digest_event(
+    *,
+    result: dict[str, Any],
+    site_id: str,
+    fields: dict[str, Any],
+    field_sources: Mapping[str, str] | None,
+) -> None:
+    """Best-effort digest log for a successful write/proposal; never raises."""
+
+    try:
+        from .dd_write_digest import build_dd_write_event, record_dd_write_event
+
+        record_dd_write_event(
+            build_dd_write_event(
+                site_id=site_id,
+                status=str(result.get("status") or ""),
+                fields=fields,
+                field_sources=dict(field_sources or {}),
+                review_url=str(_dict_get(result.get("approval"), "review_url") or ""),
+            )
+        )
+    except Exception:  # noqa: BLE001 - digest logging must never fail the write
+        pass
 
 
 def verify_rhodes_due_diligence_fields(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dd_write_log(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Keep the DD write-log fallback out of the repo working directory."""
+
+    log_dir = tmp_path_factory.mktemp("dd-write-log")
+    monkeypatch.setenv("DD_WRITE_LOG_FALLBACK_PATH", str(log_dir / "log.json"))

--- a/tests/test_dd_write_digest.py
+++ b/tests/test_dd_write_digest.py
@@ -1,0 +1,175 @@
+"""Tests for the DD write log and daily digest."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from due_diligence_reporter.dd_write_digest import (
+    build_dd_write_digest,
+    build_dd_write_event,
+    collect_dd_write_events,
+    record_dd_write_event,
+)
+
+
+def test_build_dd_write_event_shape() -> None:
+    event = build_dd_write_event(
+        site_id=" SITE1 ",
+        status="proposal_submitted",
+        fields={"foCapacity": 36, "maxCapCapacity": 54},
+        field_sources={"foCapacity": "Alpha Capacity Analysis"},
+        review_url="https://locationos.example/review",
+        run_source="M2 Direct DD Events",
+        created_at="2026-07-08T18:00:00+00:00",
+    )
+
+    assert event["site_id"] == "SITE1"
+    assert event["status"] == "proposal_submitted"
+    assert json.loads(event["fields"]) == {"foCapacity": "36", "maxCapCapacity": "54"}
+    assert json.loads(event["field_sources"]) == {
+        "foCapacity": "Alpha Capacity Analysis"
+    }
+    assert event["review_url"] == "https://locationos.example/review"
+    assert event["run_source"] == "M2 Direct DD Events"
+    assert event["created_at"] == "2026-07-08T18:00:00+00:00"
+
+
+def test_record_and_collect_via_json_fallback(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("DD_WRITE_LOG_FIRESTORE_PROJECT_ID", raising=False)
+    monkeypatch.delenv("M2_DD_STATE_FIRESTORE_PROJECT_ID", raising=False)
+    monkeypatch.delenv("DD_REPUBLISH_STATE_FIRESTORE_PROJECT_ID", raising=False)
+    monkeypatch.setenv("DD_WRITE_LOG_FALLBACK_PATH", str(tmp_path / "log.json"))
+
+    early = build_dd_write_event(
+        site_id="SITE1",
+        status="updated",
+        fields={"foCapacity": 36},
+        created_at="2026-07-07T09:00:00+00:00",
+    )
+    recent = build_dd_write_event(
+        site_id="SITE2",
+        status="proposal_submitted",
+        fields={"buildingScore": 1},
+        created_at="2026-07-08T09:00:00+00:00",
+    )
+    failed = build_dd_write_event(
+        site_id="SITE3",
+        status="failed",
+        fields={"foCapacity": 1},
+        created_at="2026-07-08T10:00:00+00:00",
+    )
+    for event in (early, recent, failed):
+        record_dd_write_event(event)
+
+    events = collect_dd_write_events(since_iso="2026-07-08T00:00:00+00:00")
+
+    assert [event["site_id"] for event in events] == ["SITE2"]
+    assert events[0]["status"] == "proposal_submitted"
+
+
+def test_record_never_raises_when_everything_fails(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("DD_WRITE_LOG_FIRESTORE_PROJECT_ID", "proj")
+    monkeypatch.setenv("DD_WRITE_LOG_FALLBACK_PATH", str(tmp_path / "log.json"))
+
+    with patch(
+        "due_diligence_reporter.dd_write_digest._save_event_to_firestore",
+        side_effect=RuntimeError("firestore down"),
+    ), patch(
+        "due_diligence_reporter.dd_write_digest.alert_firestore_fallback"
+    ) as mock_alert:
+        record_dd_write_event(
+            build_dd_write_event(site_id="SITE1", status="updated", fields={"a": 1})
+        )
+
+    mock_alert.assert_called_once()
+    payload = json.loads((tmp_path / "log.json").read_text(encoding="utf-8"))
+    assert len(payload) == 1
+
+
+def test_build_dd_write_digest_renders_sites_and_statuses() -> None:
+    events = [
+        build_dd_write_event(
+            site_id="SITE1",
+            status="updated",
+            fields={"foCapacity": 36},
+            created_at="2026-07-08T09:00:00+00:00",
+        ),
+        build_dd_write_event(
+            site_id="SITE2",
+            status="proposal_submitted",
+            fields={"buildingScore": 1},
+            review_url="https://locationos.example/review",
+            created_at="2026-07-08T10:00:00+00:00",
+        ),
+    ]
+
+    digest = build_dd_write_digest(
+        events,
+        resolve_site_name=lambda site_id: {
+            "SITE1": "Alpha Keller",
+            "SITE2": "Alpha Miami Beach",
+        }.get(site_id, ""),
+        period_label="last 24 hours",
+    )
+
+    assert digest["event_count"] == 2
+    assert digest["site_count"] == 2
+    assert "1 field update(s) applied, 1 proposal(s) submitted" in digest["text"]
+    assert "Alpha Keller" in digest["text"]
+    assert "updated: foCapacity=36" in digest["text"]
+    assert "submitted for approval: buildingScore=1" in digest["text"]
+    assert "review: https://locationos.example/review" in digest["text"]
+    assert "<h3>Alpha Miami Beach</h3>" in digest["html"]
+
+
+def test_build_dd_write_digest_empty() -> None:
+    digest = build_dd_write_digest([], period_label="last 24 hours")
+    assert digest["event_count"] == 0
+    assert "No DD field writes" in digest["text"]
+    assert "no writes" in digest["subject"]
+
+
+def test_digest_html_escapes_values_and_sanitizes_review_url() -> None:
+    events = [
+        build_dd_write_event(
+            site_id="SITE1",
+            status="updated",
+            fields={"buildingComment": '<img src=x onerror=alert(1)> "quoted"'},
+            review_url='javascript:alert(1)',
+            created_at="2026-07-08T09:00:00+00:00",
+        ),
+    ]
+
+    digest = build_dd_write_digest(
+        events,
+        resolve_site_name=lambda _sid: "<b>Alpha</b> Site",
+        period_label="last 24 hours",
+    )
+
+    assert "<img" not in digest["html"]
+    assert "&lt;img" in digest["html"]
+    assert "<b>Alpha</b>" not in digest["html"]
+    assert "&lt;b&gt;Alpha&lt;/b&gt;" in digest["html"]
+    assert "javascript:" not in digest["html"]
+    assert "javascript:" not in digest["text"]
+
+
+def test_firestore_list_404_raises_misconfiguration(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+
+    monkeypatch.setenv("DD_WRITE_LOG_FIRESTORE_PROJECT_ID", "proj")
+    session = MagicMock()
+    session.get.return_value = MagicMock(status_code=404)
+
+    with patch(
+        "due_diligence_reporter.dd_write_digest.build_authorized_session",
+        return_value=session,
+    ):
+        try:
+            collect_dd_write_events(since_iso="2026-07-08T00:00:00+00:00")
+        except RuntimeError as exc:
+            assert "404" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError on 404")

--- a/tests/test_dd_write_digest_cli.py
+++ b/tests/test_dd_write_digest_cli.py
@@ -1,0 +1,72 @@
+"""Exit-code and delivery tests for the dd-write-digest CLI."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from due_diligence_reporter.ddr_cli import main
+
+
+def _run_cli(monkeypatch, tmp_path, argv, *, settings, chat_ok=True, email_ok=True):
+    monkeypatch.setenv("DD_WRITE_LOG_FALLBACK_PATH", str(tmp_path / "log.json"))
+    monkeypatch.setenv("DD_WRITE_LOG_FIRESTORE_PROJECT_ID", "proj")
+    events = [
+        {
+            "created_at": "2099-01-01T00:00:00+00:00",
+            "site_id": "SITE1",
+            "status": "updated",
+            "fields": '{"foCapacity": "36"}',
+            "field_sources": "{}",
+            "review_url": "",
+            "run_source": "test",
+        }
+    ]
+    send_email = MagicMock(side_effect=None if email_ok else RuntimeError("smtp down"))
+    post_chat = MagicMock(side_effect=None if chat_ok else RuntimeError("chat down"))
+    with patch(
+        "due_diligence_reporter.dd_write_digest._load_events_from_firestore",
+        return_value=events,
+    ), patch("due_diligence_reporter.utils.send_email", send_email), patch(
+        "due_diligence_reporter.utils.post_google_chat_message", post_chat
+    ), patch("due_diligence_reporter.config.get_settings", return_value=settings), patch(
+        "due_diligence_reporter.rhodes.RhodesClient", side_effect=RuntimeError("no mcp")
+    ):
+        code = main(argv)
+    return code, send_email, post_chat
+
+
+def test_digest_cli_fails_when_nothing_delivered(monkeypatch, tmp_path) -> None:
+    settings = SimpleNamespace(
+        email_sender="", email_app_password="", google_chat_webhook_url=""
+    )
+    code, send_email, post_chat = _run_cli(
+        monkeypatch, tmp_path, ["dd-write-digest", "--hours", "24"], settings=settings
+    )
+    assert code == 1
+    send_email.assert_not_called()
+    post_chat.assert_not_called()
+
+
+def test_digest_cli_succeeds_with_one_channel(monkeypatch, tmp_path) -> None:
+    settings = SimpleNamespace(
+        email_sender="",
+        email_app_password="",
+        google_chat_webhook_url="https://chat.example/webhook",
+    )
+    code, _send_email, post_chat = _run_cli(
+        monkeypatch, tmp_path, ["dd-write-digest", "--hours", "24"], settings=settings
+    )
+    assert code == 0
+    post_chat.assert_called_once()
+
+
+def test_digest_cli_fails_without_store_config(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("DD_WRITE_LOG_FIRESTORE_PROJECT_ID", raising=False)
+    monkeypatch.delenv("M2_DD_STATE_FIRESTORE_PROJECT_ID", raising=False)
+    monkeypatch.delenv("DD_REPUBLISH_STATE_FIRESTORE_PROJECT_ID", raising=False)
+    monkeypatch.setenv("DD_WRITE_LOG_FALLBACK_PATH", str(tmp_path / "log.json"))
+
+    code = main(["dd-write-digest", "--hours", "24"])
+
+    assert code == 1

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from unittest.mock import patch
 
 from due_diligence_reporter.rhodes import (
     AerieApiConfig,
@@ -1932,3 +1933,65 @@ def test_notify_rhodes_phasing_review_falls_back_to_p1_dri() -> None:
     assert result["p2_dri_found"] is False
     assert client.notes[0]["mentions"] == ["P1USER"]
     assert "Auto-accepted inputs" not in client.notes[0]["body"]
+
+
+def test_successful_update_records_dd_write_digest_event() -> None:
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Test",
+            "foCapacity": 36,
+            "dueDiligence": {"foCapacity": 36},
+        },
+        due_diligence_response={"status": "ok"},
+    )
+
+    with patch(
+        "due_diligence_reporter.dd_write_digest.record_dd_write_event"
+    ) as mock_record:
+        result = update_rhodes_due_diligence(
+            site_id="SITE1",
+            fields={"foCapacity": 36},
+            client=client,  # type: ignore[arg-type]
+            field_sources={"foCapacity": "Alpha Capacity Analysis"},
+        )
+
+    assert result["status"] == "updated"
+    mock_record.assert_called_once()
+    event = mock_record.call_args.args[0]
+    assert event["site_id"] == "SITE1"
+    assert event["status"] == "updated"
+    assert '"foCapacity": "36"' in event["fields"]
+    assert "Alpha Capacity Analysis" in event["field_sources"]
+
+
+def test_submitted_proposal_records_dd_write_digest_event() -> None:
+    client = FakeRhodesClient(
+        site={
+            "_id": "SITE1",
+            "name": "Alpha Test",
+            "slug": "alpha-test",
+            "address": "123 Main St, Denver, CO 80202",
+            "p1Dri": {"email": "owner@example.com", "userId": "OWNER1"},
+        },
+        due_diligence_response={
+            "status": "awaiting_browser_approval",
+            "pendingMutationId": "MUT1",
+            "reviewUrl": "https://locationos.example/review",
+        },
+    )
+
+    with patch(
+        "due_diligence_reporter.dd_write_digest.record_dd_write_event"
+    ) as mock_record:
+        result = update_rhodes_due_diligence(
+            site_id="SITE1",
+            fields={"foCapacity": 36},
+            client=client,  # type: ignore[arg-type]
+        )
+
+    assert result["status"] == "proposal_submitted"
+    mock_record.assert_called_once()
+    event = mock_record.call_args.args[0]
+    assert event["status"] == "proposal_submitted"
+    assert event["review_url"] == "https://locationos.example/review"


### PR DESCRIPTION
## Why

The due diligence vision requires informing the site owner **and Greg** of actions taken. Site owners get per-action notes; Greg previously only heard about failures. This adds the approved daily-digest channel.

## What

- **`dd_write_digest.py`** — Firestore-backed append-only write log (`ddrDdWriteEvents`). Both success paths of `update_rhodes_due_diligence` (direct `updated` and `proposal_submitted`) record site, fields, field sources, status, and review link. Recording is best-effort and can never fail the write it describes; store config falls back through the existing state-store env chains, and degradation triggers the fallback alert from #155.
- **`ddr dd-write-digest`** CLI — collects the window's events, resolves site names via Rhodes, and delivers subject/text/HTML grouped by site ("updated: foCapacity=36" / "submitted for approval: … (review link)") via email (`DD_WRITE_DIGEST_RECIPIENTS`, default greg.foote@trilogy.com) and the Chat webhook.
- **`dd-write-digest.yml`** — weekdays 22:30 UTC (~5:30 PM Central); Monday runs use a 72-hour window so Friday-evening M2 cycles aren't dropped.
- **`daily-dd-check.yml`** — gains Firestore credentials + write-log env (it previously had none; its writes would have silently missed the log).

## Hardening from the review pass (all three blocking findings fixed)

- **No silent no-delivery greens**: the run exits 1 if zero channels deliver, and exits 1 if the Firestore store is unconfigured rather than reading an empty local fallback and reporting "no writes" forever. A 404 on list raises as misconfiguration (a missing collection lists as empty, so 404 means a bad path).
- **No HTML injection**: every interpolated value is escaped and review URLs sanitized with the repo's existing helpers — field values can carry free-text comments.
- Env fallback chains include the `DD_REPUBLISH_STATE` vars so reader and writers resolve the same store.

## Known exclusion

MCP-assisted resume writes (operator approves in browser, DDR verifies readback) are not logged — the owner performed those interactively. Documented in the module docstring.

## Verification

- Full suite: **1393 passed, 13 skipped** (+15 tests: event shape, fallback round-trip + status filter, never-raises, digest rendering, HTML-escaping/URL sanitization, 404-raises, both rhodes hook paths, CLI exit codes for zero-delivery / one-channel / unconfigured-store)
- ruff clean, mypy clean; live CLI dry-run rendered a real digest
- conftest fixture isolates the JSON fallback from the repo working dir (test pollution found via the live dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)