### PR TITLE
Repoint AADP remediation checkout to EDU-Ops-Team production repo

### DIFF
--- a/.github/workflows/portfolio-automation-gaps.yml
+++ b/.github/workflows/portfolio-automation-gaps.yml
@@ -102,7 +102,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.trigger_remediation != 'false' }}
         uses: actions/checkout@v4
         with:
-          repository: trilogy-group/alpha-analysis-downstream-processing
+          repository: EDU-Ops-Team/alpha-analysis-downstream-processing
           ref: main
           path: aadp-remediation
           token: ${{ secrets.AADP_REMEDIATION_REPO_TOKEN || github.token }}

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -253,7 +253,8 @@ def test_portfolio_gap_snapshot_triggers_aadp_remediation_without_oauth() -> Non
     assert "secrets.GOOGLE_CHAT_WEBHOOK_URL" not in text
     assert "portfolio-gaps" in text
     assert "portfolio-automation-gaps.json" in text
-    assert "trilogy-group/alpha-analysis-downstream-processing" in text
+    assert "EDU-Ops-Team/alpha-analysis-downstream-processing" in text
+    assert "trilogy-group/" not in text
     assert "AADP_REMEDIATION_REPO_TOKEN" in text
     assert "AADP_DRIVE_PARENT_FOLDER_ID" in text
     assert (


### PR DESCRIPTION
## What
One-line workflow change: `portfolio-automation-gaps.yml` now checks out `EDU-Ops-Team/alpha-analysis-downstream-processing` (the production home of AADP Standard Intake since 2026-07-06) instead of the retired `trilogy-group` copy. Contract test updated to pin the new org and reject any `trilogy-group/` reference in the workflow.

## Why
Decision from the 2026-07-09 nine-repo architecture review: AADP should only be used from EDU-Ops-Team. The remediation entry point (`alpha_analysis_downstream_processing_mcp.portfolio_gap_remediation.remediate_portfolio_gap_snapshot`) is confirmed present in the EDU-Ops-Team copy at the exact import path `run_aadp_portfolio_gap_remediation.py` loads.

## Verification
- `uv run pytest tests/test_workflow_contracts.py` — 22 passed.
- **Post-merge check required:** the `AADP_REMEDIATION_REPO_TOKEN` secret may be scoped to trilogy-group only. After merging, trigger `portfolio-automation-gaps` via workflow_dispatch and confirm the "Checkout AADP remediation runner" step succeeds; if it fails with 404/auth, reissue the fine-grained PAT with read access to EDU-Ops-Team/alpha-analysis-downstream-processing.

## Follow-up (tracked separately)
Archive or freeze the trilogy-group copy so the two repos stop diverging (it received pushes as recently as 2026-07-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)