### PR TITLE
Polish proposal evidence and MCP-assist alignment (P3 batch)

### DIFF
--- a/src/due_diligence_reporter/report_pipeline.py
+++ b/src/due_diligence_reporter/report_pipeline.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -2459,6 +2460,7 @@ def _record_rhodes_due_diligence_update_step(
                     site_title=result.site_title,
                     site_id=site_id,
                     fields=fields,
+                    field_sources=field_sources,
                     error=str(update_status.get("error") or ""),
                     document_already_rendered=bool(result.doc_url),
                     doc_url=result.doc_url or "",
@@ -2551,7 +2553,13 @@ def _verify_locationos_mcp_due_diligence_update(
         **base,
         "status": "failed",
         "reason": "locationos_mcp_readback_failed",
-        "error": str(readback_status.get("error") or readback_status.get("reason") or ""),
+        "error": (
+            str(readback_status.get("error") or readback_status.get("reason") or "")
+            + " Note: an operator-approved updateDueDiligence can land in the "
+            "LocationOS approval queue, in which case values will not read "
+            "back until the pending field-change request is approved - check "
+            "the approval queue before retrying the write."
+        ).strip(),
         "readback": readback_status,
     }
 
@@ -2569,6 +2577,7 @@ def _build_locationos_mcp_write_request(
     site_id: str,
     fields: dict[str, Any],
     error: str,
+    field_sources: Mapping[str, str] | None = None,
     document_already_rendered: bool = False,
     doc_url: str = "",
 ) -> dict[str, Any]:
@@ -2597,6 +2606,7 @@ def _build_locationos_mcp_write_request(
         "site_title": site_title,
         "run_id": run_id,
         "arguments": arguments,
+        "field_sources": dict(field_sources or {}),
         "readback": {
             "server": "locationos",
             "tool": "getSite",

--- a/src/due_diligence_reporter/source_packet.py
+++ b/src/due_diligence_reporter/source_packet.py
@@ -428,10 +428,15 @@ def dd_field_update_sources(
         if not update.locationos_key:
             continue
         titles = [_safe_title(title) for title in update.source_titles if str(title).strip()]
-        if not titles:
-            titles = [str(name).strip() for name in update.required_source_docs if str(name).strip()]
         if titles:
             sources[update.locationos_key] = ", ".join(titles)
+            continue
+        # No captured registered title: name the required source TYPE and say
+        # so, rather than presenting a doc-type label as if it were a
+        # specific registered document title.
+        labels = [str(name).strip() for name in update.required_source_docs if str(name).strip()]
+        if labels:
+            sources[update.locationos_key] = "required source: " + ", ".join(labels)
     return sources
 
 

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -1913,6 +1913,7 @@ class TestProcessSitePipeline:
         assert result.rhodes_due_diligence_update is not None
         mcp_request = result.rhodes_due_diligence_update["locationos_mcp_write_request"]
         assert mcp_request["resume"]["required"] is False
+        assert "field_sources" in mcp_request
         update_kwargs = mock_update_due_diligence.call_args.kwargs
         assert update_kwargs["fields"] == {
             "status": "complete",
@@ -2454,7 +2455,8 @@ class TestProcessSitePipeline:
 
         assert result.status == "report_data_prepared"
         assert result.failed_step == "rhodes.due_diligence_update"
-        assert result.error == "foCapacity did not match"
+        assert result.error.startswith("foCapacity did not match")
+        assert "approval queue" in result.error
         route_tool_call.assert_not_called()
         rhodes_note.assert_not_called()
 

--- a/tests/test_source_packet.py
+++ b/tests/test_source_packet.py
@@ -376,7 +376,7 @@ def test_dd_field_update_sources_maps_locationos_keys_to_doc_titles() -> None:
 
     assert sources == {
         "foCapacity": "Alpha Capacity Analysis - Site.json",
-        "buildingScore": "Phase 1 Phase 2 workbook",
+        "buildingScore": "required source: Phase 1 Phase 2 workbook",
     }
 
 


### PR DESCRIPTION
## What

Three small reviewer follow-ups from the approval-queue work, batched:

- **`ddr-mpp`** — the MCP-assisted write request (`locationos_mcp_write_request`) now carries the field→source-document evidence map, so writes an operator completes through their own MCP session have the same reviewer context as automated proposals.
- **`ddr-52j`** — when no registered document title was captured, the evidence map entry reads `required source: <type>` instead of presenting a doc-type label as though it were a specific registered title under the "registered on this site record" heading.
- **`ddr-014`** — the resume-mcp-write readback failure message now explains that an operator-approved `updateDueDiligence` may be pending in the approval queue (values won't read back until approved). Still fails conservative — actual queue polling is blocked on the LocationOS `listFieldChangeRequests` fix (`ddr-dzc`).

## Verification

- Full suite: **1397 passed, 13 skipped**; ruff clean, mypy clean
- Review pass skipped: three reviewer-prescribed follow-ups, each with updated/added test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)