### PR TITLE
Auto-accept DDR's own Rhodes MCP elicitations

### DIFF
--- a/src/due_diligence_reporter/rhodes.py
+++ b/src/due_diligence_reporter/rhodes.py
@@ -141,6 +141,53 @@ def _parse_json_rpc_response(resp: requests.Response) -> dict[str, Any]:
     return data
 
 
+_CONFIRMATION_TOKEN_RE = re.compile(
+    r"\b(confirm|confirmed|approve|approved|accept|accepted|acknowledge|acknowledged"
+    r"|authorize|authorized|proceed|allow|yes)\b"
+)
+
+
+def _build_safe_confirmation_result(params: Any) -> dict[str, Any]:
+    """Accept form-mode boolean confirmation elicitations; decline the rest.
+
+    Mirrors document-router's root fix: booleans that read as confirmations
+    are answered true; an elicitation asking for any other required input is
+    declined (it is a real form, not a write confirmation).
+    """
+    if not isinstance(params, dict):
+        return {"action": "decline"}
+    mode = params.get("mode")
+    if mode and mode != "form":
+        return {"action": "decline"}
+    schema = params.get("requestedSchema")
+    if not isinstance(schema, dict) or schema.get("type") != "object":
+        return {"action": "decline"}
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return {"action": "decline"}
+    required = {item for item in (schema.get("required") or []) if isinstance(item, str)}
+    message = params.get("message")
+    content: dict[str, bool] = {}
+    for field, definition in properties.items():
+        if (
+            isinstance(definition, dict)
+            and definition.get("type") == "boolean"
+            and _is_confirmation_field(field, definition, message)
+        ):
+            content[field] = True
+        elif field in required:
+            return {"action": "decline"}
+    if any(field not in content for field in required):
+        return {"action": "decline"}
+    return {"action": "accept", "content": content}
+
+
+def _is_confirmation_field(field: str, definition: dict[str, Any], message: Any) -> bool:
+    parts = [field, definition.get("title"), definition.get("description"), message]
+    haystack = " ".join(item for item in parts if isinstance(item, str)).lower()
+    return bool(_CONFIRMATION_TOKEN_RE.search(haystack))
+
+
 def _raise_for_rhodes_error(resp: requests.Response) -> None:
     if resp.ok:
         return
@@ -689,21 +736,101 @@ class RhodesClient:
                 headers=_rhodes_headers(self.cfg.api_key, session_id=self._session_id),
                 json=payload,
                 timeout=RHODES_TIMEOUT_SECONDS,
+                stream=True,
             )
         except requests.RequestException as exc:
             raise RhodesError(f"Rhodes MCP request failed: {exc}") from exc
 
-        if not self._session_id:
-            self._session_id = (
-                resp.headers.get("Mcp-Session-Id")
-                or resp.headers.get("mcp-session-id")
-                or resp.headers.get("MCP-Session-Id")
-            )
+        with resp:
+            if not self._session_id:
+                self._session_id = (
+                    resp.headers.get("Mcp-Session-Id")
+                    or resp.headers.get("mcp-session-id")
+                    or resp.headers.get("MCP-Session-Id")
+                )
 
-        _raise_for_rhodes_error(resp)
-        if resp.status_code == 202 and not resp.text:
-            return {}
-        return _parse_json_rpc_response(resp)
+            _raise_for_rhodes_error(resp)
+            content_type = resp.headers.get("content-type", "")
+            if "text/event-stream" in content_type:
+                return self._read_sse_response(resp, expected_id=payload.get("id"))
+            if resp.status_code == 202 and not resp.text:
+                return {}
+            return _parse_json_rpc_response(resp)
+
+    def _read_sse_response(
+        self, resp: requests.Response, *, expected_id: Any
+    ) -> dict[str, Any]:
+        """Read a streamable-HTTP SSE response incrementally.
+
+        The stream can interleave server->client requests (elicitation
+        confirmations) with the final response to our own request; server
+        requests are answered inline so the call completes autonomously.
+        """
+        data_lines: list[str] = []
+        for raw_line in resp.iter_lines(decode_unicode=True):
+            line = (raw_line or "").strip()
+            if line.startswith("data:"):
+                chunk = line.removeprefix("data:").strip()
+                if chunk and chunk != "[DONE]":
+                    data_lines.append(chunk)
+                continue
+            if line:
+                continue
+            reply = self._dispatch_stream_event(data_lines, expected_id=expected_id)
+            data_lines = []
+            if reply is not None:
+                return reply
+        reply = self._dispatch_stream_event(data_lines, expected_id=expected_id)
+        return reply if reply is not None else {}
+
+    def _dispatch_stream_event(
+        self, data_lines: list[str], *, expected_id: Any
+    ) -> dict[str, Any] | None:
+        if not data_lines:
+            return None
+        try:
+            message = json.loads("\n".join(data_lines))
+        except ValueError:
+            return None
+        if not isinstance(message, dict):
+            return None
+        if "method" in message:
+            if message.get("id") is not None:
+                self._answer_server_request(message)
+            return None
+        if expected_id is None or message.get("id") == expected_id:
+            return message
+        return None
+
+    def _answer_server_request(self, request: dict[str, Any]) -> None:
+        """Answer a server->client request arriving on a call stream.
+
+        Rhodes sends elicitation/create to confirm mutations. Every call this
+        client makes is DDR-initiated (it never relays third-party requests),
+        so confirmations are auto-accepted; anything else is refused loudly.
+        """
+        if request.get("method") == "elicitation/create":
+            response: dict[str, Any] = {
+                "jsonrpc": "2.0",
+                "id": request.get("id"),
+                "result": _build_safe_confirmation_result(request.get("params")),
+            }
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": request.get("id"),
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+        try:
+            reply = self._session.post(
+                self.cfg.mcp_url,
+                headers=_rhodes_headers(self.cfg.api_key, session_id=self._session_id),
+                json=response,
+                timeout=RHODES_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise RhodesError(f"Rhodes MCP elicitation response failed: {exc}") from exc
+        _raise_for_rhodes_error(reply)
 
     def _ensure_initialized(self) -> None:
         if self._initialized:
@@ -714,7 +841,11 @@ class RhodesClient:
                 "method": "initialize",
                 "params": {
                     "protocolVersion": MCP_PROTOCOL_VERSION,
-                    "capabilities": {},
+                    # Elicitation declared so Rhodes confirmation-gates DDR's
+                    # own writes to this client instead of rejecting them
+                    # with elicitation_unsupported (fleet policy: a worker
+                    # auto-accepts mutations it itself initiated).
+                    "capabilities": {"elicitation": {"form": {}}},
                     "clientInfo": {
                         "name": "due-diligence-reporter",
                         "version": "0.2.0",

--- a/tests/test_rhodes.py
+++ b/tests/test_rhodes.py
@@ -1995,3 +1995,163 @@ def test_submitted_proposal_records_dd_write_digest_event() -> None:
     event = mock_record.call_args.args[0]
     assert event["status"] == "proposal_submitted"
     assert event["review_url"] == "https://locationos.example/review"
+
+
+# --- MCP elicitation auto-accept (fleet write policy: accept own-initiated writes) ---
+
+
+class FakeMcpResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        body: str = "",
+        json_payload: Any = None,
+    ) -> None:
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.headers = headers or {}
+        self._json = json_payload
+        self.text = body if body else (json.dumps(json_payload) if json_payload is not None else "")
+        self._body = self.text
+        self.request = None
+
+    def json(self) -> Any:
+        return self._json
+
+    def iter_lines(self, decode_unicode: bool = False) -> Any:
+        return iter(self._body.splitlines())
+
+    def __enter__(self) -> "FakeMcpResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> bool:
+        return False
+
+
+class FakeMcpSession:
+    def __init__(self, responses: list[FakeMcpResponse]) -> None:
+        self.responses = list(responses)
+        self.posts: list[dict[str, Any]] = []
+
+    def post(self, url: str, **kwargs: Any) -> FakeMcpResponse:
+        self.posts.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError(f"No fake MCP response queued for POST {url}")
+        return self.responses.pop(0)
+
+
+def _mcp_client_with_session(responses: list[FakeMcpResponse]) -> tuple[RhodesClient, FakeMcpSession]:
+    from due_diligence_reporter.rhodes import RhodesConfig
+
+    client = RhodesClient(RhodesConfig(mcp_url="https://rhodes.test/mcp", api_key="key"))
+    session = FakeMcpSession(responses)
+    client._session = session  # type: ignore[assignment]
+    return client, session
+
+
+def _init_responses() -> list[FakeMcpResponse]:
+    return [
+        FakeMcpResponse(
+            headers={"content-type": "application/json", "Mcp-Session-Id": "S1"},
+            json_payload={"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}},
+        ),
+        FakeMcpResponse(status_code=202, headers={"content-type": "application/json"}),
+    ]
+
+
+def test_initialize_declares_elicitation_capability() -> None:
+    client, session = _mcp_client_with_session(_init_responses())
+
+    client._ensure_initialized()
+
+    init_payload = session.posts[0]["json"]
+    assert init_payload["params"]["capabilities"] == {"elicitation": {"form": {}}}
+
+
+def test_call_tool_auto_accepts_confirmation_elicitation() -> None:
+    elicitation = {
+        "jsonrpc": "2.0",
+        "id": 77,
+        "method": "elicitation/create",
+        "params": {
+            "mode": "form",
+            "message": "Confirm registerDocument write",
+            "requestedSchema": {
+                "type": "object",
+                "properties": {"confirm": {"type": "boolean", "title": "Confirm write"}},
+                "required": ["confirm"],
+            },
+        },
+    }
+    final = {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": {"documentId": "DOC1"}}}
+    sse_body = f"data: {json.dumps(elicitation)}\n\ndata: {json.dumps(final)}\n"
+    client, session = _mcp_client_with_session(
+        _init_responses()
+        + [
+            FakeMcpResponse(headers={"content-type": "text/event-stream"}, body=sse_body),
+            FakeMcpResponse(status_code=202, headers={"content-type": "application/json"}),
+        ]
+    )
+
+    payload = client.call_tool("registerDocument", {"siteId": "SITE1"})
+
+    assert payload == {"documentId": "DOC1"}
+    answer = session.posts[3]["json"]
+    assert answer == {
+        "jsonrpc": "2.0",
+        "id": 77,
+        "result": {"action": "accept", "content": {"confirm": True}},
+    }
+
+
+def test_call_tool_declines_elicitation_requiring_real_input() -> None:
+    elicitation = {
+        "jsonrpc": "2.0",
+        "id": 78,
+        "method": "elicitation/create",
+        "params": {
+            "mode": "form",
+            "message": "Provide a justification",
+            "requestedSchema": {
+                "type": "object",
+                "properties": {"justification": {"type": "string"}},
+                "required": ["justification"],
+            },
+        },
+    }
+    final = {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": {"status": "rejected"}}}
+    sse_body = f"data: {json.dumps(elicitation)}\n\ndata: {json.dumps(final)}\n"
+    client, session = _mcp_client_with_session(
+        _init_responses()
+        + [
+            FakeMcpResponse(headers={"content-type": "text/event-stream"}, body=sse_body),
+            FakeMcpResponse(status_code=202, headers={"content-type": "application/json"}),
+        ]
+    )
+
+    payload = client.call_tool("registerDocument", {"siteId": "SITE1"})
+
+    assert payload == {"status": "rejected"}
+    answer = session.posts[3]["json"]
+    assert answer["result"] == {"action": "decline"}
+
+
+def test_unknown_server_request_is_refused_with_method_not_found() -> None:
+    server_request = {"jsonrpc": "2.0", "id": 79, "method": "sampling/createMessage", "params": {}}
+    final = {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": {"ok": True}}}
+    sse_body = f"data: {json.dumps(server_request)}\n\ndata: {json.dumps(final)}\n"
+    client, session = _mcp_client_with_session(
+        _init_responses()
+        + [
+            FakeMcpResponse(headers={"content-type": "text/event-stream"}, body=sse_body),
+            FakeMcpResponse(status_code=202, headers={"content-type": "application/json"}),
+        ]
+    )
+
+    payload = client.call_tool("getSite", {"siteId": "SITE1"})
+
+    assert payload == {"ok": True}
+    answer = session.posts[3]["json"]
+    assert answer["error"]["code"] == -32601


### PR DESCRIPTION
Closes #162.

Declares the MCP elicitation capability at initialize and answers `elicitation/create` requests inline on the tools/call stream:
- form-mode **boolean confirmation** fields are auto-accepted — every call this client makes is DDR-initiated, so per the fleet write policy (a worker auto-accepts mutations it itself initiated; document-router root fix d55ce67) there is no allowlist to hand-maintain
- elicitations demanding **real input** (non-boolean required fields) are declined — those are forms, not write confirmations
- unknown server->client requests are refused loudly with `-32601`

Net effect: confirmation-gated mutations (registerDocument / updateDueDiligence / addNote) complete autonomously instead of becoming `pending_user_action` handoff notes. Genuine server-side approval sessions (`awaiting_browser_approval`) still hand off loudly — that gate is a key-permission tier the client cannot and should not self-accept.

Verification: 4 new transport tests (auto-accept, decline-real-forms, method-not-found refusal, capability declaration); full suite **1,401 passed, 13 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)